### PR TITLE
fix: preflight backup dir and hint Full Disk Access

### DIFF
--- a/README.md
+++ b/README.md
@@ -275,6 +275,7 @@ Phosphor parses this to provide file-system-like browsing without modifying the 
 
 Phosphor now surfaces the underlying `pymobiledevice3` and `idevicebackup2` stderr in the failure message. Common causes:
 
+0. **Directory "is not readable" / permission denied** - macOS protects `~/Library/Application Support/MobileSync/Backup` with TCC. Grant Phosphor **Full Disk Access** in **System Settings -> Privacy & Security -> Full Disk Access**, then relaunch Phosphor. Alternatively pick a different backup directory in **Phosphor -> Settings** (for example `~/Documents/Phosphor Backups`).
 1. **Trust prompt missed** - Unlock the device, tap **Trust This Computer**, enter your passcode, then retry the backup.
 2. **Stale pymobiledevice3** - iOS 17/18/26 require a recent release. Upgrade with:
    ```bash

--- a/Sources/Phosphor/Services/BackupManager.swift
+++ b/Sources/Phosphor/Services/BackupManager.swift
@@ -42,7 +42,49 @@ final class BackupManager: ObservableObject {
         if lower.contains("invalidservice") || lower.contains("remotexpc") || lower.contains("tunneld") {
             return "Backup requires an up-to-date pymobiledevice3. Upgrade with: pip3 install --upgrade pymobiledevice3"
         }
+        if lower.contains("is not readable") || lower.contains("permission denied") || lower.contains("operation not permitted") {
+            return """
+            macOS is blocking access to the backup directory. Grant Phosphor 'Full Disk Access':
+            System Settings -> Privacy & Security -> Full Disk Access -> enable Phosphor.
+            Alternatively, pick a different backup directory in Phosphor > Settings (for example ~/Documents/Phosphor Backups).
+            """
+        }
         return nil
+    }
+
+    /// Preflight check: verify the active backup directory exists and is readable/writable
+    /// by this process. ~/Library/Application Support/MobileSync/Backup is TCC-protected
+    /// on macOS 10.15+ and requires Full Disk Access for sandboxed or unsigned apps.
+    static func validateBackupDirectory(_ path: String) -> (ok: Bool, reason: String?) {
+        let fm = FileManager.default
+        var isDir: ObjCBool = false
+        if !fm.fileExists(atPath: path, isDirectory: &isDir) {
+            do {
+                try fm.createDirectory(atPath: path, withIntermediateDirectories: true)
+            } catch {
+                return (false, "Cannot create backup directory at \(path): \(error.localizedDescription)")
+            }
+            return (true, nil)
+        }
+        if !isDir.boolValue {
+            return (false, "\(path) exists but is not a directory.")
+        }
+        if !fm.isReadableFile(atPath: path) || !fm.isWritableFile(atPath: path) {
+            let isDefault = (path == defaultBackupDir)
+            var msg = "Phosphor cannot read or write \(path)."
+            if isDefault {
+                msg += """
+
+
+                This is the system MobileSync directory which macOS protects with TCC.
+                Grant Phosphor 'Full Disk Access':
+                System Settings -> Privacy & Security -> Full Disk Access -> enable Phosphor, then restart the app.
+                Alternatively, pick a different backup directory in Phosphor > Settings (for example ~/Documents/Phosphor Backups).
+                """
+            }
+            return (false, msg)
+        }
+        return (true, nil)
     }
 
     /// Build a composite error string combining stderr tail and diagnostic hint.
@@ -119,8 +161,16 @@ final class BackupManager: ObservableObject {
         backupPercent = 0
         lastError = nil
 
-        // Ensure backup directory exists
-        try? FileManager.default.createDirectory(atPath: Self.activeBackupDir, withIntermediateDirectories: true)
+        // Preflight: bail early with a clear message when the directory is unreadable
+        // (most commonly a Full Disk Access grant missing on the default location).
+        let preflight = Self.validateBackupDirectory(Self.activeBackupDir)
+        if !preflight.ok {
+            isCreatingBackup = false
+            backupProgress = "Backup failed"
+            lastError = preflight.reason
+            onProgress(preflight.reason ?? "Backup directory is not accessible.")
+            return false
+        }
 
         // Primary: pymobiledevice3
         let pySuccess = await createBackupViaPymobiledevice(udid: udid, full: true, onProgress: onProgress)
@@ -250,7 +300,14 @@ final class BackupManager: ObservableObject {
         backupPercent = 0
         lastError = nil
 
-        try? FileManager.default.createDirectory(atPath: Self.activeBackupDir, withIntermediateDirectories: true)
+        let preflight = Self.validateBackupDirectory(Self.activeBackupDir)
+        if !preflight.ok {
+            isCreatingBackup = false
+            backupProgress = "Backup failed"
+            lastError = preflight.reason
+            onProgress(preflight.reason ?? "Backup directory is not accessible.")
+            return false
+        }
 
         // Primary: pymobiledevice3 (without --full flag)
         if PyMobileDevice.available() {


### PR DESCRIPTION
Follow-up to #3 for #1.

## Root cause (confirmed by reporter on v1.0.1)

The new diagnostic from #3 exposed the real failure:

> Invalid value for 'BACKUP_DIRECTORY': Directory '/Users/brian/Library/Application Support/MobileSync/Backup' is not readable.

`~/Library/Application Support/MobileSync/Backup` is TCC-protected on macOS 10.15+. A non-sandboxed app bundle still needs **Full Disk Access** to read it, and by default it has none, so `pymobiledevice3` (and `idevicebackup2`) inherit the denial.

## Changes

- `BackupManager.validateBackupDirectory()` runs before every backup; returns a clear message if the directory is missing, not a directory, or not readable/writable.
- Full and incremental `createBackup` paths bail early so the user does not wait for both backends to fail the same way.
- `diagnosticHint()` maps `is not readable` / `permission denied` / `operation not permitted` to the Full Disk Access instructions plus the alternative-directory workaround.
- README troubleshooting section lists the TCC cause first.

## Test plan

- [x] `swift build` clean.
- [ ] Manual: without Full Disk Access, run backup - expect the preflight message pointing at System Settings.
- [ ] Manual: after granting Full Disk Access, run backup - expect progress.
- [ ] Manual: change backup directory to `~/Documents/Phosphor Backups` - expect preflight passes and backup proceeds.