### PR TITLE
feat: wire EncryptedBackupReader into backup browse flow

### DIFF
--- a/Sources/Phosphor/Services/EncryptedBackupReader.swift
+++ b/Sources/Phosphor/Services/EncryptedBackupReader.swift
@@ -71,28 +71,38 @@ final class EncryptedBackupReader {
     }
 
     /// Decrypt using the iphone_backup_decrypt Python package.
+    // Resolve the python3 binary at startup so GUI apps (which don't inherit the
+    // Homebrew PATH) still find the right interpreter.
+    private static let python3Path: String = {
+        for candidate in ["/opt/homebrew/bin/python3", "/usr/local/bin/python3", "/usr/bin/python3"] {
+            if FileManager.default.isExecutableFile(atPath: candidate) { return candidate }
+        }
+        return "python3"
+    }()
+
     private func tryPythonDecrypt(password: String) async -> BackupManifest? {
         let tmpDir = NSTemporaryDirectory() + "phosphor-decrypt-\(UUID().uuidString.prefix(8))"
 
         // Check if the Python tool is available
-        let checkResult = await Shell.runAsync("python3", arguments: ["-c", "import iphone_backup_decrypt"])
+        let checkResult = await Shell.runAsync(Self.python3Path, arguments: ["-c", "import iphone_backup_decrypt"])
         guard checkResult.succeeded else { return nil }
 
         // Create temp directory for decrypted output
         try? FileManager.default.createDirectory(atPath: tmpDir, withIntermediateDirectories: true)
 
-        // Run the decryption script
+        // Pass backup_directory, passphrase, and output path as argv to avoid
+        // escaping issues with special characters in the password.
         let script = """
-        import iphone_backup_decrypt
-        backup = iphone_backup_decrypt.EncryptedBackup(backup_directory="\(backupPath)", passphrase="\(password)")
-        backup.save_manifest_file("\(tmpDir)/Manifest.db")
+        import sys, iphone_backup_decrypt
+        backup = iphone_backup_decrypt.EncryptedBackup(backup_directory=sys.argv[1], passphrase=sys.argv[2])
+        backup.save_manifest_file(sys.argv[3])
         print("OK")
         """
 
         let scriptPath = tmpDir + "/decrypt.py"
         try? script.write(toFile: scriptPath, atomically: true, encoding: .utf8)
 
-        let result = await Shell.runAsync("python3", arguments: [scriptPath], timeout: 120)
+        let result = await Shell.runAsync(Self.python3Path, arguments: [scriptPath, backupPath, password, tmpDir + "/Manifest.db"], timeout: 120)
 
         // Clean up script
         try? FileManager.default.removeItem(atPath: scriptPath)
@@ -101,15 +111,18 @@ final class EncryptedBackupReader {
 
         // Check if Manifest.db was created
         let manifestDbPath = tmpDir + "/Manifest.db"
-        guard FileManager.default.fileExists(atPath: manifestDbPath) else { return nil }
+        guard FileManager.default.fileExists(atPath: manifestDbPath) else {
+            NSLog("[Phosphor] Manifest.db not found at %@", manifestDbPath)
+            return nil
+        }
 
         decryptedManifestPath = tmpDir
 
-        // Create a temporary backup structure that points to decrypted manifest
-        // but original backup files
         do {
-            return try BackupManifest(backupPath: tmpDir)
+            // Use original backupPath for file resolution, but read the decrypted Manifest.db from tmpDir
+            return try BackupManifest(backupPath: backupPath, manifestDbPath: manifestDbPath)
         } catch {
+            NSLog("[Phosphor] BackupManifest init failed: %@", error.localizedDescription)
             return nil
         }
     }

--- a/Sources/Phosphor/Utilities/BackupManifest.swift
+++ b/Sources/Phosphor/Utilities/BackupManifest.swift
@@ -92,9 +92,19 @@ final class BackupManifest {
         }
     }
 
-    init(backupPath: String) throws {
+    convenience init(backupPath: String) throws {
+        try self.init(backupPath: backupPath, manifestOverride: nil)
+    }
+
+    /// For encrypted backups: manifestDbPath is the decrypted Manifest.db in a temp dir;
+    /// backupPath is the original backup dir used for resolving actual file paths.
+    convenience init(backupPath: String, manifestDbPath: String) throws {
+        try self.init(backupPath: backupPath, manifestOverride: manifestDbPath)
+    }
+
+    private init(backupPath: String, manifestOverride: String? = nil) throws {
         self.backupPath = backupPath
-        let manifestPath = (backupPath as NSString).appendingPathComponent("Manifest.db")
+        let manifestPath = manifestOverride ?? (backupPath as NSString).appendingPathComponent("Manifest.db")
 
         // Preflight: Manifest.db must exist, have the SQLite header, and the backup
         // must not be flagged as encrypted. Detecting this up front turns the opaque
@@ -103,7 +113,8 @@ final class BackupManifest {
         guard fm.fileExists(atPath: manifestPath) else {
             throw ManifestError.manifestMissing(path: manifestPath)
         }
-        if let plist = PlistParser.parseManifest(backupPath), plist.isEncrypted {
+        // Skip encryption check when manifestOverride is set — the caller already decrypted it.
+        if manifestOverride == nil, let plist = PlistParser.parseManifest(backupPath), plist.isEncrypted {
             throw ManifestError.backupEncrypted(path: manifestPath)
         }
         if let handle = try? FileHandle(forReadingFrom: URL(fileURLWithPath: manifestPath)) {

--- a/Sources/Phosphor/ViewModels/BackupViewModel.swift
+++ b/Sources/Phosphor/ViewModels/BackupViewModel.swift
@@ -20,9 +20,13 @@ final class BackupViewModel: ObservableObject {
     @Published var searchQuery = ""
     @Published var searchResults: [BackupManifest.FileEntry] = []
 
+    @Published var showPasswordPrompt = false
+
     let backupManager = BackupManager()
     private var currentManifest: BackupManifest?
     private var sizeResolutionTask: Task<Void, Never>?
+    private var pendingEncryptedBackup: BackupInfo?
+    private var activeEncryptedReader: EncryptedBackupReader?
 
     func loadBackups() {
         sizeResolutionTask?.cancel()
@@ -104,6 +108,15 @@ final class BackupViewModel: ObservableObject {
     // MARK: - Browsing
 
     func openBackupBrowser(_ backup: BackupInfo) {
+        activeEncryptedReader?.cleanup()
+        activeEncryptedReader = nil
+
+        if backup.isEncrypted {
+            pendingEncryptedBackup = backup
+            showPasswordPrompt = true
+            return
+        }
+
         selectedBackup = backup
         currentManifest = backupManager.openManifest(for: backup)
 
@@ -119,6 +132,25 @@ final class BackupViewModel: ObservableObject {
         } catch {
             alertMessage = "Failed to read backup: \(error.localizedDescription)"
             showAlert = true
+        }
+    }
+
+    func unlockBackup(password: String) async {
+        guard let backup = pendingEncryptedBackup else { return }
+        let reader = EncryptedBackupReader(backupPath: backup.path)
+        do {
+            let manifest = try await reader.unlock(password: password)
+            activeEncryptedReader = reader
+            selectedBackup = backup
+            currentManifest = manifest
+            browserDomains = (try? manifest.domains()) ?? []
+            showPasswordPrompt = false
+            pendingEncryptedBackup = nil
+        } catch {
+            reader.cleanup()
+            alertMessage = error.localizedDescription
+            showAlert = true
+            showPasswordPrompt = false
         }
     }
 

--- a/Sources/Phosphor/Views/Backup/BackupListView.swift
+++ b/Sources/Phosphor/Views/Backup/BackupListView.swift
@@ -7,6 +7,7 @@ struct BackupListView: View {
     @EnvironmentObject var backupVM: BackupViewModel
     @State private var showDeleteConfirm = false
     @State private var backupToDelete: BackupInfo?
+    @State private var backupPassword = ""
     @State private var showImportArchive = false
     @State private var archiveProgress: String?
     @State private var isArchiving = false
@@ -113,6 +114,16 @@ struct BackupListView: View {
         .sheet(isPresented: $showScheduleSheet) {
             BackupScheduleSheet()
                 .frame(width: 440, height: 400)
+        }
+        .sheet(isPresented: $backupVM.showPasswordPrompt) {
+            EncryptedBackupUnlockSheet(password: $backupPassword) {
+                let pwd = backupPassword
+                backupPassword = ""
+                Task { await backupVM.unlockBackup(password: pwd) }
+            } onCancel: {
+                backupPassword = ""
+                backupVM.showPasswordPrompt = false
+            }
         }
         .onAppear { backupVM.loadBackups() }
     }
@@ -261,6 +272,44 @@ struct BackupListView: View {
         .padding(.horizontal, 20)
         .padding(.vertical, 12)
         .background(Color.orange.opacity(0.08))
+    }
+}
+
+struct EncryptedBackupUnlockSheet: View {
+    @Binding var password: String
+    let onUnlock: () -> Void
+    let onCancel: () -> Void
+
+    var body: some View {
+        VStack(spacing: 20) {
+            Image(systemName: "lock.fill")
+                .font(.system(size: 36))
+                .foregroundStyle(.orange)
+
+            VStack(spacing: 6) {
+                Text("Encrypted Backup")
+                    .font(.headline)
+                Text("Enter the password you set when enabling backup encryption.")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+            }
+
+            SecureField("Backup password", text: $password)
+                .textFieldStyle(.roundedBorder)
+                .onSubmit(onUnlock)
+
+            HStack(spacing: 12) {
+                Button("Cancel", action: onCancel)
+                    .keyboardShortcut(.cancelAction)
+                Button("Unlock") { onUnlock() }
+                    .buttonStyle(.borderedProminent)
+                    .disabled(password.isEmpty)
+                    .keyboardShortcut(.defaultAction)
+            }
+        }
+        .padding(28)
+        .frame(width: 340)
     }
 }
 


### PR DESCRIPTION
## Problem

Clicking **Browse** on an encrypted backup shows an error alert and nothing else:

> This backup is encrypted. Phosphor's encrypted-backup browser needs the backup password to decrypt Manifest.db at `<path>`.

`EncryptedBackupReader.swift` was fully implemented but not wired into the UI — there was no way to enter the password.

## Solution

- **`BackupViewModel.openBackupBrowser()`**: check `backup.isEncrypted` before opening; if encrypted, store the backup and flip `showPasswordPrompt` instead of trying (and failing) to open the manifest.
- **`BackupViewModel.unlockBackup(password:)`**: new async method — creates an `EncryptedBackupReader`, calls `unlock(password:)`, and on success loads the decrypted manifest domains into `browserDomains`.
- **`BackupListView`**: adds a `SecureField` sheet bound to `backupVM.showPasswordPrompt`. On confirm, calls `unlockBackup`. Return/Enter submits. Cancel dismisses cleanly.
- **`EncryptedBackupUnlockSheet`**: small dedicated view with lock icon, explanation text, and keyboard shortcut bindings.

## Test plan

- [ ] `python3 -c "import iphone_backup_decrypt; print('ok')"` succeeds (dependency present)
- [ ] Browse on an unencrypted backup still works as before
- [ ] Browse on an encrypted backup → password sheet appears
- [ ] Wrong password → error alert, sheet closes
- [ ] Correct password → domain list loads (CameraRollDomain, AppDomain-…, etc.)
- [ ] WhatsApp / Messages tabs load data after unlocking

## Notes

`iphone-backup-decrypt` must be installed (`pip3 install iphone-backup-decrypt`). The `EncryptedBackupReader` already surfaces a user-friendly error if the package is missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019tU8GYaMsg848EmiEfBfaq