### PR TITLE
fix: reopen Phosphor windows reliably

### DIFF
--- a/Sources/Phosphor/App/PhosphorApp.swift
+++ b/Sources/Phosphor/App/PhosphorApp.swift
@@ -1,8 +1,35 @@
 import SwiftUI
+import AppKit
+
+final class PhosphorAppDelegate: NSObject, NSApplicationDelegate {
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        // Avoid resurrecting a broken 0-window restoration state. SwiftUI owns
+        // normal window creation; this only nudges AppKit when launch/reopen
+        // completes with no visible app window.
+        UserDefaults.standard.set(true, forKey: "ApplePersistenceIgnoreState")
+        UserDefaults.standard.set(false, forKey: "NSQuitAlwaysKeepsWindows")
+        ensureWindowSoon()
+    }
+
+    func applicationShouldHandleReopen(_ sender: NSApplication, hasVisibleWindows flag: Bool) -> Bool {
+        if !flag { ensureWindowSoon() }
+        return true
+    }
+
+    private func ensureWindowSoon() {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.35) {
+            let hasVisibleWindow = NSApp.windows.contains { $0.isVisible && !$0.isMiniaturized }
+            guard !hasVisibleWindow else { return }
+            NSApp.sendAction(#selector(NSApplication.newWindowForTab(_:)), to: nil, from: nil)
+            NSApp.activate(ignoringOtherApps: true)
+        }
+    }
+}
 
 @main
 struct PhosphorApp: App {
 
+    @NSApplicationDelegateAdaptor(PhosphorAppDelegate.self) private var appDelegate
     @StateObject private var deviceVM = DeviceViewModel()
     @StateObject private var backupVM = BackupViewModel()
     @StateObject private var scheduler = BackupScheduler()
@@ -34,8 +61,6 @@ struct PhosphorApp: App {
         .windowToolbarStyle(.unified(showsTitle: true))
         .defaultSize(width: 1100, height: 720)
         .commands {
-            CommandGroup(replacing: .newItem) {}
-
             CommandMenu("Device") {
                 Button("Refresh Devices") {
                     Task { await deviceVM.refresh() }


### PR DESCRIPTION
## Summary
- Restores the standard new-window command
- Adds a small app delegate reopen guard for 0-window launches/reopens

## Verification
- swift build
- swift build -c release
