### PR TITLE
fix: default to ~/Documents/Phosphor Backups, stop recommending FDA

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,11 +271,17 @@ Phosphor parses this to provide file-system-like browsing without modifying the 
 
 ## Troubleshooting
 
+### Where Phosphor stores backups
+
+Starting with v1.0.4, Phosphor's default backup directory is `~/Documents/Phosphor Backups`. This is a user-owned location, so Phosphor needs no special permission grant; it also keeps Phosphor's backups separate from Finder's, which eliminates any risk of a Phosphor run corrupting Finder-managed backups.
+
+If you are upgrading from v1.0.3 or earlier and were using the system MobileSync directory, Phosphor will detect existing backups there on first launch and pin it as your override - nothing changes. You can switch to the new default any time from **Phosphor -> Settings -> Backup Directory -> Reset**.
+
 ### "Both backup methods failed"
 
 Phosphor now surfaces the underlying `pymobiledevice3` and `idevicebackup2` stderr in the failure message. Common causes:
 
-0. **Directory "is not readable" / permission denied** - macOS protects `~/Library/Application Support/MobileSync/Backup` with TCC. Grant Phosphor **Full Disk Access** in **System Settings -> Privacy & Security -> Full Disk Access**, then relaunch Phosphor. Alternatively pick a different backup directory in **Phosphor -> Settings** (for example `~/Documents/Phosphor Backups`).
+0. **Directory "is not readable" / permission denied** - you pointed Phosphor at `~/Library/Application Support/MobileSync/Backup` but did not grant Full Disk Access. Prefer switching the backup directory back to the default `~/Documents/Phosphor Backups` in **Settings**; only grant Full Disk Access if you specifically need Phosphor to read Apple's shared backups.
 1. **Trust prompt missed** - Unlock the device, tap **Trust This Computer**, enter your passcode, then retry the backup.
 2. **Stale pymobiledevice3** - iOS 17/18/26 require a recent release. Upgrade with:
    ```bash

--- a/Sources/Phosphor/App/PhosphorApp.swift
+++ b/Sources/Phosphor/App/PhosphorApp.swift
@@ -8,6 +8,13 @@ struct PhosphorApp: App {
     @StateObject private var scheduler = BackupScheduler()
     @AppStorage("phosphor.hasCompletedOnboarding") private var hasCompletedOnboarding = false
 
+    init() {
+        // Pre-1.0.4 users defaulted to Apple's MobileSync directory implicitly.
+        // Pin that choice explicitly so they don't lose sight of existing backups
+        // when the default flips to ~/Documents/Phosphor Backups.
+        BackupManager.migrateLegacyBackupDirectory()
+    }
+
     var body: some Scene {
         WindowGroup {
             ContentView()

--- a/Sources/Phosphor/Services/BackupManager.swift
+++ b/Sources/Phosphor/Services/BackupManager.swift
@@ -44,9 +44,9 @@ final class BackupManager: ObservableObject {
         }
         if lower.contains("is not readable") || lower.contains("permission denied") || lower.contains("operation not permitted") {
             return """
-            macOS is blocking access to the backup directory. Grant Phosphor 'Full Disk Access':
-            System Settings -> Privacy & Security -> Full Disk Access -> enable Phosphor.
-            Alternatively, pick a different backup directory in Phosphor > Settings (for example ~/Documents/Phosphor Backups).
+            macOS is blocking access to the backup directory. The easiest fix is to switch Phosphor's backup directory to a user-owned location:
+            Phosphor -> Settings -> Backup Directory -> ~/Documents/Phosphor Backups.
+            Only if you specifically want Phosphor to read Apple's shared MobileSync backups do you need to grant Full Disk Access (System Settings -> Privacy & Security -> Full Disk Access). Full Disk Access is not recommended - Phosphor does not need it for its own backups.
             """
         }
         return nil
@@ -103,19 +103,62 @@ final class BackupManager: ObservableObject {
         return lines.joined(separator: "\n\n")
     }
 
-    /// Default backup location used by Apple and libimobiledevice.
+    /// Phosphor's default backup location: inside ~/Documents so no special permission
+    /// grant is needed, and so Phosphor never shares a directory with Finder's backups
+    /// (a misbehaving run could otherwise corrupt the user's Finder backups).
     static let defaultBackupDir: String = {
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        return "\(home)/Documents/Phosphor Backups"
+    }()
+
+    /// Apple's MobileSync directory. Kept as a named constant so settings UI and
+    /// migration logic can offer it to users who explicitly opt in.
+    static let systemMobileSyncDir: String = {
         let home = FileManager.default.homeDirectoryForCurrentUser.path
         return "\(home)/Library/Application Support/MobileSync/Backup"
     }()
 
-    /// Active backup directory - reads from UserDefaults if customized, falls back to default.
+    /// UserDefaults key for the active backup directory.
+    static let backupDirectoryUserDefaultsKey = "phosphor.backupDirectory"
+
+    /// Active backup directory. Falls back to the default when no override is set.
     static var activeBackupDir: String {
-        let custom = UserDefaults.standard.string(forKey: "phosphor.backupDirectory")
-        if let custom, !custom.isEmpty, custom != defaultBackupDir {
+        let custom = UserDefaults.standard.string(forKey: backupDirectoryUserDefaultsKey)
+        if let custom, !custom.isEmpty {
             return custom
         }
         return defaultBackupDir
+    }
+
+    /// One-time migration for users upgrading from <= 1.0.3. Earlier versions defaulted to
+    /// the system MobileSync directory without recording the choice in UserDefaults. Rather
+    /// than silently orphan their backups when the default flipped to Documents, pin the
+    /// MobileSync path as an explicit override if it actually contains Phosphor-visible
+    /// backup directories. Safe to call on every launch - the `migrated` flag makes it idempotent.
+    static func migrateLegacyBackupDirectory(defaults: UserDefaults = .standard) {
+        let migrationKey = "phosphor.backupDirectory.migratedFromMobileSync"
+        if defaults.bool(forKey: migrationKey) { return }
+        defer { defaults.set(true, forKey: migrationKey) }
+
+        // User already has a chosen directory - nothing to migrate.
+        if let existing = defaults.string(forKey: backupDirectoryUserDefaultsKey),
+           !existing.isEmpty {
+            return
+        }
+
+        let fm = FileManager.default
+        guard fm.fileExists(atPath: systemMobileSyncDir) else { return }
+
+        // Only pin MobileSync if we can actually read it AND it holds a UDID-shaped backup
+        // Info.plist. Otherwise the new Documents default is strictly better.
+        let contents = (try? fm.contentsOfDirectory(atPath: systemMobileSyncDir)) ?? []
+        let hasBackup = contents.contains { name in
+            let info = "\(systemMobileSyncDir)/\(name)/Info.plist"
+            return fm.isReadableFile(atPath: info)
+        }
+        if hasBackup {
+            defaults.set(systemMobileSyncDir, forKey: backupDirectoryUserDefaultsKey)
+        }
     }
 
     // MARK: - Discovery

--- a/Sources/Phosphor/Views/Settings/SettingsView.swift
+++ b/Sources/Phosphor/Views/Settings/SettingsView.swift
@@ -62,7 +62,7 @@ struct SettingsView: View {
                     }
                 }
 
-                Text("Default: ~/Library/Application Support/MobileSync/Backup")
+                Text("Default: ~/Documents/Phosphor Backups (no special permission required)")
                     .font(.system(size: 11))
                     .foregroundStyle(.secondary)
             }


### PR DESCRIPTION
Closes #1.

Follow-up to the v1.0.2 preflight and the v1.0.3 encrypted-backup detection. @bskendig's review on #1 called out the real UX / security issue: defaulting to `~/Library/Application Support/MobileSync/Backup` forces every user into a Full Disk Access grant for a permission Phosphor does not actually need, and shares a directory with Finder's backups where a misbehaving Phosphor run could corrupt them. He's right.

## Changes

- `BackupManager.defaultBackupDir` now points at `~/Documents/Phosphor Backups`. No TCC grant needed, no overlap with Finder.
- `BackupManager.systemMobileSyncDir` kept as a named constant for users who explicitly opt in.
- `BackupManager.migrateLegacyBackupDirectory()` runs once at launch for upgrades from <= 1.0.3. If the user had no recorded override AND MobileSync holds readable `Info.plist` entries, the migration pins MobileSync as an explicit override so existing backups stay visible. Idempotent via a migration flag.
- `PhosphorApp.init` calls the migration.
- `SettingsView` wording reflects the new default.
- Backup failure diagnostic for 'is not readable' / 'permission denied' now recommends switching directory first and labels Full Disk Access as *not recommended*.
- README Troubleshooting section explains the new default and the rationale.

## Test plan

- [x] `swift build` clean.
- [ ] Fresh install: default directory is `~/Documents/Phosphor Backups`, backup proceeds without FDA.
- [ ] Upgrade path with existing MobileSync backups: migration pins MobileSync, existing backups remain visible.
- [ ] Upgrade path with no MobileSync backups: default flips to Documents, migration records the flag and doesn't re-run.
- [ ] Settings > Reset restores Documents default.