### PR TITLE
fix: detect encrypted Manifest.db and surface it clearly

### DIFF
--- a/Sources/Phosphor/Utilities/BackupManifest.swift
+++ b/Sources/Phosphor/Utilities/BackupManifest.swift
@@ -4,6 +4,36 @@ import Foundation
 /// The Manifest.db contains a "Files" table mapping domain/relativePath to SHA-1 hashed filenames.
 final class BackupManifest {
 
+    /// Errors surfaced when opening a backup.
+    enum ManifestError: Error, LocalizedError {
+        case manifestMissing(path: String)
+        case backupEncrypted(path: String)
+        case manifestUnreadable(path: String, underlying: String)
+
+        var errorDescription: String? {
+            switch self {
+            case .manifestMissing(let path):
+                return """
+                Backup is incomplete - Manifest.db not found at \(path).
+                The backup may have been cancelled or only partially written. Re-run the backup and try again.
+                """
+            case .backupEncrypted(let path):
+                return """
+                This backup is encrypted.
+                iOS remembers the encrypted-backup setting at the device level, so every backup for this device is encrypted until it is disabled in Finder (Finder -> the device -> uncheck 'Encrypt local backup').
+                Phosphor's encrypted-backup browser needs the backup password to decrypt Manifest.db at \(path).
+                """
+            case .manifestUnreadable(let path, let underlying):
+                return "Cannot read Manifest.db at \(path): \(underlying)"
+            }
+        }
+    }
+
+    /// Leading magic bytes of a SQLite 3 database file.
+    /// Encrypted iOS backups store Manifest.db as an opaque blob without this header,
+    /// which is what makes sqlite3_prepare fail with 'unable to open database file'.
+    private static let sqliteMagic = Data("SQLite format 3\0".utf8)
+
     let backupPath: String
     private let db: SQLiteReader
 
@@ -64,7 +94,32 @@ final class BackupManifest {
     init(backupPath: String) throws {
         self.backupPath = backupPath
         let manifestPath = (backupPath as NSString).appendingPathComponent("Manifest.db")
-        self.db = try SQLiteReader(path: manifestPath)
+
+        // Preflight: Manifest.db must exist, have the SQLite header, and the backup
+        // must not be flagged as encrypted. Detecting this up front turns the opaque
+        // 'SQLite prepare failed: unable to open database file' into a useful message.
+        let fm = FileManager.default
+        guard fm.fileExists(atPath: manifestPath) else {
+            throw ManifestError.manifestMissing(path: manifestPath)
+        }
+        if let plist = PlistParser.parseManifest(backupPath), plist.isEncrypted {
+            throw ManifestError.backupEncrypted(path: manifestPath)
+        }
+        if let handle = try? FileHandle(forReadingFrom: URL(fileURLWithPath: manifestPath)) {
+            defer { try? handle.close() }
+            let header = try? handle.read(upToCount: Self.sqliteMagic.count)
+            if header != Self.sqliteMagic {
+                // Missing the SQLite magic means encrypted data (most common),
+                // a truncated download, or a different file format entirely.
+                throw ManifestError.backupEncrypted(path: manifestPath)
+            }
+        }
+
+        do {
+            self.db = try SQLiteReader(path: manifestPath)
+        } catch {
+            throw ManifestError.manifestUnreadable(path: manifestPath, underlying: error.localizedDescription)
+        }
     }
 
     /// Get all unique domains in the backup.

--- a/Sources/Phosphor/Utilities/SQLiteReader.swift
+++ b/Sources/Phosphor/Utilities/SQLiteReader.swift
@@ -25,9 +25,23 @@ final class SQLiteReader {
 
     init(path: String) throws {
         self.path = path
+
+        // Fail fast if the file is missing: sqlite3_open_v2 with READONLY opens
+        // lazily, so a missing file would surface as a confusing prepare error later.
+        guard FileManager.default.fileExists(atPath: path) else {
+            throw SQLiteError.openFailed("file not found: \(path)")
+        }
+
+        // Open read-only + immutable via URI so SQLite never tries to create
+        // -wal / -shm sidecars next to the database. Backup directories can be
+        // TCC-protected or read-only and WAL creation would otherwise fail the
+        // first prepare with 'unable to open database file'.
         var dbPointer: OpaquePointer?
-        let flags = SQLITE_OPEN_READONLY | SQLITE_OPEN_NOMUTEX
-        let rc = sqlite3_open_v2(path, &dbPointer, flags, nil)
+        let encoded = path
+            .addingPercentEncoding(withAllowedCharacters: .urlPathAllowed) ?? path
+        let uri = "file:\(encoded)?mode=ro&immutable=1"
+        let flags = SQLITE_OPEN_READONLY | SQLITE_OPEN_NOMUTEX | SQLITE_OPEN_URI
+        let rc = sqlite3_open_v2(uri, &dbPointer, flags, nil)
         guard rc == SQLITE_OK, let opened = dbPointer else {
             let msg = dbPointer.flatMap { String(cString: sqlite3_errmsg($0)) } ?? "unknown error"
             sqlite3_close(dbPointer)

--- a/Sources/Phosphor/ViewModels/BackupViewModel.swift
+++ b/Sources/Phosphor/ViewModels/BackupViewModel.swift
@@ -54,13 +54,18 @@ final class BackupViewModel: ObservableObject {
         selectedBackup = backup
         currentManifest = backupManager.openManifest(for: backup)
 
-        if let manifest = currentManifest {
-            do {
-                browserDomains = try manifest.domains()
-            } catch {
-                alertMessage = "Failed to read backup: \(error.localizedDescription)"
-                showAlert = true
-            }
+        guard let manifest = currentManifest else {
+            // openManifest swallows the error into backupManager.lastError; surface it.
+            alertMessage = backupManager.lastError ?? "Failed to open backup."
+            showAlert = true
+            return
+        }
+
+        do {
+            browserDomains = try manifest.domains()
+        } catch {
+            alertMessage = "Failed to read backup: \(error.localizedDescription)"
+            showAlert = true
         }
     }
 


### PR DESCRIPTION
Fixes #5.

## Root cause

Brian reported `SQLite prepare failed: unable to open database file` across every backup browser entry after creating a backup on v1.0.2. That is the error SQLite returns when the file it opened lazily cannot actually be read as a SQLite file.

In iOS encrypted backups Manifest.db is an opaque encrypted blob wrapped with the `.sqlite` extension, so `sqlite3_open_v2` with `SQLITE_OPEN_READONLY` succeeds (open is lazy) and the first `sqlite3_prepare_v2` fails with the unhelpful IO error. iOS pins the encrypted-backup flag at the device level, so every subsequent backup made by any tool - Finder, idevicebackup2, pymobiledevice3, Phosphor - is encrypted the same way.

## Changes

- `BackupManifest.ManifestError` covers the three failure modes (`manifestMissing`, `backupEncrypted`, `manifestUnreadable`) with messages that tell the user how to disable encryption in Finder or why the backup is not browsable.
- `BackupManifest.init` preflights Manifest.db:
  1. existence check
  2. `Manifest.plist -> IsEncrypted` check
  3. SQLite magic-byte check (`SQLite format 3\0`) - catches cases where Manifest.plist is not authoritative (partial backups, third-party wrappers).
- `SQLiteReader.init` opens via `file:...?mode=ro&immutable=1` URI so SQLite never tries to create `-wal` / `-shm` sidecars next to the database, which would otherwise break on read-only or TCC-protected backup dirs.
- `BackupViewModel.openBackupBrowser` now surfaces `backupManager.lastError` when `openManifest` returns nil instead of silently showing an empty browser.

## Test plan

- [x] `swift build` clean.
- [ ] Manual: browse an encrypted backup - expect the 'backup is encrypted' message with Finder disable instructions.
- [ ] Manual: browse an unencrypted backup - expect normal domain list.
- [ ] Manual: point at an empty directory - expect 'Manifest.db not found'.