### PR TITLE
fix: surface real backup errors and widen pymobiledevice3 discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,23 @@ Phosphor parses this to provide file-system-like browsing without modifying the 
 - [x] Backup encryption management (enable/disable/change password)
 - [ ] Voicemail browsing
 
+## Troubleshooting
+
+### "Both backup methods failed"
+
+Phosphor now surfaces the underlying `pymobiledevice3` and `idevicebackup2` stderr in the failure message. Common causes:
+
+1. **Trust prompt missed** - Unlock the device, tap **Trust This Computer**, enter your passcode, then retry the backup.
+2. **Stale pymobiledevice3** - iOS 17/18/26 require a recent release. Upgrade with:
+   ```bash
+   pip3 install --upgrade pymobiledevice3
+   ```
+3. **Binary not on PATH** - GUI apps do not inherit your shell PATH. Phosphor probes `pipx`, Homebrew, and `~/Library/Python/3.{10..14}/bin` automatically; if you installed pymobiledevice3 elsewhere, symlink it into one of those directories.
+4. **Missing Python dependencies** - `ModuleNotFoundError` in the failure details means a partial install. Reinstall with `pip3 install --upgrade --force-reinstall pymobiledevice3`.
+5. **Pairing record mismatch** - From Terminal, run `pymobiledevice3 lockdown pair` once, accept the Trust prompt, then retry.
+
+For encrypted backup issues, verify the device has a passcode set and that `pymobiledevice3 backup2 encryption` reports the expected state.
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup and guidelines.

--- a/Sources/Phosphor/Services/BackupManager.swift
+++ b/Sources/Phosphor/Services/BackupManager.swift
@@ -15,6 +15,52 @@ final class BackupManager: ObservableObject {
     /// Active backup process for cancellation.
     private var activeProcess: Process?
 
+    /// Maximum number of trailing stderr lines to retain for diagnostics on failure.
+    private static let stderrTailLineLimit = 20
+
+    /// Lines retained from the most recent pymobiledevice3 stderr stream.
+    private var pymobiledeviceStderrTail: [String] = []
+
+    /// Translate a pymobiledevice3 or idevicebackup2 stderr blob into a short actionable hint.
+    private static func diagnosticHint(for stderr: String) -> String? {
+        let lower = stderr.lowercased()
+        if lower.contains("not paired") || lower.contains("pairingdialogresponsepending") || lower.contains("trust this computer") {
+            return "Device is not trusted. Unlock it and tap 'Trust' when prompted, then try again."
+        }
+        if lower.contains("passcodesetuprequired") || lower.contains("setpasscode") {
+            return "Set a passcode on the device before running an encrypted backup."
+        }
+        if lower.contains("no device found") || lower.contains("no devices connected") {
+            return "No device detected. Reconnect the cable and ensure the device is unlocked."
+        }
+        if lower.contains("backupdomainoverridden") || lower.contains("mobilebackup2error") {
+            return "iOS rejected the backup request. Disable/re-enable encryption or reboot the device."
+        }
+        if lower.contains("modulenotfounderror") || lower.contains("no module named") {
+            return "pymobiledevice3 is installed but missing dependencies. Reinstall with: pip3 install --upgrade pymobiledevice3"
+        }
+        if lower.contains("invalidservice") || lower.contains("remotexpc") || lower.contains("tunneld") {
+            return "Backup requires an up-to-date pymobiledevice3. Upgrade with: pip3 install --upgrade pymobiledevice3"
+        }
+        return nil
+    }
+
+    /// Build a composite error string combining stderr tail and diagnostic hint.
+    private static func composeFailureMessage(primary: String, stderr: String) -> String {
+        let trimmed = stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+        let hint = diagnosticHint(for: trimmed)
+        var lines: [String] = [primary]
+        if let hint { lines.append(hint) }
+        if !trimmed.isEmpty {
+            let tail = trimmed
+                .components(separatedBy: "\n")
+                .suffix(stderrTailLineLimit)
+                .joined(separator: "\n")
+            lines.append("Details:\n\(tail)")
+        }
+        return lines.joined(separator: "\n\n")
+    }
+
     /// Default backup location used by Apple and libimobiledevice.
     static let defaultBackupDir: String = {
         let home = FileManager.default.homeDirectoryForCurrentUser.path
@@ -86,11 +132,14 @@ final class BackupManager: ObservableObject {
             return true
         }
 
+        let pymobiledeviceStderr = pymobiledeviceStderrTail.joined(separator: "\n")
+
         // Fallback: idevicebackup2
         backupProgress = "Trying idevicebackup2..."
         onProgress("Falling back to idevicebackup2...")
 
         let args = ["backup", "--full", "-u", udid, Self.activeBackupDir]
+        var idevicebackupStderr = ""
 
         return await withCheckedContinuation { continuation in
             Shell.runStreaming(
@@ -104,19 +153,29 @@ final class BackupManager: ObservableObject {
                     }
                     onProgress(output)
                 },
-                onError: { [weak self] error in
-                    self?.lastError = error
+                onError: { error in
+                    idevicebackupStderr.append(error)
                 },
                 completion: { [weak self] exitCode in
                     Task { @MainActor in
-                        self?.isCreatingBackup = false
+                        guard let self else {
+                            continuation.resume(returning: exitCode == 0)
+                            return
+                        }
+                        self.isCreatingBackup = false
                         if exitCode == 0 {
-                            self?.backupProgress = "Backup complete"
-                            self?.backupPercent = 1.0
-                            self?.discoverBackups()
+                            self.backupProgress = "Backup complete"
+                            self.backupPercent = 1.0
+                            self.discoverBackups()
                         } else {
-                            self?.backupProgress = "Backup failed. Install pymobiledevice3: pip3 install pymobiledevice3"
-                            self?.lastError = "Both backup methods failed."
+                            let combinedStderr = [pymobiledeviceStderr, idevicebackupStderr]
+                                .filter { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+                                .joined(separator: "\n---\n")
+                            self.backupProgress = "Backup failed"
+                            self.lastError = Self.composeFailureMessage(
+                                primary: "Both backup methods failed.",
+                                stderr: combinedStderr
+                            )
                         }
                         continuation.resume(returning: exitCode == 0)
                     }
@@ -128,12 +187,13 @@ final class BackupManager: ObservableObject {
     /// Backup using pymobiledevice3.
     private func createBackupViaPymobiledevice(udid: String, full: Bool, onProgress: @escaping (String) -> Void) async -> Bool {
         guard PyMobileDevice.available() else {
-            lastError = "pymobiledevice3 not installed"
+            lastError = "pymobiledevice3 not installed. Install with: pip3 install pymobiledevice3"
             return false
         }
 
         backupProgress = "Creating backup via pymobiledevice3..."
         onProgress("Creating backup via pymobiledevice3...")
+        pymobiledeviceStderrTail.removeAll()
 
         return await withCheckedContinuation { continuation in
             activeProcess = PyMobileDevice.backup(
@@ -152,11 +212,23 @@ final class BackupManager: ObservableObject {
                 },
                 onError: { [weak self] error in
                     let trimmed = error.trimmingCharacters(in: .whitespacesAndNewlines)
-                    if !trimmed.isEmpty {
-                        // pymobiledevice3 sends progress on stderr
-                        if let pct = PyMobileDevice.parseProgress(from: trimmed) {
-                            self?.backupPercent = pct
-                            self?.backupProgress = "Backup: \(Int(pct * 100))%"
+                    guard !trimmed.isEmpty else { return }
+                    // pymobiledevice3 sends progress on stderr.
+                    if let pct = PyMobileDevice.parseProgress(from: trimmed) {
+                        self?.backupPercent = pct
+                        self?.backupProgress = "Backup: \(Int(pct * 100))%"
+                        return
+                    }
+                    // Retain non-progress stderr lines so a failure surfaces the real reason.
+                    guard let self else { return }
+                    for line in trimmed.components(separatedBy: "\n") {
+                        let l = line.trimmingCharacters(in: .whitespacesAndNewlines)
+                        if l.isEmpty { continue }
+                        self.pymobiledeviceStderrTail.append(l)
+                        if self.pymobiledeviceStderrTail.count > Self.stderrTailLineLimit {
+                            self.pymobiledeviceStderrTail.removeFirst(
+                                self.pymobiledeviceStderrTail.count - Self.stderrTailLineLimit
+                            )
                         }
                     }
                 },
@@ -192,6 +264,9 @@ final class BackupManager: ObservableObject {
             }
         }
 
+        let pymobiledeviceStderr = pymobiledeviceStderrTail.joined(separator: "\n")
+        var idevicebackupStderr = ""
+
         // Fallback: idevicebackup2
         return await withCheckedContinuation { continuation in
             Shell.runStreaming(
@@ -205,16 +280,29 @@ final class BackupManager: ObservableObject {
                     }
                     onProgress(output)
                 },
-                onError: { [weak self] error in
-                    self?.lastError = error
+                onError: { error in
+                    idevicebackupStderr.append(error)
                 },
                 completion: { [weak self] exitCode in
                     Task { @MainActor in
-                        self?.isCreatingBackup = false
-                        self?.backupProgress = exitCode == 0 ? "Backup complete" : "Backup failed"
+                        guard let self else {
+                            continuation.resume(returning: exitCode == 0)
+                            return
+                        }
+                        self.isCreatingBackup = false
                         if exitCode == 0 {
-                            self?.backupPercent = 1.0
-                            self?.discoverBackups()
+                            self.backupProgress = "Backup complete"
+                            self.backupPercent = 1.0
+                            self.discoverBackups()
+                        } else {
+                            let combinedStderr = [pymobiledeviceStderr, idevicebackupStderr]
+                                .filter { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+                                .joined(separator: "\n---\n")
+                            self.backupProgress = "Backup failed"
+                            self.lastError = Self.composeFailureMessage(
+                                primary: "Incremental backup failed via both backends.",
+                                stderr: combinedStderr
+                            )
                         }
                         continuation.resume(returning: exitCode == 0)
                     }

--- a/Sources/Phosphor/Utilities/PyMobileDevice.swift
+++ b/Sources/Phosphor/Utilities/PyMobileDevice.swift
@@ -8,24 +8,24 @@ enum PyMobileDevice {
     /// Cached path to the pymobiledevice3 binary once found.
     private static var cachedBinaryPath: String?
 
+    /// Python minor versions to probe for pip3 --user installs and system Python.
+    private static let pythonMinorVersions = ["3.14", "3.13", "3.12", "3.11", "3.10"]
+
     /// Extended PATH for GUI apps that don't inherit terminal PATH.
     private static let extendedPath: String = {
         let home = FileManager.default.homeDirectoryForCurrentUser.path
-        let extra = [
+        var extra = [
             "\(home)/.local/bin",
             "\(home)/.local/pipx/venvs/pymobiledevice3/bin",
             "/opt/homebrew/bin",
             "/usr/local/bin",
-            "\(home)/Library/Python/3.13/bin",
-            "\(home)/Library/Python/3.12/bin",
-            "\(home)/Library/Python/3.11/bin",
-            "\(home)/Library/Python/3.10/bin",
         ]
+        extra.append(contentsOf: pythonMinorVersions.map { "\(home)/Library/Python/\($0)/bin" })
         let existing = ProcessInfo.processInfo.environment["PATH"] ?? "/usr/bin:/bin"
         return extra.joined(separator: ":") + ":" + existing
     }()
 
-    /// Find the pymobiledevice3 binary. Checks direct binary first (pipx),
+    /// Find the pymobiledevice3 binary. Checks direct binary first (pipx, pip --user),
     /// then python3 -m pymobiledevice3 at various Python locations.
     private static func findBinary() -> String? {
         if let cached = cachedBinaryPath { return cached }
@@ -33,13 +33,17 @@ enum PyMobileDevice {
         let home = FileManager.default.homeDirectoryForCurrentUser.path
         let fm = FileManager.default
 
-        // Direct binary locations (pipx, pip --user)
-        let directPaths = [
+        // Direct binary locations (pipx, pip --user, Homebrew)
+        var directPaths = [
             "\(home)/.local/bin/pymobiledevice3",
             "\(home)/.local/pipx/venvs/pymobiledevice3/bin/pymobiledevice3",
             "/opt/homebrew/bin/pymobiledevice3",
             "/usr/local/bin/pymobiledevice3",
         ]
+        // `pip3 install --user pymobiledevice3` on macOS drops the script here.
+        directPaths.append(contentsOf: pythonMinorVersions.map {
+            "\(home)/Library/Python/\($0)/bin/pymobiledevice3"
+        })
 
         for path in directPaths {
             if fm.isExecutableFile(atPath: path) {
@@ -49,12 +53,14 @@ enum PyMobileDevice {
         }
 
         // Try python3 -m pymobiledevice3 with various pythons
-        let pythons = [
+        var pythons = [
             "\(home)/.local/pipx/venvs/pymobiledevice3/bin/python3",
             "/opt/homebrew/bin/python3",
             "/usr/local/bin/python3",
             "/usr/bin/python3",
         ]
+        pythons.append(contentsOf: pythonMinorVersions.map { "/opt/homebrew/bin/python\($0)" })
+        pythons.append(contentsOf: pythonMinorVersions.map { "/usr/local/bin/python\($0)" })
 
         for python in pythons {
             guard fm.isExecutableFile(atPath: python) else { continue }
@@ -67,6 +73,24 @@ enum PyMobileDevice {
         }
 
         return nil
+    }
+
+    /// Clear the cached binary path so the next call re-probes the filesystem.
+    /// Useful after the user installs or upgrades pymobiledevice3 mid-session.
+    static func resetBinaryCache() {
+        cachedBinaryPath = nil
+    }
+
+    /// Query installed pymobiledevice3 version, or nil if unavailable.
+    static func version() async -> String? {
+        guard findBinary() != nil else { return nil }
+        let result = await runAsync(["version"], timeout: 10)
+        let trimmed = result.output.trimmingCharacters(in: .whitespacesAndNewlines)
+        if result.succeeded, !trimmed.isEmpty { return trimmed }
+        // Some versions respond to --version instead.
+        let alt = await runAsync(["--version"], timeout: 10)
+        let altTrimmed = alt.output.trimmingCharacters(in: .whitespacesAndNewlines)
+        return alt.succeeded && !altTrimmed.isEmpty ? altTrimmed : nil
     }
 
     /// Whether the found binary is a direct pymobiledevice3 binary (vs python3 path).


### PR DESCRIPTION
## Summary

Fixes #1. The generic "Both backup methods failed" message hid the actual cause because:

- `pymobiledevice3` stderr was scanned only for tqdm progress and otherwise discarded.
- `idevicebackup2` stderr overwrote `lastError` per chunk, so only the tail of the last fragment survived.
- `findBinary` did not probe `~/Library/Python/3.X/bin/pymobiledevice3`, the default install location for `pip3 install --user` on macOS without pipx.

## Changes

- `PyMobileDevice.findBinary` now checks `~/Library/Python/3.{10..14}/bin/pymobiledevice3` and versioned `python3.X` interpreters, plus exposes `resetBinaryCache()` and `version()`.
- `BackupManager` buffers the tail of `pymobiledevice3` stderr and merges it with `idevicebackup2` stderr on failure, then rewrites the user-facing message via a `diagnosticHint` translator (trust prompt, stale install, missing Python deps, tunneld hints, passcode requirement, etc).
- Incremental backup path gets the same treatment.
- `README.md` gains a Troubleshooting section that covers the common causes.

## Test plan

- [x] `swift build` clean (no new warnings).
- [ ] Manual: trigger backup against a device with passcode-locked trust prompt pending, confirm the failure message now names the trust prompt.
- [ ] Manual: uninstall `pymobiledevice3`, confirm install hint surfaces.
- [ ] Manual: run against iOS 26.4.1 device (issue reporter's setup) and verify actionable diagnostic on failure.