### PR TITLE
fix: harden macOS dependency and backup flows

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,14 +160,16 @@ brew install --cask phosphor
 
 1. Download the latest `.dmg` from [Releases](https://github.com/momenbasel/Phosphor/releases)
 2. Drag `Phosphor.app` to Applications
-3. Install pymobiledevice3: `pip3 install pymobiledevice3`
-4. Optional fallback: `brew install libimobiledevice ideviceinstaller`
+3. Install pipx if needed: `brew install pipx`
+4. Install pymobiledevice3: `pipx install pymobiledevice3`
+5. Optional fallback: `brew install libimobiledevice ideviceinstaller`
 
 ### Build from Source
 
 ```bash
-# Install pymobiledevice3 (primary)
-pip3 install pymobiledevice3
+# Install pipx and pymobiledevice3 (primary)
+brew install pipx
+pipx install pymobiledevice3
 
 # Optional fallback tools
 brew install libimobiledevice ideviceinstaller
@@ -187,7 +189,7 @@ open .build/Phosphor.app
 ## Requirements
 
 - **macOS 14.0** (Sonoma) or later
-- **pymobiledevice3** (primary backend, supports iOS 17-26+): `pip3 install pymobiledevice3`
+- **pymobiledevice3** (primary backend, supports iOS 17-26+): `brew install pipx && pipx install pymobiledevice3`
 - **libimobiledevice** (optional fallback): `brew install libimobiledevice`
 - **ideviceinstaller** (optional fallback for app management)
 - **ifuse** (legacy file mounting, not needed with pymobiledevice3)
@@ -285,10 +287,10 @@ Phosphor now surfaces the underlying `pymobiledevice3` and `idevicebackup2` stde
 1. **Trust prompt missed** - Unlock the device, tap **Trust This Computer**, enter your passcode, then retry the backup.
 2. **Stale pymobiledevice3** - iOS 17/18/26 require a recent release. Upgrade with:
    ```bash
-   pip3 install --upgrade pymobiledevice3
+   pipx upgrade pymobiledevice3
    ```
 3. **Binary not on PATH** - GUI apps do not inherit your shell PATH. Phosphor probes `pipx`, Homebrew, and `~/Library/Python/3.{10..14}/bin` automatically; if you installed pymobiledevice3 elsewhere, symlink it into one of those directories.
-4. **Missing Python dependencies** - `ModuleNotFoundError` in the failure details means a partial install. Reinstall with `pip3 install --upgrade --force-reinstall pymobiledevice3`.
+4. **Missing Python dependencies** - `ModuleNotFoundError` in the failure details means a partial install. Reinstall with `pipx reinstall pymobiledevice3`.
 5. **Pairing record mismatch** - From Terminal, run `pymobiledevice3 lockdown pair` once, accept the Trust prompt, then retry.
 
 For encrypted backup issues, verify the device has a passcode set and that `pymobiledevice3 backup2 encryption` reports the expected state.

--- a/Sources/Phosphor/Services/AppManager.swift
+++ b/Sources/Phosphor/Services/AppManager.swift
@@ -53,7 +53,7 @@ final class AppManager: ObservableObject {
             result = await Shell.runAsync("ideviceinstaller", arguments: ["-u", udid, "-l", "-o", "list_all"])
         }
         guard result.succeeded else {
-            lastError = result.stderr.nilIfEmpty ?? "Failed to list apps. Install pymobiledevice3: pip3 install pymobiledevice3"
+            lastError = result.stderr.nilIfEmpty ?? "Failed to list apps. Install pymobiledevice3: pipx install pymobiledevice3"
             isLoading = false
             return
         }

--- a/Sources/Phosphor/Services/BackupManager.swift
+++ b/Sources/Phosphor/Services/BackupManager.swift
@@ -37,10 +37,13 @@ final class BackupManager: ObservableObject {
             return "iOS rejected the backup request. Disable/re-enable encryption or reboot the device."
         }
         if lower.contains("modulenotfounderror") || lower.contains("no module named") {
-            return "pymobiledevice3 is installed but missing dependencies. Reinstall with: pip3 install --upgrade pymobiledevice3"
+            return "pymobiledevice3 is installed but missing dependencies. Reinstall with: pipx reinstall pymobiledevice3"
         }
         if lower.contains("invalidservice") || lower.contains("remotexpc") || lower.contains("tunneld") {
-            return "Backup requires an up-to-date pymobiledevice3. Upgrade with: pip3 install --upgrade pymobiledevice3"
+            return "Backup requires an up-to-date pymobiledevice3. Upgrade with: pipx upgrade pymobiledevice3"
+        }
+        if lower.contains("zero-length") || lower.contains("cannot parse a null") || lower.contains("mberrordomain/205") || lower.contains("error reading backup properties") {
+            return "The existing backup metadata appears incomplete or corrupt. Choose a fresh local backup folder and avoid cloud-synced folders for live backups, then retry with the device unlocked."
         }
         if lower.contains("is not readable") || lower.contains("permission denied") || lower.contains("operation not permitted") {
             return """
@@ -70,9 +73,9 @@ final class BackupManager: ObservableObject {
             return (false, "\(path) exists but is not a directory.")
         }
         if !fm.isReadableFile(atPath: path) || !fm.isWritableFile(atPath: path) {
-            let isDefault = (path == defaultBackupDir)
+            let isMobileSync = (path == systemMobileSyncDir)
             var msg = "Phosphor cannot read or write \(path)."
-            if isDefault {
+            if isMobileSync {
                 msg += """
 
 
@@ -85,6 +88,25 @@ final class BackupManager: ObservableObject {
             return (false, msg)
         }
         return (true, nil)
+    }
+
+    /// Cloud file-provider folders can hydrate files lazily and expose partial
+    /// metadata while syncing. They are risky as the live target for iOS backups.
+    static func backupDirectoryWarning(for path: String) -> String? {
+        let expanded = (path as NSString).expandingTildeInPath
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        let cloudRoots = [
+            "\(home)/Library/CloudStorage",
+            "\(home)/Library/Mobile Documents",
+            "\(home)/Dropbox",
+            "\(home)/Google Drive",
+            "\(home)/OneDrive",
+            "\(home)/SynologyDrive"
+        ]
+        if cloudRoots.contains(where: { expanded == $0 || expanded.hasPrefix($0 + "/") }) {
+            return "Cloud-synced folders are not recommended for live iOS backups. Use a local folder, then sync or export completed backups afterward."
+        }
+        return nil
     }
 
     /// Build a composite error string combining stderr tail and diagnostic hint.
@@ -329,7 +351,7 @@ final class BackupManager: ObservableObject {
     /// Backup using pymobiledevice3.
     private func createBackupViaPymobiledevice(udid: String, full: Bool, onProgress: @escaping (String) -> Void) async -> Bool {
         guard PyMobileDevice.available() else {
-            lastError = "pymobiledevice3 not installed. Install with: pip3 install pymobiledevice3"
+            lastError = "pymobiledevice3 not installed. Install with: pipx install pymobiledevice3"
             return false
         }
 

--- a/Sources/Phosphor/Services/EncryptedBackupReader.swift
+++ b/Sources/Phosphor/Services/EncryptedBackupReader.swift
@@ -53,7 +53,7 @@ final class EncryptedBackupReader {
         guard isEncrypted else { throw DecryptError.notEncrypted }
 
         // Strategy 1: Use iphone-backup-decrypt Python tool if available
-        // pip3 install iphone-backup-decrypt
+        // python3 -m pip install iphone-backup-decrypt
         let pythonResult = await tryPythonDecrypt(password: password)
         if let manifest = pythonResult {
             isUnlocked = true

--- a/Sources/Phosphor/Services/FileTransferManager.swift
+++ b/Sources/Phosphor/Services/FileTransferManager.swift
@@ -82,7 +82,12 @@ final class FileTransferManager: ObservableObject {
             return true
         }
 
-        // Fallback: ifuse mount
+        guard Shell.which("ifuse") != nil else {
+            lastError = "Could not access device filesystem. Install or repair pymobiledevice3 with: pipx install pymobiledevice3"
+            return false
+        }
+
+        // Optional legacy fallback: ifuse mount
         let tmpDir = NSTemporaryDirectory() + "phosphor-mount-\(udid.prefix(8))"
         let fm = FileManager.default
 
@@ -109,7 +114,7 @@ final class FileTransferManager: ObservableObject {
         Could not access device filesystem.
 
         Install pymobiledevice3:
-          pip3 install --upgrade pymobiledevice3
+          pipx upgrade pymobiledevice3
 
         On macOS, ifuse is not installed by Homebrew; install/repair pymobiledevice3 instead.
         \(stderr.isEmpty ? "" : "\nifuse: \(stderr)")
@@ -130,7 +135,12 @@ final class FileTransferManager: ObservableObject {
             return true
         }
 
-        // Fallback: ifuse --container
+        guard Shell.which("ifuse") != nil else {
+            lastError = "Failed to access app container. Install or repair pymobiledevice3 with: pipx install pymobiledevice3"
+            return false
+        }
+
+        // Optional legacy fallback: ifuse --container
         let tmpDir = NSTemporaryDirectory() + "phosphor-app-\(bundleId.replacingOccurrences(of: ".", with: "-"))"
         let fm = FileManager.default
         try? fm.createDirectory(atPath: tmpDir, withIntermediateDirectories: true)

--- a/Sources/Phosphor/Services/FileTransferManager.swift
+++ b/Sources/Phosphor/Services/FileTransferManager.swift
@@ -111,8 +111,7 @@ final class FileTransferManager: ObservableObject {
         Install pymobiledevice3:
           pip3 install --upgrade pymobiledevice3
 
-        Or install the ifuse fallback:
-          brew install libimobiledevice ifuse
+        On macOS, ifuse is not installed by Homebrew; install/repair pymobiledevice3 instead.
         \(stderr.isEmpty ? "" : "\nifuse: \(stderr)")
         """
         return false

--- a/Sources/Phosphor/Services/LiveDeviceBrowser.swift
+++ b/Sources/Phosphor/Services/LiveDeviceBrowser.swift
@@ -68,7 +68,12 @@ final class LiveDeviceBrowser: ObservableObject {
             }
         }
 
-        // Fallback: ifuse mount
+        guard Shell.which("ifuse") != nil else {
+            lastError = "Could not access device photos. Install or repair pymobiledevice3 with: pipx install pymobiledevice3"
+            return false
+        }
+
+        // Optional legacy fallback: ifuse mount
         let tmpDir = NSTemporaryDirectory() + "phosphor-live-\(udid.prefix(8))"
         let fm = FileManager.default
         try? fm.createDirectory(atPath: tmpDir, withIntermediateDirectories: true)
@@ -81,7 +86,7 @@ final class LiveDeviceBrowser: ObservableObject {
             return true
         }
 
-        lastError = "Could not access device. Install pymobiledevice3: pip3 install pymobiledevice3"
+        lastError = "Could not access device. Install pymobiledevice3: pipx install pymobiledevice3"
         return false
     }
 

--- a/Sources/Phosphor/Services/LiveDeviceBrowser.swift
+++ b/Sources/Phosphor/Services/LiveDeviceBrowser.swift
@@ -14,6 +14,7 @@ final class LiveDeviceBrowser: ObservableObject {
 
     private var deviceUDID: String?
     private var usesAFC = false
+    private var cachedDCIMFolders: [String] = []
 
     struct LivePhoto: Identifiable, Hashable {
         let id: String
@@ -53,17 +54,10 @@ final class LiveDeviceBrowser: ObservableObject {
                 usesAFC = true
                 isMounted = true
 
-                // Count photos across DCIM subfolders
-                var count = 0
-                for subfolder in dcimContents {
-                    guard !subfolder.isEmpty, subfolder != ".", subfolder != ".." else { continue }
-                    let subFiles = await PyMobileDevice.afcList(path: "/DCIM/\(subfolder)", udid: udid)
-                    count += subFiles.filter { name in
-                        let ext = (name as NSString).pathExtension.lowercased()
-                        return ["jpg", "jpeg", "heic", "heif", "png", "gif", "mov", "mp4", "m4v"].contains(ext)
-                    }.count
-                }
-                photoCount = count
+                cachedDCIMFolders = dcimContents
+                    .filter { !$0.isEmpty && $0 != "." && $0 != ".." }
+                    .sorted()
+                photoCount = 0
                 return true
             }
         }
@@ -99,6 +93,7 @@ final class LiveDeviceBrowser: ObservableObject {
         deviceUDID = nil
         isMounted = false
         usesAFC = false
+        cachedDCIMFolders = []
         photos = []
         photoCount = 0
     }
@@ -126,10 +121,12 @@ final class LiveDeviceBrowser: ObservableObject {
         let photoExtensions = Set(["jpg", "jpeg", "heic", "heif", "png", "gif", "webp",
                                     "mov", "mp4", "m4v", "3gp"])
 
-        let dcimContents = await PyMobileDevice.afcList(path: "/DCIM", udid: udid)
+        let dcimContents = cachedDCIMFolders.isEmpty
+            ? await PyMobileDevice.afcList(path: "/DCIM", udid: udid).sorted()
+            : cachedDCIMFolders
         var found: [LivePhoto] = []
 
-        for subfolder in dcimContents.sorted() {
+        for subfolder in dcimContents {
             guard !subfolder.isEmpty else { continue }
 
             // Just list files - don't download them yet

--- a/Sources/Phosphor/Services/MusicTransferManager.swift
+++ b/Sources/Phosphor/Services/MusicTransferManager.swift
@@ -82,14 +82,19 @@ final class MusicTransferManager: ObservableObject {
             return copied
         }
 
-        // Fallback: ifuse mount
+        guard Shell.which("ifuse") != nil else {
+            lastError = "Failed to access device music storage. Install or repair pymobiledevice3 with: pipx install pymobiledevice3"
+            return 0
+        }
+
+        // Optional legacy fallback: ifuse mount
         let tmpMount = NSTemporaryDirectory() + "phosphor-music-\(udid.prefix(8))"
         let fm = FileManager.default
         try? fm.createDirectory(atPath: tmpMount, withIntermediateDirectories: true)
 
         let mountResult = await Shell.runAsync("ifuse", arguments: ["-u", udid, tmpMount])
         guard mountResult.succeeded else {
-            lastError = "Failed to mount device. Install pymobiledevice3: pip3 install pymobiledevice3"
+            lastError = "Failed to mount device. Install pymobiledevice3: pipx install pymobiledevice3"
             return 0
         }
 
@@ -168,7 +173,12 @@ final class MusicTransferManager: ObservableObject {
             )
         }
 
-        // Fallback: ifuse mount
+        guard Shell.which("ifuse") != nil else {
+            lastError = "Failed to access device ringtone storage. Install or repair pymobiledevice3 with: pipx install pymobiledevice3"
+            return false
+        }
+
+        // Optional legacy fallback: ifuse mount
         let tmpMount = NSTemporaryDirectory() + "phosphor-ringtone-\(udid.prefix(8))"
         let fm = FileManager.default
         try? fm.createDirectory(atPath: tmpMount, withIntermediateDirectories: true)

--- a/Sources/Phosphor/Services/NativeBackupService.swift
+++ b/Sources/Phosphor/Services/NativeBackupService.swift
@@ -53,7 +53,7 @@ final class NativeBackupService: ObservableObject {
             progress = "Backup complete"
         } else {
             progress = "Backup failed"
-            lastError = lastError ?? "All backup methods failed. Try: pip3 install pymobiledevice3"
+            lastError = lastError ?? "All backup methods failed. Try: pipx install pymobiledevice3"
         }
         return pyResult
     }
@@ -137,45 +137,25 @@ final class NativeBackupService: ObservableObject {
     private func pymobiledeviceBackup(udid: String, onProgress: @escaping (String) -> Void) async -> Bool {
         onProgress("Checking for pymobiledevice3...")
 
-        // Check if pymobiledevice3 is installed
-        let checkResult = await Shell.runAsync("python3", arguments: ["-c", "import pymobiledevice3; print('ok')"], timeout: 10)
-        if !checkResult.succeeded {
-            // Try pip install
-            onProgress("Installing pymobiledevice3...")
-            let installResult = await Shell.runAsync("pip3", arguments: ["install", "pymobiledevice3"], timeout: 120)
-            if !installResult.succeeded {
-                lastError = "pymobiledevice3 not available. Install with: pip3 install pymobiledevice3"
-                return false
-            }
+        guard PyMobileDevice.available() else {
+            lastError = """
+            pymobiledevice3 is not available. Install it with:
+            brew install pipx
+            pipx install pymobiledevice3
+            """
+            return false
         }
 
         onProgress("Creating backup via pymobiledevice3...")
 
         let backupDir = BackupManager.activeBackupDir
-
-        // pymobiledevice3 backup command
-        let result = await Shell.runAsync(
-            "python3",
-            arguments: ["-m", "pymobiledevice3", "backup2", "backup", "--udid", udid, "--full", backupDir],
-            timeout: 3600
-        )
+        let result = await PyMobileDevice.runAsync(["backup2", "backup", "--udid", udid, "--full", backupDir], timeout: 3600)
 
         if result.succeeded {
             return true
         }
 
-        // Alternative pymobiledevice3 syntax
-        let altResult = await Shell.runAsync(
-            "pymobiledevice3",
-            arguments: ["backup2", "backup", "--udid", udid, "--full", backupDir],
-            timeout: 3600
-        )
-
-        if altResult.succeeded {
-            return true
-        }
-
-        lastError = result.stderr.nilIfEmpty ?? altResult.stderr.nilIfEmpty ?? "pymobiledevice3 backup failed"
+        lastError = result.stderr.nilIfEmpty ?? "pymobiledevice3 backup failed"
         return false
     }
 
@@ -186,11 +166,7 @@ final class NativeBackupService: ObservableObject {
         progress = "Restoring backup..."
 
         // Try pymobiledevice3 first (most likely to work with latest iOS)
-        let result = await Shell.runAsync(
-            "python3",
-            arguments: ["-m", "pymobiledevice3", "backup2", "restore", "--udid", udid, "--system", backupPath],
-            timeout: 3600
-        )
+        let result = await PyMobileDevice.runAsync(["backup2", "restore", "--udid", udid, "--system", backupPath], timeout: 3600)
 
         isRunning = false
         return result.succeeded

--- a/Sources/Phosphor/Utilities/Extensions.swift
+++ b/Sources/Phosphor/Utilities/Extensions.swift
@@ -101,7 +101,7 @@ extension BackupInfo {
     }
 
     /// User-friendly message when backup is incomplete.
-    static let incompleteBackupMessage = "Backup is incomplete (no Manifest.db). Create a full backup first. If using iOS 17+, run: pip3 install pymobiledevice3"
+    static let incompleteBackupMessage = "Backup is incomplete (no Manifest.db). Create a full backup first. If using iOS 17+, run: pipx install pymobiledevice3"
 }
 
 // MARK: - View Modifiers

--- a/Sources/Phosphor/Utilities/PyMobileDevice.swift
+++ b/Sources/Phosphor/Utilities/PyMobileDevice.swift
@@ -8,7 +8,7 @@ enum PyMobileDevice {
     /// Cached path to the pymobiledevice3 binary once found.
     private static var cachedBinaryPath: String?
 
-    /// Python minor versions to probe for pip3 --user installs and system Python.
+    /// Python minor versions to probe for pipx or pip --user installs and system Python.
     private static let pythonMinorVersions = ["3.14", "3.13", "3.12", "3.11", "3.10"]
 
     /// Extended PATH for GUI apps that don't inherit terminal PATH.
@@ -40,7 +40,7 @@ enum PyMobileDevice {
             "/opt/homebrew/bin/pymobiledevice3",
             "/usr/local/bin/pymobiledevice3",
         ]
-        // `pip3 install --user pymobiledevice3` on macOS drops the script here.
+        // `pipx install pymobiledevice3` or older pip --user installs may drop the script here.
         directPaths.append(contentsOf: pythonMinorVersions.map {
             "\(home)/Library/Python/\($0)/bin/pymobiledevice3"
         })

--- a/Sources/Phosphor/Utilities/PyMobileDevice.swift
+++ b/Sources/Phosphor/Utilities/PyMobileDevice.swift
@@ -46,7 +46,7 @@ enum PyMobileDevice {
         })
 
         for path in directPaths {
-            if fm.isExecutableFile(atPath: path) {
+            if fm.isExecutableFile(atPath: path), directBinaryWorks(at: path) {
                 cachedBinaryPath = path
                 return path
             }
@@ -73,6 +73,17 @@ enum PyMobileDevice {
         }
 
         return nil
+    }
+
+    /// Validate direct console-script shims before caching them. A stale pip/pipx
+    /// shim can remain executable even when its Python environment was removed
+    /// or upgraded, which would otherwise make Phosphor report pymobiledevice3 as
+    /// installed and then fail every operation at runtime.
+    private static func directBinaryWorks(at path: String) -> Bool {
+        let version = Shell.run(path, arguments: ["version"], timeout: 10)
+        if version.succeeded { return true }
+        let alt = Shell.run(path, arguments: ["--version"], timeout: 10)
+        return alt.succeeded
     }
 
     /// Clear the cached binary path so the next call re-probes the filesystem.

--- a/Sources/Phosphor/Utilities/Shell.swift
+++ b/Sources/Phosphor/Utilities/Shell.swift
@@ -123,7 +123,7 @@ enum Shell {
         return result.succeeded ? result.output : nil
     }
 
-    /// Check if libimobiledevice tools are installed.
+    /// Check if required device-management tools are installed.
     static func checkDependencies() -> [String: Bool] {
         let tools = [
             "idevice_id",
@@ -134,7 +134,6 @@ enum Shell {
             "idevicesyslog",
             "idevicename",
             "idevicescreenshot",
-            "ifuse",
             "ideviceinstaller"
         ]
         var status: [String: Bool] = [:]
@@ -142,9 +141,11 @@ enum Shell {
             status[tool] = which(tool) != nil
         }
 
-        // Check pymobiledevice3 (Python, required for latest iOS backup)
-        let pyCheck = run("python3", arguments: ["-c", "import pymobiledevice3"])
-        status["pymobiledevice3"] = pyCheck.succeeded
+        // Check pymobiledevice3 using the same resolver used by the app's device
+        // operations. GUI apps often do not inherit the terminal's Python/PATH,
+        // and pipx installs expose a runnable binary rather than an importable
+        // module from Homebrew's `python3`.
+        status["pymobiledevice3"] = PyMobileDevice.available()
 
         return status
     }

--- a/Sources/Phosphor/Utilities/Shell.swift
+++ b/Sources/Phosphor/Utilities/Shell.swift
@@ -12,6 +12,18 @@ enum Shell {
         var output: String { stdout.trimmingCharacters(in: .whitespacesAndNewlines) }
     }
 
+    private static func environmentWithToolPaths() -> [String: String] {
+        var environment = ProcessInfo.processInfo.environment
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        let extra = "\(home)/.local/bin:\(home)/.local/pipx/venvs/pymobiledevice3/bin:/opt/homebrew/bin:/usr/local/bin"
+        if let path = environment["PATH"], !path.isEmpty {
+            environment["PATH"] = extra + ":" + path
+        } else {
+            environment["PATH"] = extra + ":/usr/bin:/bin"
+        }
+        return environment
+    }
+
     /// Run a command synchronously and return the result.
     @discardableResult
     static func run(_ command: String, arguments: [String] = [], timeout: TimeInterval = 60) -> Result {
@@ -23,17 +35,7 @@ enum Shell {
         process.arguments = [command] + arguments
         process.standardOutput = stdoutPipe
         process.standardError = stderrPipe
-        process.environment = ProcessInfo.processInfo.environment
-
-        // Add common tool paths (GUI apps don't inherit terminal PATH)
-        let home = FileManager.default.homeDirectoryForCurrentUser.path
-        let extra = "\(home)/.local/bin:\(home)/.local/pipx/venvs/pymobiledevice3/bin:/opt/homebrew/bin:/usr/local/bin"
-        if var path = process.environment?["PATH"] {
-            path = extra + ":" + path
-            process.environment?["PATH"] = path
-        } else {
-            process.environment?["PATH"] = extra + ":/usr/bin:/bin"
-        }
+        process.environment = environmentWithToolPaths()
 
         do {
             try process.run()
@@ -41,15 +43,51 @@ enum Shell {
             return Result(exitCode: -1, stdout: "", stderr: "Failed to launch: \(error.localizedDescription)")
         }
 
-        let stdoutData = stdoutPipe.fileHandleForReading.readDataToEndOfFile()
-        let stderrData = stderrPipe.fileHandleForReading.readDataToEndOfFile()
+        let stdoutQueue = DispatchQueue(label: "com.phosphor.shell.stdout")
+        let stderrQueue = DispatchQueue(label: "com.phosphor.shell.stderr")
+        var stdoutData = Data()
+        var stderrData = Data()
+        let readGroup = DispatchGroup()
 
-        process.waitUntilExit()
+        readGroup.enter()
+        stdoutQueue.async {
+            stdoutData = stdoutPipe.fileHandleForReading.readDataToEndOfFile()
+            readGroup.leave()
+        }
+
+        readGroup.enter()
+        stderrQueue.async {
+            stderrData = stderrPipe.fileHandleForReading.readDataToEndOfFile()
+            readGroup.leave()
+        }
+
+        let waitSemaphore = DispatchSemaphore(value: 0)
+        DispatchQueue.global(qos: .utility).async {
+            process.waitUntilExit()
+            waitSemaphore.signal()
+        }
+
+        var timedOut = false
+        if waitSemaphore.wait(timeout: .now() + timeout) == .timedOut {
+            timedOut = true
+            process.terminate()
+            if waitSemaphore.wait(timeout: .now() + 2) == .timedOut {
+                process.interrupt()
+            }
+        }
+
+        _ = readGroup.wait(timeout: .now() + 2)
+
+        var stderr = String(data: stderrData, encoding: .utf8) ?? ""
+        if timedOut {
+            let timeoutMessage = "Command timed out after \(Int(timeout))s"
+            stderr = stderr.isEmpty ? timeoutMessage : stderr + "\n" + timeoutMessage
+        }
 
         return Result(
-            exitCode: process.terminationStatus,
+            exitCode: timedOut ? -2 : process.terminationStatus,
             stdout: String(data: stdoutData, encoding: .utf8) ?? "",
-            stderr: String(data: stderrData, encoding: .utf8) ?? ""
+            stderr: stderr
         )
     }
 
@@ -80,12 +118,7 @@ enum Shell {
         process.arguments = [command] + arguments
         process.standardOutput = stdoutPipe
         process.standardError = stderrPipe
-        process.environment = ProcessInfo.processInfo.environment
-
-        if var path = process.environment?["PATH"] {
-            path = "/opt/homebrew/bin:/usr/local/bin:" + path
-            process.environment?["PATH"] = path
-        }
+        process.environment = environmentWithToolPaths()
 
         stdoutPipe.fileHandleForReading.readabilityHandler = { handle in
             let data = handle.availableData

--- a/Sources/Phosphor/Views/Components/EmptyStateView.swift
+++ b/Sources/Phosphor/Views/Components/EmptyStateView.swift
@@ -111,6 +111,7 @@ struct SectionHeader: View {
     }
 }
 
+#if canImport(PreviewsMacros)
 #Preview("Empty State") {
     EmptyStateView(
         icon: "iphone.slash",
@@ -120,3 +121,4 @@ struct SectionHeader: View {
         actionLabel: "Refresh"
     )
 }
+#endif

--- a/Sources/Phosphor/Views/Components/StorageBar.swift
+++ b/Sources/Phosphor/Views/Components/StorageBar.swift
@@ -106,6 +106,7 @@ struct FlowLayout: Layout {
     }
 }
 
+#if canImport(PreviewsMacros)
 #Preview {
     StorageBar(
         segments: [
@@ -119,3 +120,4 @@ struct FlowLayout: Layout {
     .padding()
     .frame(width: 500)
 }
+#endif

--- a/Sources/Phosphor/Views/ContentView.swift
+++ b/Sources/Phosphor/Views/ContentView.swift
@@ -272,8 +272,10 @@ struct WelcomeView: View {
     }
 }
 
+#if canImport(PreviewsMacros)
 #Preview {
     ContentView()
         .environmentObject(DeviceViewModel())
         .environmentObject(BackupViewModel())
 }
+#endif

--- a/Sources/Phosphor/Views/Onboarding/OnboardingView.swift
+++ b/Sources/Phosphor/Views/Onboarding/OnboardingView.swift
@@ -165,7 +165,7 @@ struct OnboardingView: View {
                 setupRow(
                     "pymobiledevice3",
                     installed: depStatus["pymobiledevice3"] ?? false,
-                    command: "pip3 install pymobiledevice3"
+                    command: "brew install pipx && pipx install pymobiledevice3"
                 )
                 setupRow(
                     "libimobiledevice (optional fallback)",

--- a/Sources/Phosphor/Views/Photos/PhotoBrowserView.swift
+++ b/Sources/Phosphor/Views/Photos/PhotoBrowserView.swift
@@ -122,7 +122,7 @@ struct PhotoBrowserView: View {
                 EmptyStateView(
                     icon: "photo.on.rectangle.angled",
                     title: deviceVM.selectedDevice == nil ? "No Device Connected" : "Device Not Mounted",
-                    subtitle: "Connect your device via USB to browse photos directly without a backup. Requires ifuse (brew install ifuse).",
+                    subtitle: "Connect your device via USB to browse photos directly without a backup. Uses pymobiledevice3 AFC on macOS.",
                     action: {
                         guard let udid = deviceVM.selectedDevice?.id else { return }
                         Task {

--- a/Sources/Phosphor/Views/Settings/SettingsView.swift
+++ b/Sources/Phosphor/Views/Settings/SettingsView.swift
@@ -212,16 +212,20 @@ struct SettingsView: View {
             .listStyle(.inset(alternatesRowBackgrounds: true))
 
             VStack(alignment: .leading, spacing: 8) {
-                Text("Install all required tools with Homebrew:")
+                Text("Install required tools:")
                     .font(.system(size: 13))
 
-                Text("brew install libimobiledevice ideviceinstaller ifuse")
+                Text("brew install libimobiledevice ideviceinstaller pipx\npipx install pymobiledevice3")
                     .font(.system(size: 12, design: .monospaced))
                     .padding(8)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .background(Color(.textBackgroundColor))
                     .clipShape(RoundedRectangle(cornerRadius: 6))
                     .textSelection(.enabled)
+
+                Text("ifuse is not installed by Homebrew on macOS; Phosphor uses pymobiledevice3 AFC for filesystem access instead.")
+                    .font(.system(size: 11))
+                    .foregroundStyle(.secondary)
 
                 Button("Check Again") {
                     let deps = Shell.checkDependencies()

--- a/Sources/Phosphor/Views/Settings/SettingsView.swift
+++ b/Sources/Phosphor/Views/Settings/SettingsView.swift
@@ -78,6 +78,12 @@ struct SettingsView: View {
                         .font(.system(size: 11))
                         .foregroundStyle(.orange)
                 }
+
+                if let warning = BackupManager.backupDirectoryWarning(for: backupDirectory) {
+                    Text(warning)
+                        .font(.system(size: 11))
+                        .foregroundStyle(.orange)
+                }
             }
 
             Section("Device Polling") {

--- a/Sources/Phosphor/Views/SidebarView.swift
+++ b/Sources/Phosphor/Views/SidebarView.swift
@@ -245,9 +245,11 @@ struct SidebarView: View {
     }
 }
 
+#if canImport(PreviewsMacros)
 #Preview {
     SidebarView(selection: .constant(.devices))
         .environmentObject(DeviceViewModel())
         .environmentObject(BackupViewModel())
         .frame(width: 260)
 }
+#endif


### PR DESCRIPTION
Summary
- Stop listing `ifuse` as a required macOS dependency, since Homebrew marks it Linux-only.
- Detect `pymobiledevice3` with the same resolver used by runtime device operations instead of only testing `python3 -c import pymobiledevice3`.
- Validate direct `pymobiledevice3` shims before caching them so stale pip/pipx scripts do not report as installed.
- Replace `pip3` install/upgrade guidance and in-app auto-install attempts with pipx-based guidance.
- Add real timeout enforcement to `Shell.run` and use the same expanded GUI app PATH for streaming commands.
- Warn when the backup target is inside common cloud-synced/FileProvider folders and add an actionable hint for corrupt/zero-length backup metadata failures.
- Treat `ifuse` as an optional legacy fallback only when the binary exists, and keep user-facing recovery text focused on repairing `pymobiledevice3`.
- Avoid duplicate live photo scans by caching the DCIM folder list at mount time and counting photos during the actual scan.
- Wrap SwiftUI preview macros so `swift build` works with Command Line Tools.

Verification
- `swift build`
