### PR TITLE
fix: quit after closing last Phosphor window

### DIFF
--- a/Scripts/regression-tests.py
+++ b/Scripts/regression-tests.py
@@ -82,8 +82,14 @@ def test_app_lifecycle_quits_after_last_window_closes() -> None:
     src = read("Sources/Phosphor/App/PhosphorApp.swift")
     assert_contains(src, "applicationShouldTerminateAfterLastWindowClosed", "Phosphor should quit when the last app window closes")
     assert_contains(src, "-> Bool {\n        true\n    }", "last-window-close delegate should return true")
-    assert_contains(src, "applicationShouldHandleReopen", "Dock/app reopen should recreate a missing window")
-    assert_contains(src, "ensureWindowSoon()", "reopen recovery should keep using the no-window guard")
+    reopen = re.search(
+        r"func\s+applicationShouldHandleReopen\(_ sender: NSApplication,\s*hasVisibleWindows flag: Bool\)\s*->\s*Bool\s*\{(?P<body>.*?)\n    \}",
+        src,
+        re.S,
+    )
+    if reopen is None:
+        raise AssertionError("Dock/app reopen should recreate a missing window")
+    assert_contains(reopen.group("body"), "ensureWindowSoon()", "reopen recovery should call the no-window guard inside applicationShouldHandleReopen")
     assert_true("CommandGroup(replacing: .newItem)" not in src, "do not remove SwiftUI's standard New Window command")
 
 

--- a/Scripts/regression-tests.py
+++ b/Scripts/regression-tests.py
@@ -78,6 +78,15 @@ def test_attachment_path_cache_invariants() -> None:
     assert_contains(src, "missingAttachmentDiskPaths.insert(filename)", "resolver should store negative cache")
 
 
+def test_app_lifecycle_quits_after_last_window_closes() -> None:
+    src = read("Sources/Phosphor/App/PhosphorApp.swift")
+    assert_contains(src, "applicationShouldTerminateAfterLastWindowClosed", "Phosphor should quit when the last app window closes")
+    assert_contains(src, "-> Bool {\n        true\n    }", "last-window-close delegate should return true")
+    assert_contains(src, "applicationShouldHandleReopen", "Dock/app reopen should recreate a missing window")
+    assert_contains(src, "ensureWindowSoon()", "reopen recovery should keep using the no-window guard")
+    assert_true("CommandGroup(replacing: .newItem)" not in src, "do not remove SwiftUI's standard New Window command")
+
+
 def test_minimal_sms_schema_fixture_supports_limited_attachment_query() -> None:
     # Fixture for the limited attachment-loading query shape: only requested IDs
     # should be returned, so search/global paths do not load all attachments.

--- a/Scripts/regression/checks/app_lifecycle.py
+++ b/Scripts/regression/checks/app_lifecycle.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 
@@ -15,6 +16,11 @@ def test_phosphor_quits_after_last_window_closes(root: Path) -> None:
 
 def test_phosphor_preserves_reopen_window_recovery(root: Path) -> None:
     src = read(root, "Sources/Phosphor/App/PhosphorApp.swift")
-    assert "applicationShouldHandleReopen" in src, "Dock/app reopen should recreate a missing window"
-    assert "ensureWindowSoon()" in src, "reopen recovery should keep using the no-window guard"
+    reopen = re.search(
+        r"func\s+applicationShouldHandleReopen\(_ sender: NSApplication,\s*hasVisibleWindows flag: Bool\)\s*->\s*Bool\s*\{(?P<body>.*?)\n    \}",
+        src,
+        re.S,
+    )
+    assert reopen is not None, "Dock/app reopen should recreate a missing window"
+    assert "ensureWindowSoon()" in reopen.group("body"), "reopen recovery should call the no-window guard inside applicationShouldHandleReopen"
     assert "CommandGroup(replacing: .newItem)" not in src, "do not remove SwiftUI's standard New Window command"

--- a/Scripts/regression/checks/app_lifecycle.py
+++ b/Scripts/regression/checks/app_lifecycle.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def read(root: Path, rel: str) -> str:
+    return (root / rel).read_text()
+
+
+def test_phosphor_quits_after_last_window_closes(root: Path) -> None:
+    src = read(root, "Sources/Phosphor/App/PhosphorApp.swift")
+    assert "applicationShouldTerminateAfterLastWindowClosed" in src, "Phosphor should quit when the last app window closes"
+    assert "-> Bool {\n        true\n    }" in src, "last-window-close delegate should return true"
+
+
+def test_phosphor_preserves_reopen_window_recovery(root: Path) -> None:
+    src = read(root, "Sources/Phosphor/App/PhosphorApp.swift")
+    assert "applicationShouldHandleReopen" in src, "Dock/app reopen should recreate a missing window"
+    assert "ensureWindowSoon()" in src, "reopen recovery should keep using the no-window guard"
+    assert "CommandGroup(replacing: .newItem)" not in src, "do not remove SwiftUI's standard New Window command"

--- a/Sources/Phosphor/App/PhosphorApp.swift
+++ b/Sources/Phosphor/App/PhosphorApp.swift
@@ -16,6 +16,10 @@ final class PhosphorAppDelegate: NSObject, NSApplicationDelegate {
         return true
     }
 
+    func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
+        true
+    }
+
     private func ensureWindowSoon() {
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.35) {
             let hasVisibleWindow = NSApp.windows.contains { $0.isVisible && !$0.isMiniaturized }


### PR DESCRIPTION
## Summary
- Quit Phosphor when the last regular app window closes
- Keep the existing Dock/app reopen recovery for no-window launches
- Add lifecycle regression coverage so the close behavior and New Window command stay intact

## Verification
- `Scripts/regression-tests.py`
- `Scripts/regression/run.py`
- `swift build`
- `swift build -c release`
- `bash Scripts/build.sh`
- `Scripts/benchmark-performance.sh`
- Installed `/Applications/Phosphor.app`, launched it, clicked the red close button via System Events, confirmed the process exited, then reopened and confirmed one visible window
