### PR TITLE
fix: harden stability and wireless device discovery

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,9 @@ jobs:
       - name: Install Dependencies
         run: brew install libimobiledevice
 
+      - name: Run Regression Checks
+        run: Scripts/regression/run.py
+
       - name: Build Debug
         run: swift build
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,7 @@ Open an issue with:
 2. Create a feature branch (`git checkout -b feature/my-feature`)
 3. Make your changes
 4. Test with a real device if possible
-5. Run `swift build` to verify compilation
+5. Run `Scripts/regression/run.py` and `swift build` to verify regressions and compilation
 6. Commit with clear messages
 7. Open a PR against `main`
 

--- a/Scripts/build.sh
+++ b/Scripts/build.sh
@@ -15,9 +15,9 @@ echo "==> Building Phosphor..."
 
 cd "$PROJECT_DIR"
 
-if [ -x "$PROJECT_DIR/Scripts/regression-tests.py" ]; then
+if [ -x "$PROJECT_DIR/Scripts/regression/run.py" ]; then
     echo "==> Running regression checks..."
-    "$PROJECT_DIR/Scripts/regression-tests.py"
+    "$PROJECT_DIR/Scripts/regression/run.py"
 fi
 
 # Build release binary

--- a/Scripts/regression-tests.py
+++ b/Scripts/regression-tests.py
@@ -82,8 +82,14 @@ def test_app_lifecycle_quits_after_last_window_closes() -> None:
     src = read("Sources/Phosphor/App/PhosphorApp.swift")
     assert_contains(src, "applicationShouldTerminateAfterLastWindowClosed", "Phosphor should quit when the last app window closes")
     assert_contains(src, "-> Bool {\n        true\n    }", "last-window-close delegate should return true")
-    assert_contains(src, "applicationShouldHandleReopen", "Dock/app reopen should recreate a missing window")
-    assert_contains(src, "ensureWindowSoon()", "reopen recovery should keep using the no-window guard")
+    reopen = re.search(
+        r"func\s+applicationShouldHandleReopen\(_ sender: NSApplication,\s*hasVisibleWindows flag: Bool\)\s*->\s*Bool\s*\{(?P<body>.*?)\n    \}",
+        src,
+        re.S,
+    )
+    if reopen is None:
+        raise AssertionError("Dock/app reopen should recreate a missing window")
+    assert_contains(reopen.group("body"), "ensureWindowSoon()", "reopen recovery should call the no-window guard inside applicationShouldHandleReopen")
     assert_true("CommandGroup(replacing: .newItem)" not in src, "do not remove SwiftUI's standard New Window command")
 
 

--- a/Scripts/regression-tests.py
+++ b/Scripts/regression-tests.py
@@ -1,133 +1,15 @@
 #!/usr/bin/env python3
-"""Lightweight Phosphor regression checks.
+"""Compatibility entrypoint for Phosphor regression checks.
 
-The current Apple Command Line Tools image used for this repo does not provide
-XCTest/Testing modules, so these checks validate important source-level and
-fixture-level invariants without a Swift test framework. They are intentionally
-fast and deterministic so CI/local verification can run them alongside builds.
+The focused checks live under Scripts/regression/checks so each stability area
+can grow independently. Keep this top-level script as a stable local/CI command
+for older workflows and contributor muscle memory.
 """
 from __future__ import annotations
 
-import json
-import re
-import sqlite3
-import tempfile
+import runpy
 from pathlib import Path
-
-ROOT = Path(__file__).resolve().parents[1]
-
-
-def read(rel: str) -> str:
-    return (ROOT / rel).read_text()
-
-
-def assert_true(condition: bool, message: str) -> None:
-    if not condition:
-        raise AssertionError(message)
-
-
-def assert_contains(text: str, needle: str, message: str) -> None:
-    assert_true(needle in text, message)
-
-
-def test_streaming_exports_truncate_before_write() -> None:
-    src = read("Sources/Phosphor/Services/MessageExporter.swift")
-    for func_name in ["exportCSV", "exportPlainText", "exportHTML", "exportMbox", "exportJSON"]:
-        match = re.search(rf"private func {func_name}.*?(?=\n    private func|\n    ///|\Z)", src, re.S)
-        if match is None:
-            raise AssertionError(f"{func_name} not found")
-        body = match.group(0)
-        assert_contains(body, "removeItem(at: outputURL)", f"{func_name} must remove existing output before streaming")
-        assert_contains(body, "FileHandle(forWritingTo: outputURL)", f"{func_name} must stream through FileHandle")
-
-
-def test_json_overwrite_fixture_has_no_stale_tail() -> None:
-    with tempfile.TemporaryDirectory() as tmp:
-        path = Path(tmp) / "export.json"
-        long_payload = {"messages": [{"text": "x" * 10_000}]}
-        short_payload = {"messages": []}
-        path.write_text(json.dumps(long_payload), encoding="utf-8")
-        # Mirrors MessageExporter's truncate-before-stream pattern.
-        path.unlink(missing_ok=True)
-        with path.open("w", encoding="utf-8") as handle:
-            handle.write(json.dumps(short_payload))
-        parsed = json.loads(path.read_text(encoding="utf-8"))
-        assert_true(parsed == short_payload, "short JSON overwrite should parse without stale trailing bytes")
-
-
-def test_lazy_manifest_size_queries_do_not_eager_stat() -> None:
-    src = read("Sources/Phosphor/Utilities/BackupManifest.swift")
-    for signature in ["func files(inDomain", "func search(_ query"]:
-        start = src.index(signature)
-        end = src.index("    ///", start + 1)
-        body = src[start:end]
-        assert_true("attributesOfItem" not in body, f"{signature} must not stat files eagerly")
-        assert_true("SELECT fileID, domain, relativePath, flags" in body, f"{signature} should query metadata only")
-    vm = read("Sources/Phosphor/ViewModels/BackupViewModel.swift")
-    assert_contains(vm, "manifest.resolvingSizes(for: try manifest.files(inDomain: domain))", "backup browser should resolve visible domain sizes")
-    assert_contains(vm, "manifest.resolvingSizes(for: try manifest.search(query))", "backup search should resolve visible search sizes")
-
-
-def test_attachment_path_cache_invariants() -> None:
-    src = read("Sources/Phosphor/Services/MessageExporter.swift")
-    assert_contains(src, "attachmentDiskPathCache", "attachment path cache should exist")
-    assert_contains(src, "missingAttachmentDiskPaths", "missing attachment cache should exist")
-    assert_contains(src, "if let cached = attachmentDiskPathCache[filename]", "resolver should hit positive cache")
-    assert_contains(src, "missingAttachmentDiskPaths.contains(filename)", "resolver should hit negative cache")
-    assert_contains(src, "attachmentDiskPathCache[filename] = candidate", "resolver should store positive cache")
-    assert_contains(src, "missingAttachmentDiskPaths.insert(filename)", "resolver should store negative cache")
-
-
-def test_app_lifecycle_quits_after_last_window_closes() -> None:
-    src = read("Sources/Phosphor/App/PhosphorApp.swift")
-    assert_contains(src, "applicationShouldTerminateAfterLastWindowClosed", "Phosphor should quit when the last app window closes")
-    assert_contains(src, "-> Bool {\n        true\n    }", "last-window-close delegate should return true")
-    reopen = re.search(
-        r"func\s+applicationShouldHandleReopen\(_ sender: NSApplication,\s*hasVisibleWindows flag: Bool\)\s*->\s*Bool\s*\{(?P<body>.*?)\n    \}",
-        src,
-        re.S,
-    )
-    if reopen is None:
-        raise AssertionError("Dock/app reopen should recreate a missing window")
-    assert_contains(reopen.group("body"), "ensureWindowSoon()", "reopen recovery should call the no-window guard inside applicationShouldHandleReopen")
-    assert_true("CommandGroup(replacing: .newItem)" not in src, "do not remove SwiftUI's standard New Window command")
-
-
-def test_minimal_sms_schema_fixture_supports_limited_attachment_query() -> None:
-    # Fixture for the limited attachment-loading query shape: only requested IDs
-    # should be returned, so search/global paths do not load all attachments.
-    with tempfile.TemporaryDirectory() as tmp:
-        db_path = Path(tmp) / "sms.db"
-        con = sqlite3.connect(db_path)
-        con.executescript(
-            """
-            CREATE TABLE attachment (ROWID INTEGER PRIMARY KEY, guid TEXT, filename TEXT, mime_type TEXT, transfer_name TEXT, total_bytes INTEGER);
-            CREATE TABLE message_attachment_join (message_id INTEGER, attachment_id INTEGER);
-            INSERT INTO attachment VALUES (1,'a','~/Library/SMS/Attachments/a.jpg','image/jpeg','a.jpg',10);
-            INSERT INTO attachment VALUES (2,'b','~/Library/SMS/Attachments/b.jpg','image/jpeg','b.jpg',20);
-            INSERT INTO message_attachment_join VALUES (100,1);
-            INSERT INTO message_attachment_join VALUES (200,2);
-            """
-        )
-        rows = con.execute(
-            """
-            SELECT maj.message_id, a.ROWID, a.guid, a.filename, a.mime_type, a.transfer_name, a.total_bytes
-            FROM attachment a JOIN message_attachment_join maj ON maj.attachment_id = a.ROWID
-            WHERE maj.message_id IN (?)
-            """,
-            (100,),
-        ).fetchall()
-        assert_true(len(rows) == 1 and rows[0][0] == 100, "limited attachment query should only load requested message IDs")
-        con.close()
-
-
-def main() -> None:
-    tests = [name for name in globals() if name.startswith("test_")]
-    for name in sorted(tests):
-        globals()[name]()
-        print(f"PASS {name}")
-    print(f"PASS {len(tests)} regression checks")
 
 
 if __name__ == "__main__":
-    main()
+    runpy.run_path(str(Path(__file__).with_name("regression") / "run.py"), run_name="__main__")

--- a/Scripts/regression-tests.py
+++ b/Scripts/regression-tests.py
@@ -78,6 +78,15 @@ def test_attachment_path_cache_invariants() -> None:
     assert_contains(src, "missingAttachmentDiskPaths.insert(filename)", "resolver should store negative cache")
 
 
+def test_app_lifecycle_quits_after_last_window_closes() -> None:
+    src = read("Sources/Phosphor/App/PhosphorApp.swift")
+    assert_contains(src, "applicationShouldTerminateAfterLastWindowClosed", "Phosphor should quit when the last app window closes")
+    assert_contains(src, "-> Bool {\n        true\n    }", "last-window-close delegate should return true")
+    assert_contains(src, "applicationShouldHandleReopen", "Dock/app reopen should recreate a missing window")
+    assert_contains(src, "ensureWindowSoon()", "reopen recovery should keep using the no-window guard")
+    assert_true("CommandGroup(replacing: .newItem)" not in src, "do not remove SwiftUI's standard New Window command")
+
+
 def test_minimal_sms_schema_fixture_supports_limited_attachment_query() -> None:
     # Fixture for the limited attachment-loading query shape: only requested IDs
     # should be returned, so search/global paths do not load all attachments.

--- a/Scripts/regression/checks/app_lifecycle.py
+++ b/Scripts/regression/checks/app_lifecycle.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 
@@ -15,6 +16,11 @@ def test_phosphor_quits_after_last_window_closes(root: Path) -> None:
 
 def test_phosphor_preserves_reopen_window_recovery(root: Path) -> None:
     src = read(root, "Sources/Phosphor/App/PhosphorApp.swift")
-    assert "applicationShouldHandleReopen" in src, "Dock/app reopen should recreate a missing window"
-    assert "ensureWindowSoon()" in src, "reopen recovery should keep using the no-window guard"
+    reopen = re.search(
+        r"func\s+applicationShouldHandleReopen\(_ sender: NSApplication,\s*hasVisibleWindows flag: Bool\)\s*->\s*Bool\s*\{(?P<body>.*?)\n    \}",
+        src,
+        re.S,
+    )
+    assert reopen is not None, "Dock/app reopen should recreate a missing window"
+    assert "ensureWindowSoon()" in reopen.group("body"), "reopen recovery should call the no-window guard inside applicationShouldHandleReopen"
     assert "CommandGroup(replacing: .newItem)" not in src, "do not remove SwiftUI's standard New Window command"

--- a/Scripts/regression/checks/app_lifecycle.py
+++ b/Scripts/regression/checks/app_lifecycle.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def read(root: Path, rel: str) -> str:
+    return (root / rel).read_text()
+
+
+def test_phosphor_quits_after_last_window_closes(root: Path) -> None:
+    src = read(root, "Sources/Phosphor/App/PhosphorApp.swift")
+    assert "applicationShouldTerminateAfterLastWindowClosed" in src, "Phosphor should quit when the last app window closes"
+    assert "-> Bool {\n        true\n    }" in src, "last-window-close delegate should return true"
+
+
+def test_phosphor_preserves_reopen_window_recovery(root: Path) -> None:
+    src = read(root, "Sources/Phosphor/App/PhosphorApp.swift")
+    assert "applicationShouldHandleReopen" in src, "Dock/app reopen should recreate a missing window"
+    assert "ensureWindowSoon()" in src, "reopen recovery should keep using the no-window guard"
+    assert "CommandGroup(replacing: .newItem)" not in src, "do not remove SwiftUI's standard New Window command"

--- a/Scripts/regression/checks/backup_manifest.py
+++ b/Scripts/regression/checks/backup_manifest.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def read(root: Path, rel: str) -> str:
+    return (root / rel).read_text()
+
+
+def test_lazy_manifest_size_queries_do_not_eager_stat(root: Path) -> None:
+    src = read(root, "Sources/Phosphor/Utilities/BackupManifest.swift")
+    for signature in ["func files(inDomain", "func search(_ query"]:
+        start = src.index(signature)
+        end = src.index("    ///", start + 1)
+        body = src[start:end]
+        assert "attributesOfItem" not in body, f"{signature} must not stat files eagerly"
+        assert "SELECT fileID, domain, relativePath, flags" in body, f"{signature} should query metadata only"
+
+    vm = read(root, "Sources/Phosphor/ViewModels/BackupViewModel.swift")
+    assert "manifest.resolvingSizes(for: try manifest.files(inDomain: domain))" in vm, "backup browser should resolve visible domain sizes"
+    assert "manifest.resolvingSizes(for: try manifest.search(query))" in vm, "backup search should resolve visible search sizes"
+
+
+def test_manifest_open_preflights_encrypted_and_missing_backups(root: Path) -> None:
+    src = read(root, "Sources/Phosphor/Utilities/BackupManifest.swift")
+    assert "case manifestMissing" in src, "missing Manifest.db should have a typed user-facing error"
+    assert "case backupEncrypted" in src, "encrypted backup should have a typed user-facing error"
+    assert "PlistParser.parseManifest(backupPath), plist.isEncrypted" in src, "Manifest.plist encryption should be checked before sqlite open"
+    assert "SQLite format 3" in src, "Manifest.db header should be preflighted before sqlite open"
+    assert "case manifestUnreadable" in src, "unreadable Manifest.db should preserve the underlying error"

--- a/Scripts/regression/checks/device_backup.py
+++ b/Scripts/regression/checks/device_backup.py
@@ -41,6 +41,7 @@ def test_bonjour_finder_visible_devices_are_discovery_hints(root: Path) -> None:
 
     view = read(root, "Sources/Phosphor/Views/Device/DeviceOverviewView.swift")
     assert_contains(view, "Finder-visible devices", "Empty device state should disclose devices Finder can see")
+    assert_contains(view, "Nearby, Not Backup-Ready", "Finder-visible-only devices should have a distinct non-backup-ready state")
     assert_contains(view, "cannot open a usbmux connection", "UI should explain why Finder visibility is not enough")
 
 
@@ -82,19 +83,47 @@ def test_wifi_schedules_use_network_discovery_and_network_backup_flag(root: Path
     assert_contains(scheduler, 'let fallbackArgs = schedule.wifiOnly ? ["-n"] : ["-l"]', "Wi-Fi-only fallback should use idevice_id -n")
     assert_contains(scheduler, "createIncrementalBackup(udid: udid, preferNetwork: preferNetwork)", "scheduled incremental backups should preserve network preference")
     assert_contains(scheduler, "createBackup(udid: udid, preferNetwork: preferNetwork)", "scheduled full backups should preserve network preference")
+    assert_contains(scheduler, "schedule.incrementalOnly && BackupManager.hasExistingBackup(for: udid)", "Scheduled incremental mode should run the required first full backup when metadata is missing")
+    assert_contains(scheduler, "running required first full backup", "Scheduled first-full fallback should be logged clearly")
 
 
 def test_incremental_backups_require_existing_metadata(root: Path) -> None:
     manager = read(root, "Sources/Phosphor/Services/BackupManager.swift")
     assert_contains(manager, "hasExistingBackup(for udid", "BackupManager should expose an existing-backup metadata preflight")
-    assert_contains(manager, "looksLikeBackupFolder(deviceDirectory)", "Existing-backup preflight should require Info.plist and Manifest metadata")
+    assert_contains(manager, "backupMetadataHealth(for udid", "BackupManager should distinguish complete, missing, and incomplete backup metadata")
+    assert_contains(manager, "looksLikeBackupFolder(deviceDirectory) ? .complete : .incomplete", "Existing-backup preflight should require Info.plist and Manifest metadata")
     assert_contains(manager, "Backup needs a full backup first", "Incremental backup should fail before backend calls when metadata is missing")
     assert_contains(manager, "Run a full backup first; future Wi-Fi backups can be incremental", "Missing metadata error should be actionable")
+    assert_contains(manager, "deleteIncompleteBackup(for udid", "Recovery flow should be able to remove interrupted partial backup folders")
 
     view = read(root, "Sources/Phosphor/Views/Backup/BackupListView.swift")
     assert_contains(view, "shouldOfferIncremental(for: device)", "Backup UI should only offer incremental when a backup exists for the selected device")
     assert_contains(view, "First Wi-Fi Backup (Full)", "First Wi-Fi backup action should be full, not incremental")
     assert_contains(view, "Create Full Wi-Fi Backup", "Empty Wi-Fi backup state should default to a full backup")
+    assert_contains(view, "First backup must be full", "Backup UI should explicitly explain first-backup state")
+    assert_contains(view, "USB is recommended for the first backup", "Backup UI should recommend USB for first full backups")
+
+
+def test_backup_failures_have_recovery_actions_and_collapsed_details(root: Path) -> None:
+    manager = read(root, "Sources/Phosphor/Services/BackupManager.swift")
+    assert_contains(manager, "struct BackupFailure", "Backup failures should be structured for user-facing recovery UI")
+    assert_contains(manager, "RecoveryAction", "Backup failures should carry recommended recovery actions")
+    assert_contains(manager, "lastBackupFailure", "BackupManager should publish structured backup failures")
+    assert_contains(manager, "technicalDetails", "Raw backend details should be separated from the short user-facing message")
+
+    vm = read(root, "Sources/Phosphor/ViewModels/BackupViewModel.swift")
+    assert_contains(vm, "backupIssue", "BackupViewModel should surface structured backup issues separately from success alerts")
+    assert_contains(vm, "retryLastBackup", "BackupViewModel should support recommended retry action")
+    assert_contains(vm, "deleteIncompleteBackupAndRunFull", "BackupViewModel should implement incomplete-backup recovery")
+
+    view = read(root, "Sources/Phosphor/Views/Backup/BackupListView.swift")
+    assert_contains(view, "BackupIssueSheet", "Backup failures should use a sheet instead of dumping raw tracebacks in an alert")
+    assert_contains(view, "DisclosureGroup(\"Technical details\"", "Technical details should be collapsed by default")
+    assert_contains(view, "Delete Incomplete Backup & Run Full", "Incomplete backup failures should offer a recovery action")
+    assert_contains(view, "Open Backup Settings", "Permission/folder failures should offer a settings action")
+
+    app = read(root, "Sources/Phosphor/App/PhosphorApp.swift")
+    assert_contains(app, "preferNetwork: device.connectionType == .wifi", "Backup menu command should preserve Wi-Fi network preference")
 
 
 def test_idevicebackup2_network_argument_order_is_before_backup_subcommand(root: Path) -> None:

--- a/Scripts/regression/checks/device_backup.py
+++ b/Scripts/regression/checks/device_backup.py
@@ -21,6 +21,42 @@ def test_pymobiledevice_queries_usb_and_network_before_fallback(root: Path) -> N
     assert_contains(src, '(entry["Properties"] as? [String: Any])?["ConnectionType"] as? String', "usbmux JSON parser should inspect nested Properties.ConnectionType")
 
 
+def test_bonjour_finder_visible_devices_are_discovery_hints(root: Path) -> None:
+    src = read(root, "Sources/Phosphor/Utilities/PyMobileDevice.swift")
+    assert_contains(src, "struct BonjourDevice", "Bonjour-discovered devices should use a separate hint model")
+    assert_contains(src, '"/usr/bin/dns-sd"', "Bonjour fallback should use macOS dns-sd directly")
+    assert_contains(src, '"_apple-mobdev2._tcp"', "Bonjour fallback should browse Apple's MobileDevice service")
+    assert_contains(src, "parseBonjourBrowseOutput", "Bonjour browse output should be parsed explicitly")
+    assert_contains(src, "parseBonjourHost", "Bonjour resolve output should preserve the advertised host")
+    assert_contains(src, "not the device UDID", "Bonjour identifiers must not be treated as backup-capable UDIDs")
+
+    manager = read(root, "Sources/Phosphor/Services/DeviceManager.swift")
+    assert_contains(manager, "nearbyWirelessDevices", "DeviceManager should publish Finder-visible wireless hints")
+    assert_contains(manager, "cachedBonjourDevices", "Bonjour discovery should be cached to avoid polling dns-sd constantly")
+    assert_contains(manager, "connectedDevices = []", "Bonjour-only devices should not be mixed into backup-capable devices")
+
+    view = read(root, "Sources/Phosphor/Views/Device/DeviceOverviewView.swift")
+    assert_contains(view, "Finder-visible devices", "Empty device state should disclose devices Finder can see")
+    assert_contains(view, "cannot open a usbmux connection", "UI should explain why Finder visibility is not enough")
+
+
+def test_mobdev2_wireless_discovery_uses_real_udid_and_pymobiledevice_backup(root: Path) -> None:
+    src = read(root, "Sources/Phosphor/Utilities/PyMobileDevice.swift")
+    assert_contains(src, '["bonjour", "mobdev2", "--timeout", "3"]', "wireless discovery should query pymobiledevice3 mobdev2 with a bounded browse timeout")
+    assert_contains(src, "parseMobdev2DeviceEntries", "mobdev2 JSON should be parsed into typed device entries")
+    assert_contains(src, 'entry["UniqueDeviceID"] as? String', "mobdev2 discovery must use the real device UDID")
+    assert_contains(src, 'discoveryMethod: "mobdev2"', "mobdev2 entries should preserve their discovery method")
+    assert_contains(src, "discoveryInfo", "mobdev2 metadata should be available for the UI without slow lockdown probes")
+    assert_contains(src, 'args.append("--mobdev2")', "pymobiledevice3 Wi-Fi backups should use the mobdev2 backend")
+
+    manager = read(root, "Sources/Phosphor/Services/DeviceManager.swift")
+    assert_contains(manager, "deviceInfo(fromDiscoveryInfo:", "DeviceManager should build cards from mobdev2 metadata")
+    assert_contains(manager, "entry.discoveryInfo", "scanForDevices should pass mobdev2 metadata into fetchDeviceInfo")
+
+    backup = read(root, "Sources/Phosphor/Services/BackupManager.swift")
+    assert_contains(backup, "preferNetwork: preferNetwork", "BackupManager should thread Wi-Fi preference into pymobiledevice3 backup")
+
+
 def test_device_entry_merge_prefers_usb_without_dropping_network_only(root: Path) -> None:
     src = read(root, "Sources/Phosphor/Utilities/PyMobileDevice.swift")
     merge = re.search(r"private static func mergeDeviceEntries\(_ entries: \[DeviceEntry\]\).*?\n    \}", src, re.S)

--- a/Scripts/regression/checks/device_backup.py
+++ b/Scripts/regression/checks/device_backup.py
@@ -85,11 +85,21 @@ def test_wifi_schedules_use_network_discovery_and_network_backup_flag(root: Path
     assert_contains(scheduler, "createBackup(udid: udid, preferNetwork: preferNetwork)", "scheduled full backups should preserve network preference")
     assert_contains(scheduler, "schedule.incrementalOnly && BackupManager.hasExistingBackup(for: udid)", "Scheduled incremental mode should run the required first full backup when metadata is missing")
     assert_contains(scheduler, "running required first full backup", "Scheduled first-full fallback should be logged clearly")
+    assert_contains(scheduler, "able to notice a schedule that is enabled after launch", "App-level scheduler should keep monitoring so schedules enabled after launch can run")
+    assert_contains(scheduler, "if schedule.nextRunDate == nil { updateNextRunDate() }", "Scheduler should initialize next run when a separate UI instance enables the schedule")
+    assert_contains(scheduler, "func runNow() async {\n        guard !isRunningScheduledBackup else { return }\n        isRunningScheduledBackup = true", "Run Now should set the running guard before async device discovery")
 
     view = read(root, "Sources/Phosphor/Views/Backup/BackupListView.swift")
     assert_contains(view, "Wi-Fi only (skip if Wi-Fi is not available)", "Wi-Fi-only schedule copy should not say USB is required")
     assert_contains(view, "Incremental when possible (faster)", "Schedule copy should not promise incremental-only behavior when first run may be full")
     assert_contains(view, "first scheduled run will create the required full backup", "Schedule UI should explain first-run behavior for incremental mode")
+    assert_not_contains(view, "scheduler.startMonitoring()", "Schedule sheets should not start duplicate schedulers separate from the app-level monitor")
+    assert_contains(view, ".onChange(of: scheduler.schedule.preferredHour)", "Schedule sheet should refresh next-run timing when preferred time changes")
+
+    settings = read(root, "Sources/Phosphor/Views/Settings/SettingsView.swift")
+    assert_contains(settings, "Wi-Fi only (skip if Wi-Fi is not available)", "Settings schedule copy should match the safer schedule sheet copy")
+    assert_contains(settings, "Incremental when possible (faster)", "Settings should not promise incremental-only behavior when first run may be full")
+    assert_contains(settings, ".onChange(of: scheduler.schedule.preferredHour)", "Settings should refresh next-run timing when preferred time changes")
 
 
 def test_incremental_backups_require_existing_metadata(root: Path) -> None:
@@ -138,6 +148,7 @@ def test_backup_failures_have_recovery_actions_and_collapsed_details(root: Path)
     assert_contains(view, "handleBackupIssueAction(_ issue", "Backup recovery actions should receive the full failed issue context")
     assert_contains(view, "Move Incomplete Backup to Trash?", "Destructive incomplete-backup recovery should require explicit confirmation")
     assert_contains(view, "incompleteBackupTrashConfirmationMessage", "Incomplete-backup confirmation should show the exact path before moving it")
+    assert_contains(view, "pendingIncompleteBackupIssue = issue\n            backupVM.backupIssue = nil\n            showIncompleteBackupTrashConfirm = true", "Incomplete-backup confirmation should dismiss the issue sheet before presenting the destructive confirmation")
     assert_contains(view, "DisclosureGroup(\"Technical details\"", "Technical details should be collapsed by default")
     assert_contains(view, "Delete Incomplete Backup & Run Full", "Incomplete backup failures should offer a recovery action")
     assert_contains(view, "Open Backup Settings", "Permission/folder failures should offer a settings action")
@@ -154,3 +165,15 @@ def test_idevicebackup2_network_argument_order_is_before_backup_subcommand(root:
     assert_contains(body, 'var args = ["-u", udid]', "idevicebackup2 should start with the target UDID")
     assert body.index('if preferNetwork { args.append("-n") }') < body.index('args.append("backup")'), "idevicebackup2 -n must come before backup subcommand"
     assert body.index('args.append("backup")') < body.index('if full { args.append("--full") }'), "backup subcommand should come before --full"
+
+
+def test_phosphor_archive_import_uses_active_dir_and_rejects_unsafe_archives(root: Path) -> None:
+    archiver = read(root, "Sources/Phosphor/Services/BackupArchiver.swift")
+    assert_contains(archiver, "MainActor.run { BackupManager.activeBackupDir }", "Archive import should use Phosphor's active backup directory, not Apple's protected MobileSync default")
+    assert_contains(archiver, "archiveEntryIsSafe", "Archive import should validate tar entries before extraction")
+    assert_contains(archiver, "guard !entry.hasPrefix(\"/\")", "Archive import should reject absolute tar paths")
+    assert_contains(archiver, "!components.contains(\"..\")", "Archive import should reject parent-directory traversal entries")
+    assert_contains(archiver, "topLevelEntries(in: entries).intersection(existingDirs)", "Archive import should not overwrite an existing backup directory")
+    assert_contains(archiver, "looksLikeBackupFolder(itemPath)", "Archive import should only report complete backup folders as imported")
+    assert_contains(archiver, "moveImportedEntriesToTrash", "Failed archive imports should clean up newly extracted entries")
+    assert_contains(archiver, "archive did not contain a complete iOS backup", "Invalid safe archives should fail with a clear reason")

--- a/Scripts/regression/checks/device_backup.py
+++ b/Scripts/regression/checks/device_backup.py
@@ -12,6 +12,10 @@ def assert_contains(text: str, needle: str, message: str) -> None:
     assert needle in text, message
 
 
+def assert_not_contains(text: str, needle: str, message: str) -> None:
+    assert needle not in text, message
+
+
 def test_pymobiledevice_queries_usb_and_network_before_fallback(root: Path) -> None:
     src = read(root, "Sources/Phosphor/Utilities/PyMobileDevice.swift")
     assert_contains(src, 'runAsync(["usbmux", "list", "--usb"]', "device discovery must explicitly query USB devices")
@@ -40,18 +44,19 @@ def test_bonjour_finder_visible_devices_are_discovery_hints(root: Path) -> None:
     assert_contains(view, "cannot open a usbmux connection", "UI should explain why Finder visibility is not enough")
 
 
-def test_mobdev2_wireless_discovery_uses_real_udid_and_pymobiledevice_backup(root: Path) -> None:
+def test_mobdev2_wireless_discovery_is_a_non_backup_hint(root: Path) -> None:
     src = read(root, "Sources/Phosphor/Utilities/PyMobileDevice.swift")
     assert_contains(src, '["bonjour", "mobdev2", "--timeout", "3"]', "wireless discovery should query pymobiledevice3 mobdev2 with a bounded browse timeout")
     assert_contains(src, "parseMobdev2DeviceEntries", "mobdev2 JSON should be parsed into typed device entries")
     assert_contains(src, 'entry["UniqueDeviceID"] as? String', "mobdev2 discovery must use the real device UDID")
     assert_contains(src, 'discoveryMethod: "mobdev2"', "mobdev2 entries should preserve their discovery method")
-    assert_contains(src, "discoveryInfo", "mobdev2 metadata should be available for the UI without slow lockdown probes")
-    assert_contains(src, 'args.append("--mobdev2")', "pymobiledevice3 Wi-Fi backups should use the mobdev2 backend")
+    assert_contains(src, "mobdev2Devices.map", "mobdev2 metadata should feed Finder-visible nearby-device hints")
+    assert_contains(src, "still a discovery hint", "mobdev2 devices should not be treated as backup-capable targets")
+    assert_not_contains(src, 'args.append("--mobdev2")', "pymobiledevice3 backup must not invoke interactive mobdev2 in a non-TTY app")
 
     manager = read(root, "Sources/Phosphor/Services/DeviceManager.swift")
-    assert_contains(manager, "deviceInfo(fromDiscoveryInfo:", "DeviceManager should build cards from mobdev2 metadata")
-    assert_contains(manager, "entry.discoveryInfo", "scanForDevices should pass mobdev2 metadata into fetchDeviceInfo")
+    assert_contains(manager, "cachedBonjourDevices", "DeviceManager should show mobdev2/Finder-visible devices as nearby hints")
+    assert_contains(manager, "connectedDevices = []", "mobdev2-only devices should not be mixed into backup-capable devices")
 
     backup = read(root, "Sources/Phosphor/Services/BackupManager.swift")
     assert_contains(backup, "preferNetwork: preferNetwork", "BackupManager should thread Wi-Fi preference into pymobiledevice3 backup")

--- a/Scripts/regression/checks/device_backup.py
+++ b/Scripts/regression/checks/device_backup.py
@@ -86,11 +86,17 @@ def test_wifi_schedules_use_network_discovery_and_network_backup_flag(root: Path
     assert_contains(scheduler, "schedule.incrementalOnly && BackupManager.hasExistingBackup(for: udid)", "Scheduled incremental mode should run the required first full backup when metadata is missing")
     assert_contains(scheduler, "running required first full backup", "Scheduled first-full fallback should be logged clearly")
 
+    view = read(root, "Sources/Phosphor/Views/Backup/BackupListView.swift")
+    assert_contains(view, "Wi-Fi only (skip if Wi-Fi is not available)", "Wi-Fi-only schedule copy should not say USB is required")
+    assert_contains(view, "first scheduled run will create the required full backup", "Schedule UI should explain first-run behavior for incremental mode")
+
 
 def test_incremental_backups_require_existing_metadata(root: Path) -> None:
     manager = read(root, "Sources/Phosphor/Services/BackupManager.swift")
     assert_contains(manager, "hasExistingBackup(for udid", "BackupManager should expose an existing-backup metadata preflight")
     assert_contains(manager, "backupMetadataHealth(for udid", "BackupManager should distinguish complete, missing, and incomplete backup metadata")
+    assert_contains(manager, "if Self.looksLikeBackupFolder(dir)", "Single-backup discovery should exclude Info.plist-only incomplete folders")
+    assert_contains(manager, "guard Self.looksLikeBackupFolder(fullPath) else { continue }", "Backup discovery should exclude incomplete child backup folders")
     assert_contains(manager, "looksLikeBackupFolder(deviceDirectory) ? .complete : .incomplete", "Existing-backup preflight should require Info.plist and Manifest metadata")
     assert_contains(manager, "Backup needs a full backup first", "Incremental backup should fail before backend calls when metadata is missing")
     assert_contains(manager, "Run a full backup first; future Wi-Fi backups can be incremental", "Missing metadata error should be actionable")
@@ -98,6 +104,7 @@ def test_incremental_backups_require_existing_metadata(root: Path) -> None:
 
     view = read(root, "Sources/Phosphor/Views/Backup/BackupListView.swift")
     assert_contains(view, "shouldOfferIncremental(for: device)", "Backup UI should only offer incremental when a backup exists for the selected device")
+    assert_contains(view, "BackupManager.hasExistingBackup(for: device.id) && backupVM.backups.contains", "Backup UI should require complete metadata before offering incremental")
     assert_contains(view, "First Wi-Fi Backup (Full)", "First Wi-Fi backup action should be full, not incremental")
     assert_contains(view, "Create Full Wi-Fi Backup", "Empty Wi-Fi backup state should default to a full backup")
     assert_contains(view, "First backup must be full", "Backup UI should explicitly explain first-backup state")
@@ -115,6 +122,9 @@ def test_backup_failures_have_recovery_actions_and_collapsed_details(root: Path)
     assert_contains(vm, "backupIssue", "BackupViewModel should surface structured backup issues separately from success alerts")
     assert_contains(vm, "retryLastBackup", "BackupViewModel should support recommended retry action")
     assert_contains(vm, "deleteIncompleteBackupAndRunFull", "BackupViewModel should implement incomplete-backup recovery")
+    assert_contains(vm, "private func clearBrowserState()", "BackupViewModel should clear stale browser state before opening another backup")
+    assert_contains(vm, "selectedBackup = nil", "Failed backup browser opens should not leave stale selected backup state visible")
+    assert_contains(vm, "browserDomains = []", "Failed backup browser opens should not leave stale domains visible")
 
     view = read(root, "Sources/Phosphor/Views/Backup/BackupListView.swift")
     assert_contains(view, "BackupIssueSheet", "Backup failures should use a sheet instead of dumping raw tracebacks in an alert")

--- a/Scripts/regression/checks/device_backup.py
+++ b/Scripts/regression/checks/device_backup.py
@@ -88,6 +88,7 @@ def test_wifi_schedules_use_network_discovery_and_network_backup_flag(root: Path
 
     view = read(root, "Sources/Phosphor/Views/Backup/BackupListView.swift")
     assert_contains(view, "Wi-Fi only (skip if Wi-Fi is not available)", "Wi-Fi-only schedule copy should not say USB is required")
+    assert_contains(view, "Incremental when possible (faster)", "Schedule copy should not promise incremental-only behavior when first run may be full")
     assert_contains(view, "first scheduled run will create the required full backup", "Schedule UI should explain first-run behavior for incremental mode")
 
 
@@ -101,6 +102,10 @@ def test_incremental_backups_require_existing_metadata(root: Path) -> None:
     assert_contains(manager, "Backup needs a full backup first", "Incremental backup should fail before backend calls when metadata is missing")
     assert_contains(manager, "Run a full backup first; future Wi-Fi backups can be incremental", "Missing metadata error should be actionable")
     assert_contains(manager, "deleteIncompleteBackup(for udid", "Recovery flow should be able to remove interrupted partial backup folders")
+    assert_contains(manager, "expectedPath", "Incomplete-backup recovery should validate the exact failed path before moving anything")
+    assert_contains(manager, "incompleteBackupHasKnownMarkers", "Incomplete-backup recovery should require recognizable iOS backup markers before moving a folder")
+    assert_contains(manager, "trashItem", "Incomplete-backup recovery should move folders to Trash instead of permanently deleting them")
+    assert_not_contains(manager, "removeItem(atPath: path)", "Incomplete-backup recovery should not permanently delete backup folders")
 
     view = read(root, "Sources/Phosphor/Views/Backup/BackupListView.swift")
     assert_contains(view, "shouldOfferIncremental(for: device)", "Backup UI should only offer incremental when a backup exists for the selected device")
@@ -122,12 +127,17 @@ def test_backup_failures_have_recovery_actions_and_collapsed_details(root: Path)
     assert_contains(vm, "backupIssue", "BackupViewModel should surface structured backup issues separately from success alerts")
     assert_contains(vm, "retryLastBackup", "BackupViewModel should support recommended retry action")
     assert_contains(vm, "deleteIncompleteBackupAndRunFull", "BackupViewModel should implement incomplete-backup recovery")
+    assert_contains(vm, "runFullBackup(for issue", "Recovery actions should use the failed issue context, not the currently selected device")
+    assert_contains(vm, "expectedPath: path", "Recovery deletion should use the exact path from the failed issue")
     assert_contains(vm, "private func clearBrowserState()", "BackupViewModel should clear stale browser state before opening another backup")
     assert_contains(vm, "selectedBackup = nil", "Failed backup browser opens should not leave stale selected backup state visible")
     assert_contains(vm, "browserDomains = []", "Failed backup browser opens should not leave stale domains visible")
 
     view = read(root, "Sources/Phosphor/Views/Backup/BackupListView.swift")
     assert_contains(view, "BackupIssueSheet", "Backup failures should use a sheet instead of dumping raw tracebacks in an alert")
+    assert_contains(view, "handleBackupIssueAction(_ issue", "Backup recovery actions should receive the full failed issue context")
+    assert_contains(view, "Move Incomplete Backup to Trash?", "Destructive incomplete-backup recovery should require explicit confirmation")
+    assert_contains(view, "incompleteBackupTrashConfirmationMessage", "Incomplete-backup confirmation should show the exact path before moving it")
     assert_contains(view, "DisclosureGroup(\"Technical details\"", "Technical details should be collapsed by default")
     assert_contains(view, "Delete Incomplete Backup & Run Full", "Incomplete backup failures should offer a recovery action")
     assert_contains(view, "Open Backup Settings", "Permission/folder failures should offer a settings action")

--- a/Scripts/regression/checks/device_backup.py
+++ b/Scripts/regression/checks/device_backup.py
@@ -155,6 +155,8 @@ def test_backup_failures_have_recovery_actions_and_collapsed_details(root: Path)
 
     app = read(root, "Sources/Phosphor/App/PhosphorApp.swift")
     assert_contains(app, "preferNetwork: device.connectionType == .wifi", "Backup menu command should preserve Wi-Fi network preference")
+    assert_contains(app, "confirmFirstFullWiFiBackup", "Backup menu command should use the same first full Wi-Fi safety confirmation")
+    assert_contains(app, "device.connectionType == .wifi && !BackupManager.hasExistingBackup", "Wi-Fi menu backups without metadata should be confirmed before starting")
 
 
 def test_idevicebackup2_network_argument_order_is_before_backup_subcommand(root: Path) -> None:
@@ -177,3 +179,52 @@ def test_phosphor_archive_import_uses_active_dir_and_rejects_unsafe_archives(roo
     assert_contains(archiver, "looksLikeBackupFolder(itemPath)", "Archive import should only report complete backup folders as imported")
     assert_contains(archiver, "moveImportedEntriesToTrash", "Failed archive imports should clean up newly extracted entries")
     assert_contains(archiver, "archive did not contain a complete iOS backup", "Invalid safe archives should fail with a clear reason")
+
+
+def test_sidebar_device_rows_select_the_clicked_device(root: Path) -> None:
+    sidebar = read(root, "Sources/Phosphor/Views/SidebarView.swift")
+    assert_contains(sidebar, "sidebarButton(.devices, onSelect: { deviceVM.selectDevice(device) })", "Each sidebar device row should select its own device, not the first device")
+    assert_not_contains(sidebar, "selectDevice(first)", "Generic device sidebar action must not always select the first device")
+
+
+def test_backup_selection_and_browser_navigation_stay_in_sync(root: Path) -> None:
+    vm = read(root, "Sources/Phosphor/ViewModels/BackupViewModel.swift")
+    assert_contains(vm, "reconcileSelectedBackupAfterReload", "Reloading backups should reconcile stale selected backup state")
+    assert_contains(vm, "backups.contains(where: { $0.id == selectedBackup.id && $0.path == selectedBackup.path })", "Selected backup should remain valid only if the same backup path is still present")
+    assert_contains(vm, "@discardableResult\n    func openBackupBrowser(_ backup: BackupInfo) -> Bool", "Opening a backup should report success so views can navigate only after manifest load")
+
+    content = read(root, "Sources/Phosphor/Views/ContentView.swift")
+    assert_contains(content, "BackupListView(onBrowseBackup: { selectedSection = .backupBrowser })", "Backup list Browse should navigate to Backup Browser after a successful open")
+    assert_contains(content, "BackupTimeMachineView(onBrowseBackup: { selectedSection = .backupBrowser })", "Time Machine Browse should navigate to Backup Browser after a successful open")
+
+    browser = read(root, "Sources/Phosphor/Views/Backup/BackupBrowserView.swift")
+    assert_contains(browser, ".onChange(of: backupVM.selectedBackup?.id)", "Backup browser should clear local selections when the selected backup changes")
+    assert_contains(browser, "selectedFiles.removeAll()", "Backup browser should drop selected file state when backup/domain changes")
+
+
+def test_file_browser_delete_requires_confirmation_and_blocks_directories(root: Path) -> None:
+    view = read(root, "Sources/Phosphor/Views/Files/FileBrowserView.swift")
+    assert_contains(view, "pendingDeleteFile", "File browser delete should stage a pending file before confirmation")
+    assert_contains(view, ".alert(\"Delete File?\"", "File browser delete should require a confirmation alert")
+    assert_contains(view, "if !entry.isDirectory", "File browser should not expose directory deletion in the context menu")
+    assert_not_contains(view, "Task { try? await fileManager.deleteFile(entry) }", "File browser context menu must not delete immediately")
+
+    manager = read(root, "Sources/Phosphor/Services/FileTransferManager.swift")
+    assert_contains(manager, "guard !entry.isDirectory", "FileTransferManager should reject directory deletion at the service layer")
+    assert_contains(manager, "Directory deletion is not supported", "Directory deletion rejection should be explicit")
+
+
+def test_backup_extract_preserves_domain_relative_paths(root: Path) -> None:
+    manager = read(root, "Sources/Phosphor/Services/BackupManager.swift")
+    assert_contains(manager, "private func extractionDestination(for entry", "Backup extraction should centralize safe destination path construction")
+    assert_contains(manager, "appendingPathComponent(safeDomain)", "Backup extraction should group files by domain to avoid basename collisions")
+    assert_contains(manager, "entry.relativePath", "Backup extraction should preserve manifest relative paths instead of flattening to fileName")
+    assert_not_contains(manager, "appendingPathComponent(entry.fileName)\n            do {", "Backup extraction should not flatten every selected file to destination/fileName")
+
+
+def test_live_photo_exports_use_path_based_names(root: Path) -> None:
+    live = read(root, "Sources/Phosphor/Services/LiveDeviceBrowser.swift")
+    assert_contains(live, "private func uniqueLocalName(for photo", "Live photo export should centralize duplicate-safe local naming")
+    assert_contains(live, "photo.path", "Live photo export naming should use the full device path, not only the basename")
+    assert_contains(live, "replacingOccurrences(of: \"/\", with: \"_\")", "Live photo export should preserve DCIM folder identity in local filenames")
+    assert_contains(live, "appendingPathComponent(uniqueLocalName(for: photo))", "Live photo temp cache and export should use duplicate-safe names")

--- a/Scripts/regression/checks/device_backup.py
+++ b/Scripts/regression/checks/device_backup.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+
+def read(root: Path, rel: str) -> str:
+    return (root / rel).read_text()
+
+
+def assert_contains(text: str, needle: str, message: str) -> None:
+    assert needle in text, message
+
+
+def test_pymobiledevice_queries_usb_and_network_before_fallback(root: Path) -> None:
+    src = read(root, "Sources/Phosphor/Utilities/PyMobileDevice.swift")
+    assert_contains(src, 'runAsync(["usbmux", "list", "--usb"]', "device discovery must explicitly query USB devices")
+    assert_contains(src, 'runAsync(["usbmux", "list", "--network"]', "device discovery must explicitly query network devices")
+    assert_contains(src, 'runAsync(["usbmux", "list"])', "device discovery should retain default usbmux fallback")
+    assert_contains(src, 'entry["ConnectionType"] as? String', "usbmux JSON parser should inspect top-level ConnectionType")
+    assert_contains(src, '(entry["Properties"] as? [String: Any])?["ConnectionType"] as? String', "usbmux JSON parser should inspect nested Properties.ConnectionType")
+
+
+def test_device_entry_merge_prefers_usb_without_dropping_network_only(root: Path) -> None:
+    src = read(root, "Sources/Phosphor/Utilities/PyMobileDevice.swift")
+    merge = re.search(r"private static func mergeDeviceEntries\(_ entries: \[DeviceEntry\]\).*?\n    \}", src, re.S)
+    assert merge is not None, "PyMobileDevice.mergeDeviceEntries should exist"
+    body = merge.group(0)
+    assert_contains(body, "orderedUdids", "merge should preserve stable discovery order")
+    assert_contains(body, 'connectionType != "USB" || entry.connectionType == "USB"', "merge should prefer USB when both transports are visible")
+
+    manager = read(root, "Sources/Phosphor/Services/DeviceManager.swift")
+    assert_contains(manager, "deviceInfoCache.removeAll()", "zero-device scans should clear stale device cache")
+    assert_contains(manager, "networkDeviceCache = nil", "zero-device scans should clear stale network-device cache")
+
+
+def test_wifi_schedules_use_network_discovery_and_network_backup_flag(root: Path) -> None:
+    scheduler = read(root, "Sources/Phosphor/Services/BackupScheduler.swift")
+    assert_contains(scheduler, "pyEntries.filter { $0.connectionType != \"USB\" }", "Wi-Fi-only schedules should filter out USB pymobiledevice entries")
+    assert_contains(scheduler, "PyMobileDevice.listNetworkDevices()", "Wi-Fi-only schedules should probe network devices explicitly")
+    assert_contains(scheduler, 'let fallbackArgs = schedule.wifiOnly ? ["-n"] : ["-l"]', "Wi-Fi-only fallback should use idevice_id -n")
+    assert_contains(scheduler, "createIncrementalBackup(udid: udid, preferNetwork: preferNetwork)", "scheduled incremental backups should preserve network preference")
+    assert_contains(scheduler, "createBackup(udid: udid, preferNetwork: preferNetwork)", "scheduled full backups should preserve network preference")
+
+
+def test_idevicebackup2_network_argument_order_is_before_backup_subcommand(root: Path) -> None:
+    manager = read(root, "Sources/Phosphor/Services/BackupManager.swift")
+    match = re.search(r"private func idevicebackupArguments\(.*?\) -> \[String\] \{(?P<body>.*?)\n    \}", manager, re.S)
+    assert match is not None, "idevicebackupArguments should centralize fallback argument order"
+    body = match.group("body")
+    assert_contains(body, 'var args = ["-u", udid]', "idevicebackup2 should start with the target UDID")
+    assert body.index('if preferNetwork { args.append("-n") }') < body.index('args.append("backup")'), "idevicebackup2 -n must come before backup subcommand"
+    assert body.index('args.append("backup")') < body.index('if full { args.append("--full") }'), "backup subcommand should come before --full"

--- a/Scripts/regression/checks/device_backup.py
+++ b/Scripts/regression/checks/device_backup.py
@@ -84,6 +84,19 @@ def test_wifi_schedules_use_network_discovery_and_network_backup_flag(root: Path
     assert_contains(scheduler, "createBackup(udid: udid, preferNetwork: preferNetwork)", "scheduled full backups should preserve network preference")
 
 
+def test_incremental_backups_require_existing_metadata(root: Path) -> None:
+    manager = read(root, "Sources/Phosphor/Services/BackupManager.swift")
+    assert_contains(manager, "hasExistingBackup(for udid", "BackupManager should expose an existing-backup metadata preflight")
+    assert_contains(manager, "looksLikeBackupFolder(deviceDirectory)", "Existing-backup preflight should require Info.plist and Manifest metadata")
+    assert_contains(manager, "Backup needs a full backup first", "Incremental backup should fail before backend calls when metadata is missing")
+    assert_contains(manager, "Run a full backup first; future Wi-Fi backups can be incremental", "Missing metadata error should be actionable")
+
+    view = read(root, "Sources/Phosphor/Views/Backup/BackupListView.swift")
+    assert_contains(view, "shouldOfferIncremental(for: device)", "Backup UI should only offer incremental when a backup exists for the selected device")
+    assert_contains(view, "First Wi-Fi Backup (Full)", "First Wi-Fi backup action should be full, not incremental")
+    assert_contains(view, "Create Full Wi-Fi Backup", "Empty Wi-Fi backup state should default to a full backup")
+
+
 def test_idevicebackup2_network_argument_order_is_before_backup_subcommand(root: Path) -> None:
     manager = read(root, "Sources/Phosphor/Services/BackupManager.swift")
     match = re.search(r"private func idevicebackupArguments\(.*?\) -> \[String\] \{(?P<body>.*?)\n    \}", manager, re.S)

--- a/Scripts/regression/checks/device_backup.py
+++ b/Scripts/regression/checks/device_backup.py
@@ -109,6 +109,7 @@ def test_incremental_backups_require_existing_metadata(root: Path) -> None:
     assert_contains(manager, "if Self.looksLikeBackupFolder(dir)", "Single-backup discovery should exclude Info.plist-only incomplete folders")
     assert_contains(manager, "guard Self.looksLikeBackupFolder(fullPath) else { continue }", "Backup discovery should exclude incomplete child backup folders")
     assert_contains(manager, "looksLikeBackupFolder(deviceDirectory) ? .complete : .incomplete", "Existing-backup preflight should require Info.plist and Manifest metadata")
+    assert_contains(manager, "isNonEmptyFile(info)", "Completeness must require non-empty metadata; zero-length Info.plist stubs are an interrupted backup, not a complete one")
     assert_contains(manager, "Backup needs a full backup first", "Incremental backup should fail before backend calls when metadata is missing")
     assert_contains(manager, "Run a full backup first; future Wi-Fi backups can be incremental", "Missing metadata error should be actionable")
     assert_contains(manager, "deleteIncompleteBackup(for udid", "Recovery flow should be able to remove interrupted partial backup folders")
@@ -176,6 +177,9 @@ def test_phosphor_archive_import_uses_active_dir_and_rejects_unsafe_archives(roo
     assert_contains(archiver, "guard !entry.hasPrefix(\"/\")", "Archive import should reject absolute tar paths")
     assert_contains(archiver, "!components.contains(\"..\")", "Archive import should reject parent-directory traversal entries")
     assert_contains(archiver, "topLevelEntries(in: entries).intersection(existingDirs)", "Archive import should not overwrite an existing backup directory")
+    assert_contains(archiver, "normalizedEntryPath", "Archive import must normalize leading ./ so overwrite detection is not bypassable")
+    assert_contains(archiver, 'subtracting(["."])', "Top-level entry set must drop the current-directory token so ./ entries map to their real directory")
+    assert_contains(archiver, "isNonEmptyFile(info)", "Archive import completeness must require a non-empty Info.plist, not just its presence")
     assert_contains(archiver, "looksLikeBackupFolder(itemPath)", "Archive import should only report complete backup folders as imported")
     assert_contains(archiver, "moveImportedEntriesToTrash", "Failed archive imports should clean up newly extracted entries")
     assert_contains(archiver, "archive did not contain a complete iOS backup", "Invalid safe archives should fail with a clear reason")
@@ -219,6 +223,8 @@ def test_backup_extract_preserves_domain_relative_paths(root: Path) -> None:
     assert_contains(manager, "private func extractionDestination(for entry", "Backup extraction should centralize safe destination path construction")
     assert_contains(manager, "appendingPathComponent(safeDomain)", "Backup extraction should group files by domain to avoid basename collisions")
     assert_contains(manager, "entry.relativePath", "Backup extraction should preserve manifest relative paths instead of flattening to fileName")
+    assert_contains(manager, 'safeDomain == "." || safeDomain == ".."', "Selective extraction must neutralize traversal domains so a crafted manifest row cannot escape the destination")
+    assert_contains(manager, "Refusing to extract", "Selective extraction should refuse to write outside the destination folder")
     assert_not_contains(manager, "appendingPathComponent(entry.fileName)\n            do {", "Backup extraction should not flatten every selected file to destination/fileName")
 
 

--- a/Scripts/regression/checks/message_export.py
+++ b/Scripts/regression/checks/message_export.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+import json
+import re
+import sqlite3
+import tempfile
+from pathlib import Path
+
+
+def read(root: Path, rel: str) -> str:
+    return (root / rel).read_text()
+
+
+def assert_contains(text: str, needle: str, message: str) -> None:
+    assert needle in text, message
+
+
+def test_streaming_exports_truncate_before_write(root: Path) -> None:
+    src = read(root, "Sources/Phosphor/Services/MessageExporter.swift")
+    for func_name in ["exportCSV", "exportPlainText", "exportHTML", "exportMbox", "exportJSON"]:
+        match = re.search(rf"private func {func_name}.*?(?=\n    private func|\n    ///|\Z)", src, re.S)
+        assert match is not None, f"{func_name} not found"
+        body = match.group(0)
+        assert_contains(body, "removeItem(at: outputURL)", f"{func_name} must remove existing output before streaming")
+        assert_contains(body, "FileHandle(forWritingTo: outputURL)", f"{func_name} must stream through FileHandle")
+
+
+def test_json_overwrite_fixture_has_no_stale_tail(root: Path) -> None:
+    del root  # fixture mirrors the Swift export invariant without touching source files.
+    with tempfile.TemporaryDirectory() as tmp:
+        path = Path(tmp) / "export.json"
+        long_payload = {"messages": [{"text": "x" * 10_000}]}
+        short_payload = {"messages": []}
+        path.write_text(json.dumps(long_payload), encoding="utf-8")
+        path.unlink(missing_ok=True)
+        with path.open("w", encoding="utf-8") as handle:
+            handle.write(json.dumps(short_payload))
+        assert json.loads(path.read_text(encoding="utf-8")) == short_payload
+
+
+def test_attachment_path_cache_invariants(root: Path) -> None:
+    src = read(root, "Sources/Phosphor/Services/MessageExporter.swift")
+    assert_contains(src, "attachmentDiskPathCache", "attachment path cache should exist")
+    assert_contains(src, "missingAttachmentDiskPaths", "missing attachment cache should exist")
+    assert_contains(src, "if let cached = attachmentDiskPathCache[filename]", "resolver should hit positive cache")
+    assert_contains(src, "missingAttachmentDiskPaths.contains(filename)", "resolver should hit negative cache")
+    assert_contains(src, "attachmentDiskPathCache[filename] = candidate", "resolver should store positive cache")
+    assert_contains(src, "missingAttachmentDiskPaths.insert(filename)", "resolver should store negative cache")
+
+
+def test_minimal_sms_schema_fixture_supports_limited_attachment_query(root: Path) -> None:
+    del root
+    with tempfile.TemporaryDirectory() as tmp:
+        db_path = Path(tmp) / "sms.db"
+        con = sqlite3.connect(db_path)
+        con.executescript(
+            """
+            CREATE TABLE attachment (ROWID INTEGER PRIMARY KEY, guid TEXT, filename TEXT, mime_type TEXT, transfer_name TEXT, total_bytes INTEGER);
+            CREATE TABLE message_attachment_join (message_id INTEGER, attachment_id INTEGER);
+            INSERT INTO attachment VALUES (1,'a','~/Library/SMS/Attachments/a.jpg','image/jpeg','a.jpg',10);
+            INSERT INTO attachment VALUES (2,'b','~/Library/SMS/Attachments/b.jpg','image/jpeg','b.jpg',20);
+            INSERT INTO message_attachment_join VALUES (100,1);
+            INSERT INTO message_attachment_join VALUES (200,2);
+            """
+        )
+        rows = con.execute(
+            """
+            SELECT maj.message_id, a.ROWID, a.guid, a.filename, a.mime_type, a.transfer_name, a.total_bytes
+            FROM attachment a JOIN message_attachment_join maj ON maj.attachment_id = a.ROWID
+            WHERE maj.message_id IN (?)
+            """,
+            (100,),
+        ).fetchall()
+        con.close()
+        assert len(rows) == 1 and rows[0][0] == 100, "limited attachment query should only load requested message IDs"
+
+
+def test_message_exporter_caches_schema_and_preserves_tapback_context(root: Path) -> None:
+    src = read(root, "Sources/Phosphor/Services/MessageExporter.swift")
+    assert_contains(src, "private let messageColumns", "message table columns should be cached per exporter")
+    assert_contains(src, "private func foldRows", "reaction/tapback folding should be centralized")
+    assert_contains(src, "reactionEventsByTarget", "tapback rows must be folded with their target messages")
+    assert_contains(src, "associated_message_type", "tapback detection should use associated_message_type when present")

--- a/Scripts/regression/checks/message_export.py
+++ b/Scripts/regression/checks/message_export.py
@@ -25,6 +25,24 @@ def test_streaming_exports_truncate_before_write(root: Path) -> None:
         assert_contains(body, "FileHandle(forWritingTo: outputURL)", f"{func_name} must stream through FileHandle")
 
 
+
+
+
+def test_bulk_message_exports_use_collision_safe_filenames(root: Path) -> None:
+    src = read(root, "Sources/Phosphor/Services/MessageExporter.swift")
+    assert_contains(src, "private func exportFilename(for chat", "Bulk message export should centralize filename generation")
+    assert_contains(src, "-chat-\\(chat.id)", "Bulk message export filenames should include chat id to avoid duplicate-title overwrites")
+    export_all = re.search(r"func exportAllChats\(.*?\) throws -> Int \{(?P<body>.*?)\n    \}", src, re.S)
+    assert export_all is not None, "exportAllChats should exist"
+    assert_contains(export_all.group("body"), "exportFilename(for: chat", "exportAllChats should use collision-safe filenames")
+
+
+def test_html_export_cleans_stale_attachment_folder(root: Path) -> None:
+    src = read(root, "Sources/Phosphor/Services/MessageExporter.swift")
+    assert_contains(src, "private func removeAttachmentFolder(forHTMLPath", "HTML export should have explicit stale attachment cleanup")
+    html = re.search(r"private func exportHTML\(.*?\) throws \{(?P<body>.*?)\n    \}", src, re.S)
+    assert html is not None, "exportHTML should exist"
+    assert_contains(html.group("body"), "removeAttachmentFolder(forHTMLPath: path)", "HTML export should remove stale attachment folders before staging/writing")
 def test_json_overwrite_fixture_has_no_stale_tail(root: Path) -> None:
     del root  # fixture mirrors the Swift export invariant without touching source files.
     with tempfile.TemporaryDirectory() as tmp:

--- a/Scripts/regression/checks/shell_safety.py
+++ b/Scripts/regression/checks/shell_safety.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def read(root: Path, rel: str) -> str:
+    return (root / rel).read_text()
+
+
+def swift_block_after(text: str, signature: str) -> str:
+    start = text.index(signature)
+    brace = text.index("{", start)
+    depth = 0
+    for index in range(brace, len(text)):
+        char = text[index]
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return text[start:index + 1]
+    raise AssertionError(f"unterminated Swift block after {signature}")
+
+
+def test_shell_run_does_not_block_global_dispatch_workers(root: Path) -> None:
+    src = read(root, "Sources/Phosphor/Utilities/Shell.swift")
+    body = swift_block_after(src, "static func run(_ command: String")
+    assert "process.terminationHandler" in body, "Shell.run should wait via Process.terminationHandler"
+    assert "SIGKILL" in body, "Shell.run should force-kill commands that ignore graceful timeout termination"
+    assert "waitUntilExit()" not in body, "Shell.run must not burn a global dispatch worker in waitUntilExit()"
+    assert "DispatchQueue.global" not in body, "Shell.run must not allocate a global queue worker per process"
+
+
+def test_shell_run_async_does_not_block_global_dispatch_workers(root: Path) -> None:
+    src = read(root, "Sources/Phosphor/Utilities/Shell.swift")
+    body = swift_block_after(src, "static func runAsync(_ command: String")
+    assert "process.terminationHandler" in body, "Shell.runAsync should wait via Process.terminationHandler"
+    assert "readabilityHandler" in body, "Shell.runAsync should collect pipe output without blocking reader workers"
+    assert "SIGKILL" in body, "Shell.runAsync should force-kill commands that ignore graceful timeout termination"
+    assert "waitUntilExit()" not in body, "Shell.runAsync must not block a worker in waitUntilExit()"
+    assert "DispatchQueue.global" not in body, "Shell.runAsync must not allocate a global queue worker per process"
+
+
+def test_no_crash_only_swift_shortcuts(root: Path) -> None:
+    offenders: list[str] = []
+    for path in (root / "Sources").rglob("*.swift"):
+        text = path.read_text(errors="ignore")
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            if "try!" in line or "as!" in line or "fatalError(" in line or "preconditionFailure(" in line:
+                offenders.append(f"{path.relative_to(root)}:{lineno}: {line.strip()}")
+    assert not offenders, "Avoid crash-only Swift shortcuts:\n" + "\n".join(offenders)

--- a/Scripts/regression/checks/shell_safety.py
+++ b/Scripts/regression/checks/shell_safety.py
@@ -41,6 +41,14 @@ def test_shell_run_async_does_not_block_global_dispatch_workers(root: Path) -> N
     assert "DispatchQueue.global" not in body, "Shell.runAsync must not allocate a global queue worker per process"
 
 
+def test_shell_run_async_cancels_timeout_watchdog_on_finish(root: Path) -> None:
+    src = read(root, "Sources/Phosphor/Utilities/Shell.swift")
+    body = swift_block_after(src, "static func runAsync(_ command: String")
+    assert "attachWatchdog" in body, "runAsync should hand its timeout watchdog to the state so it can be cancelled early"
+    assert "pendingWatchdog?.cancel()" in src, "finish should cancel the watchdog so pipe fds are freed the moment the command completes"
+    assert "timedOut ? -1 : process.terminationStatus" in body, "runAsync must not read terminationStatus on the timed-out path (process may still be running)"
+
+
 def test_no_crash_only_swift_shortcuts(root: Path) -> None:
     offenders: list[str] = []
     for path in (root / "Sources").rglob("*.swift"):

--- a/Sources/Phosphor/App/PhosphorApp.swift
+++ b/Sources/Phosphor/App/PhosphorApp.swift
@@ -92,8 +92,14 @@ struct PhosphorApp: App {
 
             CommandMenu("Backup") {
                 Button("New Backup") {
-                    guard let udid = deviceVM.selectedDevice?.id else { return }
-                    Task { await backupVM.createBackup(udid: udid) }
+                    guard let device = deviceVM.selectedDevice else { return }
+                    Task {
+                        await backupVM.createBackup(
+                            udid: device.id,
+                            incremental: false,
+                            preferNetwork: device.connectionType == .wifi
+                        )
+                    }
                 }
                 .keyboardShortcut("b", modifiers: .command)
                 .disabled(deviceVM.selectedDevice == nil)

--- a/Sources/Phosphor/App/PhosphorApp.swift
+++ b/Sources/Phosphor/App/PhosphorApp.swift
@@ -16,6 +16,10 @@ final class PhosphorAppDelegate: NSObject, NSApplicationDelegate {
         return true
     }
 
+    func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
+        true
+    }
+
     private func ensureWindowSoon() {
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.35) {
             let hasVisibleWindow = NSApp.windows.contains { $0.isVisible && !$0.isMiniaturized }

--- a/Sources/Phosphor/App/PhosphorApp.swift
+++ b/Sources/Phosphor/App/PhosphorApp.swift
@@ -1,5 +1,5 @@
-import SwiftUI
 import AppKit
+import SwiftUI
 
 final class PhosphorAppDelegate: NSObject, NSApplicationDelegate {
     func applicationDidFinishLaunching(_ notification: Notification) {
@@ -93,6 +93,9 @@ struct PhosphorApp: App {
             CommandMenu("Backup") {
                 Button("New Backup") {
                     guard let device = deviceVM.selectedDevice else { return }
+                    if device.connectionType == .wifi && !BackupManager.hasExistingBackup(for: device.id) {
+                        guard confirmFirstFullWiFiBackup(for: device) else { return }
+                    }
                     Task {
                         await backupVM.createBackup(
                             udid: device.id,
@@ -121,5 +124,15 @@ struct PhosphorApp: App {
             get: { !hasCompletedOnboarding },
             set: { if !$0 { hasCompletedOnboarding = true } }
         )
+    }
+
+    private func confirmFirstFullWiFiBackup(for device: DeviceInfo) -> Bool {
+        let alert = NSAlert()
+        alert.messageText = "Create First Full Wi-Fi Backup?"
+        alert.informativeText = "\(device.name) does not have complete backup metadata yet. The first backup must be full and can take a long time over Wi-Fi. USB is recommended. Continue with Wi-Fi?"
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: "Create Full Wi-Fi Backup")
+        alert.addButton(withTitle: "Cancel")
+        return alert.runModal() == .alertFirstButtonReturn
     }
 }

--- a/Sources/Phosphor/Services/BackupArchiver.swift
+++ b/Sources/Phosphor/Services/BackupArchiver.swift
@@ -18,6 +18,45 @@ enum BackupArchiver {
         let archiveSize: UInt64
     }
 
+    private static func archiveEntries(at path: String) async -> [String]? {
+        let result = await Shell.runAsync("tar", arguments: ["-tzf", path])
+        guard result.succeeded else { return nil }
+        return result.output
+            .components(separatedBy: "\n")
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+    }
+
+    private static func archiveEntryIsSafe(_ entry: String) -> Bool {
+        guard !entry.hasPrefix("/") else { return false }
+        let components = entry.split(separator: "/", omittingEmptySubsequences: false).map(String.init)
+        return !components.contains("..")
+    }
+
+    private static func topLevelEntries(in entries: [String]) -> Set<String> {
+        Set(entries.compactMap { entry in
+            entry.split(separator: "/", omittingEmptySubsequences: true).first.map(String.init)
+        })
+    }
+
+    private static func looksLikeBackupFolder(_ path: String) -> Bool {
+        let fm = FileManager.default
+        let info = (path as NSString).appendingPathComponent("Info.plist")
+        let manifestPlist = (path as NSString).appendingPathComponent("Manifest.plist")
+        let manifestDb = (path as NSString).appendingPathComponent("Manifest.db")
+        return fm.fileExists(atPath: info) &&
+               (fm.fileExists(atPath: manifestPlist) || fm.fileExists(atPath: manifestDb))
+    }
+
+    private static func moveImportedEntriesToTrash(_ entries: Set<String>, in destination: String) {
+        let fm = FileManager.default
+        for item in entries {
+            let path = (destination as NSString).appendingPathComponent(item)
+            var trashedURL: NSURL?
+            try? fm.trashItem(at: URL(fileURLWithPath: path), resultingItemURL: &trashedURL)
+        }
+    }
+
     // MARK: - Archive (Export)
 
     /// Create a .phosphor archive from a backup directory.
@@ -74,16 +113,38 @@ enum BackupArchiver {
         to backupDir: String? = nil,
         onProgress: @escaping (String) -> Void
     ) async -> String? {
-        let home = FileManager.default.homeDirectoryForCurrentUser.path
-        let defaultDir = "\(home)/Library/Application Support/MobileSync/Backup"
-        let destination = backupDir ?? defaultDir
+        let destination: String
+        if let backupDir {
+            destination = backupDir
+        } else {
+            destination = await MainActor.run { BackupManager.activeBackupDir }
+        }
         let fm = FileManager.default
 
+        guard let entries = await archiveEntries(at: archivePath), !entries.isEmpty else {
+            onProgress("Import failed: archive could not be read")
+            return nil
+        }
+        guard entries.allSatisfy(archiveEntryIsSafe) else {
+            onProgress("Import failed: archive contains unsafe paths")
+            return nil
+        }
+
         // Ensure destination exists
-        try? fm.createDirectory(atPath: destination, withIntermediateDirectories: true)
+        do {
+            try fm.createDirectory(atPath: destination, withIntermediateDirectories: true)
+        } catch {
+            onProgress("Import failed: could not create backup directory: \(error.localizedDescription)")
+            return nil
+        }
 
         // Snapshot existing directories BEFORE extraction to detect new ones
         let existingDirs = Set(fm.sortedContents(atPath: destination))
+        let collisions = topLevelEntries(in: entries).intersection(existingDirs)
+        guard collisions.isEmpty else {
+            onProgress("Import failed: backup already exists (\(collisions.sorted().joined(separator: ", ")))")
+            return nil
+        }
 
         onProgress("Extracting backup archive...")
 
@@ -100,11 +161,10 @@ enum BackupArchiver {
             let currentDirs = Set(fm.sortedContents(atPath: destination))
             let newDirs = currentDirs.subtracting(existingDirs)
 
-            // Check each new directory for Info.plist (valid backup)
+            // Check each new directory for complete backup metadata.
             for item in newDirs {
                 let itemPath = (destination as NSString).appendingPathComponent(item)
-                let infoPlist = (itemPath as NSString).appendingPathComponent("Info.plist")
-                if fm.fileExists(atPath: infoPlist) {
+                if looksLikeBackupFolder(itemPath) {
                     return itemPath
                 }
             }
@@ -112,13 +172,16 @@ enum BackupArchiver {
             // Fallback: scan all for valid backup
             for item in currentDirs {
                 let itemPath = (destination as NSString).appendingPathComponent(item)
-                let infoPlist = (itemPath as NSString).appendingPathComponent("Info.plist")
-                if fm.fileExists(atPath: infoPlist) && !existingDirs.contains(item) {
+                if looksLikeBackupFolder(itemPath) && !existingDirs.contains(item) {
                     return itemPath
                 }
             }
+            moveImportedEntriesToTrash(newDirs, in: destination)
+            onProgress("Import failed: archive did not contain a complete iOS backup")
             return nil
         } else {
+            let currentDirs = Set(fm.sortedContents(atPath: destination))
+            moveImportedEntriesToTrash(currentDirs.subtracting(existingDirs), in: destination)
             onProgress("Import failed: \(result.stderr)")
             return nil
         }
@@ -134,10 +197,7 @@ enum BackupArchiver {
         let archiveSize = (try? fm.attributesOfItem(atPath: path)[.size] as? UInt64) ?? 0
 
         // List contents to find Info.plist
-        let listResult = await Shell.runAsync("tar", arguments: ["-tzf", path])
-        guard listResult.succeeded else { return nil }
-
-        let files = listResult.output.components(separatedBy: "\n")
+        guard let files = await archiveEntries(at: path), files.allSatisfy(archiveEntryIsSafe) else { return nil }
         guard let infoPlistEntry = files.first(where: { $0.hasSuffix("Info.plist") && !$0.contains("/") || $0.components(separatedBy: "/").count == 2 && $0.hasSuffix("Info.plist") }) else {
             return nil
         }

--- a/Sources/Phosphor/Services/BackupArchiver.swift
+++ b/Sources/Phosphor/Services/BackupArchiver.swift
@@ -27,6 +27,17 @@ enum BackupArchiver {
             .filter { !$0.isEmpty }
     }
 
+    /// Strip a leading `./` (repeatedly) so `./UDID/Info.plist` and `UDID/Info.plist`
+    /// collapse to the same top-level directory. tar writes both to the same place, so
+    /// collision detection must see them identically or an existing backup gets clobbered.
+    private static func normalizedEntryPath(_ entry: String) -> String {
+        var normalized = entry
+        while normalized.hasPrefix("./") {
+            normalized.removeFirst(2)
+        }
+        return normalized
+    }
+
     private static func archiveEntryIsSafe(_ entry: String) -> Bool {
         guard !entry.hasPrefix("/") else { return false }
         let components = entry.split(separator: "/", omittingEmptySubsequences: false).map(String.init)
@@ -35,17 +46,27 @@ enum BackupArchiver {
 
     private static func topLevelEntries(in entries: [String]) -> Set<String> {
         Set(entries.compactMap { entry in
-            entry.split(separator: "/", omittingEmptySubsequences: true).first.map(String.init)
-        })
+            normalizedEntryPath(entry)
+                .split(separator: "/", omittingEmptySubsequences: true)
+                .first
+                .map(String.init)
+        }).subtracting(["."])
+    }
+
+    private static func isNonEmptyFile(_ path: String) -> Bool {
+        guard let attributes = try? FileManager.default.attributesOfItem(atPath: path),
+              let size = attributes[.size] as? UInt64 else {
+            return false
+        }
+        return size > 0
     }
 
     private static func looksLikeBackupFolder(_ path: String) -> Bool {
-        let fm = FileManager.default
         let info = (path as NSString).appendingPathComponent("Info.plist")
         let manifestPlist = (path as NSString).appendingPathComponent("Manifest.plist")
         let manifestDb = (path as NSString).appendingPathComponent("Manifest.db")
-        return fm.fileExists(atPath: info) &&
-               (fm.fileExists(atPath: manifestPlist) || fm.fileExists(atPath: manifestDb))
+        return isNonEmptyFile(info) &&
+               (isNonEmptyFile(manifestPlist) || isNonEmptyFile(manifestDb))
     }
 
     private static func moveImportedEntriesToTrash(_ entries: Set<String>, in destination: String) {

--- a/Sources/Phosphor/Services/BackupManager.swift
+++ b/Sources/Phosphor/Services/BackupManager.swift
@@ -11,6 +11,28 @@ final class BackupManager: ObservableObject {
     @Published var backupProgress: String = ""
     @Published var backupPercent: Double = 0
     @Published var lastError: String?
+    @Published var lastBackupFailure: BackupFailure?
+
+    enum RecoveryAction: String, Hashable {
+        case runFullBackup
+        case deleteIncompleteAndRunFull
+        case openBackupSettings
+        case retry
+    }
+
+    struct BackupFailure: Identifiable, Hashable {
+        let id = UUID()
+        let title: String
+        let message: String
+        let technicalDetails: String?
+        let recoveryAction: RecoveryAction?
+    }
+
+    enum BackupMetadataHealth: Equatable {
+        case complete
+        case missing
+        case incomplete(path: String)
+    }
 
     /// Active backup process for cancellation.
     private var activeProcess: Process?
@@ -22,37 +44,37 @@ final class BackupManager: ObservableObject {
     private var pymobiledeviceStderrTail: [String] = []
 
     /// Translate a pymobiledevice3 or idevicebackup2 stderr blob into a short actionable hint.
-    private static func diagnosticHint(for stderr: String) -> String? {
+    private static func diagnostic(for stderr: String) -> (hint: String?, action: RecoveryAction?) {
         let lower = stderr.lowercased()
         if lower.contains("not paired") || lower.contains("pairingdialogresponsepending") || lower.contains("trust this computer") {
-            return "Device is not trusted. Unlock it and tap 'Trust' when prompted, then try again."
+            return ("Device is not trusted. Unlock it and tap 'Trust' when prompted, then try again.", .retry)
         }
         if lower.contains("passcodesetuprequired") || lower.contains("setpasscode") {
-            return "Set a passcode on the device before running an encrypted backup."
+            return ("Set a passcode on the device before running an encrypted backup.", .retry)
         }
         if lower.contains("no device found") || lower.contains("no devices connected") {
-            return "No device detected. Reconnect the cable and ensure the device is unlocked."
+            return ("No device detected. Reconnect the cable and ensure the device is unlocked.", .retry)
         }
         if lower.contains("backupdomainoverridden") || lower.contains("mobilebackup2error") {
-            return "iOS rejected the backup request. Disable/re-enable encryption or reboot the device."
+            return ("iOS rejected the backup request. Disable/re-enable encryption or reboot the device.", .retry)
         }
         if lower.contains("modulenotfounderror") || lower.contains("no module named") {
-            return "pymobiledevice3 is installed but missing dependencies. Reinstall with: pipx reinstall pymobiledevice3"
+            return ("pymobiledevice3 is installed but missing dependencies. Reinstall with: pipx reinstall pymobiledevice3", nil)
         }
         if lower.contains("invalidservice") || lower.contains("remotexpc") || lower.contains("tunneld") {
-            return "Backup requires an up-to-date pymobiledevice3. Upgrade with: pipx upgrade pymobiledevice3"
+            return ("Backup requires an up-to-date pymobiledevice3. Upgrade with: pipx upgrade pymobiledevice3", .retry)
         }
         if lower.contains("zero-length") || lower.contains("cannot parse a null") || lower.contains("mberrordomain/205") || lower.contains("error reading backup properties") {
-            return "The existing backup metadata appears incomplete or corrupt. Choose a fresh local backup folder and avoid cloud-synced folders for live backups, then retry with the device unlocked."
+            return ("The existing backup metadata appears incomplete or corrupt. Delete the incomplete backup or choose a fresh local backup folder, then run a full backup with the device unlocked.", .deleteIncompleteAndRunFull)
         }
         if lower.contains("is not readable") || lower.contains("permission denied") || lower.contains("operation not permitted") {
-            return """
+            return ("""
             macOS is blocking access to the backup directory. The easiest fix is to switch Phosphor's backup directory to a user-owned location:
             Phosphor -> Settings -> Backup Directory -> ~/Documents/Phosphor Backups.
             Only if you specifically want Phosphor to read Apple's shared MobileSync backups do you need to grant Full Disk Access (System Settings -> Privacy & Security -> Full Disk Access). Full Disk Access is not recommended - Phosphor does not need it for its own backups.
-            """
+            """, .openBackupSettings)
         }
-        return nil
+        return (nil, nil)
     }
 
     /// Preflight check: verify the active backup directory exists and is readable/writable
@@ -111,18 +133,27 @@ final class BackupManager: ObservableObject {
 
     /// Build a composite error string combining stderr tail and diagnostic hint.
     private static func composeFailureMessage(primary: String, stderr: String) -> String {
+        let failure = backupFailure(primary: primary, stderr: stderr)
+        return [failure.title, failure.message, failure.technicalDetails.map { "Details:\n\($0)" }]
+            .compactMap { $0 }
+            .joined(separator: "\n\n")
+    }
+
+    private static func backupFailure(primary: String, stderr: String) -> BackupFailure {
         let trimmed = stderr.trimmingCharacters(in: .whitespacesAndNewlines)
-        let hint = diagnosticHint(for: trimmed)
+        let diagnostic = diagnostic(for: trimmed)
         var lines: [String] = [primary]
-        if let hint { lines.append(hint) }
-        if !trimmed.isEmpty {
-            let tail = trimmed
-                .components(separatedBy: "\n")
-                .suffix(stderrTailLineLimit)
-                .joined(separator: "\n")
-            lines.append("Details:\n\(tail)")
-        }
-        return lines.joined(separator: "\n\n")
+        if let hint = diagnostic.hint { lines.append(hint) }
+        let tail = trimmed.isEmpty ? nil : trimmed
+            .components(separatedBy: "\n")
+            .suffix(stderrTailLineLimit)
+            .joined(separator: "\n")
+        return BackupFailure(
+            title: "Backup Failed",
+            message: lines.joined(separator: "\n\n"),
+            technicalDetails: tail,
+            recoveryAction: diagnostic.action
+        )
     }
 
     /// Phosphor's default backup location: inside ~/Documents so no special permission
@@ -262,13 +293,34 @@ final class BackupManager: ObservableObject {
                (fm.fileExists(atPath: manifestPlist) || fm.fileExists(atPath: manifestDb))
     }
 
+    static func backupPath(for udid: String, in directory: String? = nil) -> String {
+        let rootDirectory = directory ?? activeBackupDir
+        return (rootDirectory as NSString).appendingPathComponent(udid)
+    }
+
+    /// Check whether a device has complete backup metadata, no backup folder,
+    /// or an interrupted partial folder that should be cleaned up before retry.
+    static func backupMetadataHealth(for udid: String, in directory: String? = nil) -> BackupMetadataHealth {
+        let deviceDirectory = backupPath(for: udid, in: directory)
+        let fm = FileManager.default
+        var isDir: ObjCBool = false
+        guard fm.fileExists(atPath: deviceDirectory, isDirectory: &isDir) else {
+            return .missing
+        }
+        guard isDir.boolValue else { return .incomplete(path: deviceDirectory) }
+        return looksLikeBackupFolder(deviceDirectory) ? .complete : .incomplete(path: deviceDirectory)
+    }
+
     /// Incremental backups require an existing valid backup metadata folder for
     /// the target UDID. If the folder is missing or partially-created, both
     /// backup backends fail with low-level MBErrorDomain/205 plist errors.
     static func hasExistingBackup(for udid: String, in directory: String? = nil) -> Bool {
-        let rootDirectory = directory ?? activeBackupDir
-        let deviceDirectory = (rootDirectory as NSString).appendingPathComponent(udid)
-        return looksLikeBackupFolder(deviceDirectory)
+        backupMetadataHealth(for: udid, in: directory) == .complete
+    }
+
+    static func deleteIncompleteBackup(for udid: String, in directory: String? = nil) throws {
+        guard case .incomplete(let path) = backupMetadataHealth(for: udid, in: directory) else { return }
+        try FileManager.default.removeItem(atPath: path)
     }
 
     // MARK: - Backup Creation
@@ -284,6 +336,7 @@ final class BackupManager: ObservableObject {
         backupProgress = "Starting backup..."
         backupPercent = 0
         lastError = nil
+        lastBackupFailure = nil
 
         // Preflight: bail early with a clear message when the directory is unreadable
         // (most commonly a Full Disk Access grant missing on the default location).
@@ -292,7 +345,27 @@ final class BackupManager: ObservableObject {
             isCreatingBackup = false
             backupProgress = "Backup failed"
             lastError = preflight.reason
+            lastBackupFailure = BackupFailure(
+                title: "Backup Folder Not Accessible",
+                message: preflight.reason ?? "Phosphor cannot read or write the selected backup folder.",
+                technicalDetails: Self.activeBackupDir,
+                recoveryAction: .openBackupSettings
+            )
             onProgress(preflight.reason ?? "Backup directory is not accessible.")
+            return false
+        }
+
+        if case .incomplete(let path) = Self.backupMetadataHealth(for: udid) {
+            isCreatingBackup = false
+            backupProgress = "Incomplete backup found"
+            lastBackupFailure = BackupFailure(
+                title: "Incomplete Backup Found",
+                message: "A previous backup for this device did not finish, so iOS may reject another backup in this folder. Delete the incomplete folder, then run a full backup again.",
+                technicalDetails: path,
+                recoveryAction: .deleteIncompleteAndRunFull
+            )
+            lastError = lastBackupFailure?.message
+            onProgress(lastError ?? "Incomplete backup found.")
             return false
         }
 
@@ -351,6 +424,11 @@ final class BackupManager: ObservableObject {
                                 .filter { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
                                 .joined(separator: "\n---\n")
                             self.backupProgress = "Backup failed"
+                            let failure = Self.backupFailure(
+                                primary: "Both backup methods failed.",
+                                stderr: combinedStderr
+                            )
+                            self.lastBackupFailure = failure
                             self.lastError = Self.composeFailureMessage(
                                 primary: "Both backup methods failed.",
                                 stderr: combinedStderr
@@ -444,21 +522,49 @@ final class BackupManager: ObservableObject {
         backupProgress = "Starting incremental backup..."
         backupPercent = 0
         lastError = nil
+        lastBackupFailure = nil
 
         let preflight = Self.validateBackupDirectory(Self.activeBackupDir)
         if !preflight.ok {
             isCreatingBackup = false
             backupProgress = "Backup failed"
             lastError = preflight.reason
+            lastBackupFailure = BackupFailure(
+                title: "Backup Folder Not Accessible",
+                message: preflight.reason ?? "Phosphor cannot read or write the selected backup folder.",
+                technicalDetails: Self.activeBackupDir,
+                recoveryAction: .openBackupSettings
+            )
             onProgress(preflight.reason ?? "Backup directory is not accessible.")
             return false
         }
 
-        guard Self.hasExistingBackup(for: udid) else {
+        switch Self.backupMetadataHealth(for: udid) {
+        case .complete:
+            break
+        case .missing:
             isCreatingBackup = false
             backupProgress = "Backup needs a full backup first"
-            lastError = "No complete backup metadata exists for this device yet. Run a full backup first; future Wi-Fi backups can be incremental."
+            lastBackupFailure = BackupFailure(
+                title: "Full Backup Required",
+                message: "No complete backup exists for this device yet. Run a full backup first; future Wi-Fi backups can be incremental.",
+                technicalDetails: Self.backupPath(for: udid),
+                recoveryAction: .runFullBackup
+            )
+            lastError = lastBackupFailure?.message
             onProgress(lastError ?? "Run a full backup first.")
+            return false
+        case .incomplete(let path):
+            isCreatingBackup = false
+            backupProgress = "Incomplete backup found"
+            lastBackupFailure = BackupFailure(
+                title: "Incomplete Backup Found",
+                message: "A previous backup for this device did not finish. Delete the incomplete folder, then run a full backup again.",
+                technicalDetails: path,
+                recoveryAction: .deleteIncompleteAndRunFull
+            )
+            lastError = lastBackupFailure?.message
+            onProgress(lastError ?? "Incomplete backup found.")
             return false
         }
 
@@ -514,6 +620,11 @@ final class BackupManager: ObservableObject {
                                 .filter { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
                                 .joined(separator: "\n---\n")
                             self.backupProgress = "Backup failed"
+                            let failure = Self.backupFailure(
+                                primary: "Incremental backup failed via both backends.",
+                                stderr: combinedStderr
+                            )
+                            self.lastBackupFailure = failure
                             self.lastError = Self.composeFailureMessage(
                                 primary: "Incremental backup failed via both backends.",
                                 stderr: combinedStderr

--- a/Sources/Phosphor/Services/BackupManager.swift
+++ b/Sources/Phosphor/Services/BackupManager.swift
@@ -288,7 +288,12 @@ final class BackupManager: ObservableObject {
         }
 
         // Primary: pymobiledevice3
-        let pySuccess = await createBackupViaPymobiledevice(udid: udid, full: true, onProgress: onProgress)
+        let pySuccess = await createBackupViaPymobiledevice(
+            udid: udid,
+            full: true,
+            preferNetwork: preferNetwork,
+            onProgress: onProgress
+        )
         if pySuccess {
             isCreatingBackup = false
             backupProgress = "Backup complete"
@@ -359,7 +364,12 @@ final class BackupManager: ObservableObject {
     }
 
     /// Backup using pymobiledevice3.
-    private func createBackupViaPymobiledevice(udid: String, full: Bool, onProgress: @escaping (String) -> Void) async -> Bool {
+    private func createBackupViaPymobiledevice(
+        udid: String,
+        full: Bool,
+        preferNetwork: Bool,
+        onProgress: @escaping (String) -> Void
+    ) async -> Bool {
         guard PyMobileDevice.available() else {
             lastError = "pymobiledevice3 not installed. Install with: pipx install pymobiledevice3"
             return false
@@ -374,6 +384,7 @@ final class BackupManager: ObservableObject {
                 directory: Self.activeBackupDir,
                 udid: udid,
                 full: full,
+                preferNetwork: preferNetwork,
                 onOutput: { [weak self] output in
                     let trimmed = output.trimmingCharacters(in: .whitespacesAndNewlines)
                     if !trimmed.isEmpty {
@@ -436,7 +447,12 @@ final class BackupManager: ObservableObject {
 
         // Primary: pymobiledevice3 (without --full flag)
         if PyMobileDevice.available() {
-            let success = await createBackupViaPymobiledevice(udid: udid, full: false, onProgress: onProgress)
+            let success = await createBackupViaPymobiledevice(
+                udid: udid,
+                full: false,
+                preferNetwork: preferNetwork,
+                onProgress: onProgress
+            )
             if success {
                 isCreatingBackup = false
                 backupProgress = "Backup complete"

--- a/Sources/Phosphor/Services/BackupManager.swift
+++ b/Sources/Phosphor/Services/BackupManager.swift
@@ -235,8 +235,7 @@ final class BackupManager: ObservableObject {
         // Single-backup case: the chosen dir is itself a UDID backup folder
         // (contains Info.plist + Manifest.* at its root). Common when a user
         // points the picker at an individual backup rather than its parent.
-        let rootInfoPlist = (dir as NSString).appendingPathComponent("Info.plist")
-        if fm.fileExists(atPath: rootInfoPlist),
+        if Self.looksLikeBackupFolder(dir),
            let single = BackupInfo.fromDirectory(dir, includeSize: false) {
             backups = [single]
             lastError = nil
@@ -271,8 +270,7 @@ final class BackupManager: ObservableObject {
             var itemIsDir: ObjCBool = false
             guard fm.fileExists(atPath: fullPath, isDirectory: &itemIsDir), itemIsDir.boolValue else { continue }
 
-            let infoPlist = (fullPath as NSString).appendingPathComponent("Info.plist")
-            guard fm.fileExists(atPath: infoPlist) else { continue }
+            guard Self.looksLikeBackupFolder(fullPath) else { continue }
 
             if let backup = BackupInfo.fromDirectory(fullPath, includeSize: false) {
                 discovered.append(backup)

--- a/Sources/Phosphor/Services/BackupManager.swift
+++ b/Sources/Phosphor/Services/BackupManager.swift
@@ -761,6 +761,26 @@ final class BackupManager: ObservableObject {
 
     // MARK: - Selective Extract
 
+    private func extractionDestination(for entry: BackupManifest.FileEntry, under destination: String) -> String {
+        let safeDomain = entry.domain
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: ":", with: "_")
+        let relativeComponents = entry.relativePath
+            .split(separator: "/")
+            .map(String.init)
+            .filter { !$0.isEmpty && $0 != "." && $0 != ".." }
+
+        var path = (destination as NSString).appendingPathComponent(safeDomain)
+        for component in relativeComponents {
+            path = (path as NSString).appendingPathComponent(component)
+        }
+
+        if relativeComponents.isEmpty || entry.relativePath.hasSuffix("/") {
+            path = (path as NSString).appendingPathComponent(entry.fileName)
+        }
+        return path
+    }
+
     func extractFiles(
         from backup: BackupInfo,
         entries: [BackupManifest.FileEntry],
@@ -770,7 +790,7 @@ final class BackupManager: ObservableObject {
         var extracted = 0
 
         for entry in entries where entry.isFile {
-            let destPath = (destination as NSString).appendingPathComponent(entry.fileName)
+            let destPath = extractionDestination(for: entry, under: destination)
             do {
                 try manifest.extractFile(entry, to: destPath)
                 extracted += 1

--- a/Sources/Phosphor/Services/BackupManager.swift
+++ b/Sources/Phosphor/Services/BackupManager.swift
@@ -262,6 +262,15 @@ final class BackupManager: ObservableObject {
                (fm.fileExists(atPath: manifestPlist) || fm.fileExists(atPath: manifestDb))
     }
 
+    /// Incremental backups require an existing valid backup metadata folder for
+    /// the target UDID. If the folder is missing or partially-created, both
+    /// backup backends fail with low-level MBErrorDomain/205 plist errors.
+    static func hasExistingBackup(for udid: String, in directory: String? = nil) -> Bool {
+        let rootDirectory = directory ?? activeBackupDir
+        let deviceDirectory = (rootDirectory as NSString).appendingPathComponent(udid)
+        return looksLikeBackupFolder(deviceDirectory)
+    }
+
     // MARK: - Backup Creation
 
     /// Create a new backup. pymobiledevice3 primary, idevicebackup2 fallback.
@@ -442,6 +451,14 @@ final class BackupManager: ObservableObject {
             backupProgress = "Backup failed"
             lastError = preflight.reason
             onProgress(preflight.reason ?? "Backup directory is not accessible.")
+            return false
+        }
+
+        guard Self.hasExistingBackup(for: udid) else {
+            isCreatingBackup = false
+            backupProgress = "Backup needs a full backup first"
+            lastError = "No complete backup metadata exists for this device yet. Run a full backup first; future Wi-Fi backups can be incremental."
+            onProgress(lastError ?? "Run a full backup first.")
             return false
         }
 

--- a/Sources/Phosphor/Services/BackupManager.swift
+++ b/Sources/Phosphor/Services/BackupManager.swift
@@ -26,6 +26,24 @@ final class BackupManager: ObservableObject {
         let message: String
         let technicalDetails: String?
         let recoveryAction: RecoveryAction?
+        let udid: String?
+        let recoveryPath: String?
+
+        init(
+            title: String,
+            message: String,
+            technicalDetails: String?,
+            recoveryAction: RecoveryAction?,
+            udid: String? = nil,
+            recoveryPath: String? = nil
+        ) {
+            self.title = title
+            self.message = message
+            self.technicalDetails = technicalDetails
+            self.recoveryAction = recoveryAction
+            self.udid = udid
+            self.recoveryPath = recoveryPath
+        }
     }
 
     enum BackupMetadataHealth: Equatable {
@@ -139,7 +157,7 @@ final class BackupManager: ObservableObject {
             .joined(separator: "\n\n")
     }
 
-    private static func backupFailure(primary: String, stderr: String) -> BackupFailure {
+    private static func backupFailure(primary: String, stderr: String, udid: String? = nil, recoveryPath: String? = nil) -> BackupFailure {
         let trimmed = stderr.trimmingCharacters(in: .whitespacesAndNewlines)
         let diagnostic = diagnostic(for: trimmed)
         var lines: [String] = [primary]
@@ -152,7 +170,9 @@ final class BackupManager: ObservableObject {
             title: "Backup Failed",
             message: lines.joined(separator: "\n\n"),
             technicalDetails: tail,
-            recoveryAction: diagnostic.action
+            recoveryAction: diagnostic.action,
+            udid: udid,
+            recoveryPath: recoveryPath
         )
     }
 
@@ -316,9 +336,43 @@ final class BackupManager: ObservableObject {
         backupMetadataHealth(for: udid, in: directory) == .complete
     }
 
-    static func deleteIncompleteBackup(for udid: String, in directory: String? = nil) throws {
+    static func incompleteBackupHasKnownMarkers(_ path: String) -> Bool {
+        let knownMarkers = ["Info.plist", "Status.plist", "Manifest.plist", "Manifest.db", "Manifest.mbdb"]
+        return knownMarkers.contains { marker in
+            FileManager.default.fileExists(atPath: (path as NSString).appendingPathComponent(marker))
+        }
+    }
+
+    static func deleteIncompleteBackup(for udid: String, expectedPath: String? = nil, in directory: String? = nil) throws {
         guard case .incomplete(let path) = backupMetadataHealth(for: udid, in: directory) else { return }
-        try FileManager.default.removeItem(atPath: path)
+        if let expectedPath, (expectedPath as NSString).standardizingPath != (path as NSString).standardizingPath {
+            throw NSError(domain: "Phosphor.Backup", code: 1, userInfo: [
+                NSLocalizedDescriptionKey: "The incomplete backup path changed. Refresh backups and try again."
+            ])
+        }
+
+        let expectedBackupPath = backupPath(for: udid, in: directory)
+        guard (path as NSString).standardizingPath == (expectedBackupPath as NSString).standardizingPath else {
+            throw NSError(domain: "Phosphor.Backup", code: 2, userInfo: [
+                NSLocalizedDescriptionKey: "Refusing to delete an unexpected backup path: \(path)"
+            ])
+        }
+
+        var isDir: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: path, isDirectory: &isDir), isDir.boolValue else {
+            throw NSError(domain: "Phosphor.Backup", code: 3, userInfo: [
+                NSLocalizedDescriptionKey: "Refusing to delete a non-directory backup path: \(path)"
+            ])
+        }
+
+        guard incompleteBackupHasKnownMarkers(path) else {
+            throw NSError(domain: "Phosphor.Backup", code: 4, userInfo: [
+                NSLocalizedDescriptionKey: "Refusing to delete \(path) because it does not contain recognizable iOS backup metadata. Delete it manually if you are sure it is safe."
+            ])
+        }
+
+        var trashedURL: NSURL?
+        try FileManager.default.trashItem(at: URL(fileURLWithPath: path), resultingItemURL: &trashedURL)
     }
 
     // MARK: - Backup Creation
@@ -347,7 +401,9 @@ final class BackupManager: ObservableObject {
                 title: "Backup Folder Not Accessible",
                 message: preflight.reason ?? "Phosphor cannot read or write the selected backup folder.",
                 technicalDetails: Self.activeBackupDir,
-                recoveryAction: .openBackupSettings
+                recoveryAction: .openBackupSettings,
+                udid: udid,
+                recoveryPath: Self.activeBackupDir
             )
             onProgress(preflight.reason ?? "Backup directory is not accessible.")
             return false
@@ -360,7 +416,9 @@ final class BackupManager: ObservableObject {
                 title: "Incomplete Backup Found",
                 message: "A previous backup for this device did not finish, so iOS may reject another backup in this folder. Delete the incomplete folder, then run a full backup again.",
                 technicalDetails: path,
-                recoveryAction: .deleteIncompleteAndRunFull
+                recoveryAction: .deleteIncompleteAndRunFull,
+                udid: udid,
+                recoveryPath: path
             )
             lastError = lastBackupFailure?.message
             onProgress(lastError ?? "Incomplete backup found.")
@@ -424,7 +482,9 @@ final class BackupManager: ObservableObject {
                             self.backupProgress = "Backup failed"
                             let failure = Self.backupFailure(
                                 primary: "Both backup methods failed.",
-                                stderr: combinedStderr
+                                stderr: combinedStderr,
+                                udid: udid,
+                                recoveryPath: Self.backupPath(for: udid)
                             )
                             self.lastBackupFailure = failure
                             self.lastError = Self.composeFailureMessage(
@@ -531,7 +591,9 @@ final class BackupManager: ObservableObject {
                 title: "Backup Folder Not Accessible",
                 message: preflight.reason ?? "Phosphor cannot read or write the selected backup folder.",
                 technicalDetails: Self.activeBackupDir,
-                recoveryAction: .openBackupSettings
+                recoveryAction: .openBackupSettings,
+                udid: udid,
+                recoveryPath: Self.activeBackupDir
             )
             onProgress(preflight.reason ?? "Backup directory is not accessible.")
             return false
@@ -547,7 +609,9 @@ final class BackupManager: ObservableObject {
                 title: "Full Backup Required",
                 message: "No complete backup exists for this device yet. Run a full backup first; future Wi-Fi backups can be incremental.",
                 technicalDetails: Self.backupPath(for: udid),
-                recoveryAction: .runFullBackup
+                recoveryAction: .runFullBackup,
+                udid: udid,
+                recoveryPath: Self.backupPath(for: udid)
             )
             lastError = lastBackupFailure?.message
             onProgress(lastError ?? "Run a full backup first.")
@@ -559,7 +623,9 @@ final class BackupManager: ObservableObject {
                 title: "Incomplete Backup Found",
                 message: "A previous backup for this device did not finish. Delete the incomplete folder, then run a full backup again.",
                 technicalDetails: path,
-                recoveryAction: .deleteIncompleteAndRunFull
+                recoveryAction: .deleteIncompleteAndRunFull,
+                udid: udid,
+                recoveryPath: path
             )
             lastError = lastBackupFailure?.message
             onProgress(lastError ?? "Incomplete backup found.")
@@ -620,7 +686,9 @@ final class BackupManager: ObservableObject {
                             self.backupProgress = "Backup failed"
                             let failure = Self.backupFailure(
                                 primary: "Incremental backup failed via both backends.",
-                                stderr: combinedStderr
+                                stderr: combinedStderr,
+                                udid: udid,
+                                recoveryPath: Self.backupPath(for: udid)
                             )
                             self.lastBackupFailure = failure
                             self.lastError = Self.composeFailureMessage(

--- a/Sources/Phosphor/Services/BackupManager.swift
+++ b/Sources/Phosphor/Services/BackupManager.swift
@@ -301,14 +301,25 @@ final class BackupManager: ObservableObject {
         lastError = nil
     }
 
+    /// True when a backup metadata file exists AND has real content. An interrupted
+    /// backup often leaves zero-length Info.plist / Manifest.* stubs; treating those
+    /// as complete makes incremental backups fail with MBErrorDomain/205 (the exact
+    /// "cannot parse null plist" failure the completeness check exists to prevent).
+    static func isNonEmptyFile(_ path: String) -> Bool {
+        guard let attributes = try? FileManager.default.attributesOfItem(atPath: path),
+              let size = attributes[.size] as? UInt64 else {
+            return false
+        }
+        return size > 0
+    }
+
     /// True when `path` looks like a single iOS backup folder (UDID dir with Info.plist + Manifest.*).
     static func looksLikeBackupFolder(_ path: String) -> Bool {
-        let fm = FileManager.default
         let info = (path as NSString).appendingPathComponent("Info.plist")
         let manifestPlist = (path as NSString).appendingPathComponent("Manifest.plist")
         let manifestDb = (path as NSString).appendingPathComponent("Manifest.db")
-        return fm.fileExists(atPath: info) &&
-               (fm.fileExists(atPath: manifestPlist) || fm.fileExists(atPath: manifestDb))
+        return isNonEmptyFile(info) &&
+               (isNonEmptyFile(manifestPlist) || isNonEmptyFile(manifestDb))
     }
 
     static func backupPath(for udid: String, in directory: String? = nil) -> String {
@@ -762,9 +773,15 @@ final class BackupManager: ObservableObject {
     // MARK: - Selective Extract
 
     private func extractionDestination(for entry: BackupManifest.FileEntry, under destination: String) -> String {
-        let safeDomain = entry.domain
+        var safeDomain = entry.domain
             .replacingOccurrences(of: "/", with: "_")
             .replacingOccurrences(of: ":", with: "_")
+        // A crafted/corrupt Manifest.db row could set domain to "." or ".." to walk
+        // out of the destination directory. Slashes are already neutralized above, so
+        // only the bare current-/parent-dir tokens remain dangerous.
+        if safeDomain == "." || safeDomain == ".." || safeDomain.isEmpty {
+            safeDomain = "_"
+        }
         let relativeComponents = entry.relativePath
             .split(separator: "/")
             .map(String.init)
@@ -789,8 +806,19 @@ final class BackupManager: ObservableObject {
         let manifest = try BackupManifest(backupPath: backup.path)
         var extracted = 0
 
+        let destinationRoot = ((destination as NSString).standardizingPath as NSString)
+            .appendingPathComponent("")
+
         for entry in entries where entry.isFile {
             let destPath = extractionDestination(for: entry, under: destination)
+            // Defense in depth: never write outside the chosen destination even if a
+            // manifest row slipped a traversal token past sanitization.
+            let standardized = (destPath as NSString).standardizingPath
+            guard standardized == (destination as NSString).standardizingPath
+                    || standardized.hasPrefix(destinationRoot) else {
+                lastError = "Refusing to extract \(entry.fileName) outside the destination folder."
+                continue
+            }
             do {
                 try manifest.extractFile(entry, to: destPath)
                 extracted += 1

--- a/Sources/Phosphor/Services/BackupScheduler.swift
+++ b/Sources/Phosphor/Services/BackupScheduler.swift
@@ -130,11 +130,14 @@ final class BackupScheduler: ObservableObject {
         let manager = BackupManager()
         let success: Bool
 
-        if schedule.incrementalOnly {
+        if schedule.incrementalOnly && BackupManager.hasExistingBackup(for: udid) {
             success = await manager.createIncrementalBackup(udid: udid, preferNetwork: preferNetwork) { [weak self] text in
                 self?.scheduledBackupProgress = text
             }
         } else {
+            if schedule.incrementalOnly {
+                addLog("No complete backup exists yet; running required first full backup", success: true)
+            }
             success = await manager.createBackup(udid: udid, preferNetwork: preferNetwork) { [weak self] text in
                 self?.scheduledBackupProgress = text
             }

--- a/Sources/Phosphor/Services/BackupScheduler.swift
+++ b/Sources/Phosphor/Services/BackupScheduler.swift
@@ -70,8 +70,10 @@ final class BackupScheduler: ObservableObject {
 
     func startMonitoring() {
         stopMonitoring()
-        guard schedule.enabled else { return }
-
+        // Keep a lightweight timer alive even when the saved schedule is disabled.
+        // Settings and schedule sheets use separate BackupScheduler instances that
+        // persist changes through UserDefaults; this app-level scheduler must be
+        // able to notice a schedule that is enabled after launch.
         timer = Timer.scheduledTimer(withTimeInterval: 300, repeats: true) { [weak self] _ in
             Task { @MainActor [weak self] in
                 await self?.checkAndRun()
@@ -96,6 +98,7 @@ final class BackupScheduler: ObservableObject {
     func checkAndRun() async {
         reloadFromDefaults()
         guard schedule.enabled, !isRunningScheduledBackup else { return }
+        if schedule.nextRunDate == nil { updateNextRunDate() }
         guard let nextRun = schedule.nextRunDate, Date() >= nextRun else { return }
 
         isRunningScheduledBackup = true
@@ -112,9 +115,11 @@ final class BackupScheduler: ObservableObject {
 
     func runNow() async {
         guard !isRunningScheduledBackup else { return }
+        isRunningScheduledBackup = true
         let target = await findTargetDevice()
         guard let target else {
             addLog("No device available for backup", success: false)
+            isRunningScheduledBackup = false
             return
         }
         await runScheduledBackup(udid: target.udid, preferNetwork: target.preferNetwork)

--- a/Sources/Phosphor/Services/DeviceManager.swift
+++ b/Sources/Phosphor/Services/DeviceManager.swift
@@ -7,6 +7,7 @@ import Combine
 final class DeviceManager: ObservableObject {
 
     @Published var connectedDevices: [DeviceInfo] = []
+    @Published var nearbyWirelessDevices: [PyMobileDevice.BonjourDevice] = []
     @Published var selectedDevice: DeviceInfo?
     @Published var isScanning = false
     @Published var lastError: String?
@@ -17,10 +18,12 @@ final class DeviceManager: ObservableObject {
     private var batteryInfoCache: [String: (info: [String: String], fetchedAt: Date)] = [:]
     private var pairStatusCache: [String: (isPaired: Bool, fetchedAt: Date)] = [:]
     private var networkDeviceCache: (entries: [PyMobileDevice.DeviceEntry], fetchedAt: Date)?
+    private var bonjourDeviceCache: (devices: [PyMobileDevice.BonjourDevice], fetchedAt: Date)?
     private let deviceInfoRefreshInterval: TimeInterval = 30
     private let batteryInfoRefreshInterval: TimeInterval = 60
     private let pairStatusRefreshInterval: TimeInterval = 120
     private let networkDeviceRefreshInterval: TimeInterval = 30
+    private let bonjourDeviceRefreshInterval: TimeInterval = 30
 
     // MARK: - Dependency Check
 
@@ -60,7 +63,9 @@ final class DeviceManager: ObservableObject {
         // network-only snapshot so devices already paired to this Mac over Wi-Fi
         // can appear even when no USB cable is attached.
         var entries = await PyMobileDevice.listDevicesWithType()
-        entries = mergeDeviceEntries(entries + (await cachedNetworkDeviceEntries(forceRefresh: forceRefresh)))
+        if !entries.contains(where: { $0.discoveryMethod == "mobdev2" }) {
+            entries = mergeDeviceEntries(entries + (await cachedNetworkDeviceEntries(forceRefresh: forceRefresh)))
+        }
 
         // Fallback: libimobiledevice. Include both USB and network-only listings.
         if entries.isEmpty {
@@ -68,7 +73,9 @@ final class DeviceManager: ObservableObject {
         }
 
         if entries.isEmpty {
+            let bonjourDevices = await cachedBonjourDevices(forceRefresh: forceRefresh)
             connectedDevices = []
+            nearbyWirelessDevices = bonjourDevices
             selectedDevice = nil
             deviceInfoCache.removeAll()
             batteryInfoCache.removeAll()
@@ -76,6 +83,8 @@ final class DeviceManager: ObservableObject {
             networkDeviceCache = nil
             return
         }
+
+        nearbyWirelessDevices = []
 
         let visibleUDIDs = Set(entries.map(\.udid))
         deviceInfoCache = deviceInfoCache.filter { visibleUDIDs.contains($0.key) }
@@ -92,6 +101,7 @@ final class DeviceManager: ObservableObject {
             if var device = await fetchDeviceInfo(
                 udid: entry.udid,
                 connectionType: connType,
+                discoveryInfo: entry.discoveryInfo,
                 forceRefresh: forceRefresh
             ) {
                 device.connectionType = connType
@@ -118,6 +128,17 @@ final class DeviceManager: ObservableObject {
         let entries = await PyMobileDevice.listNetworkDeviceEntries()
         networkDeviceCache = (entries, Date())
         return entries
+    }
+
+    private func cachedBonjourDevices(forceRefresh: Bool = false) async -> [PyMobileDevice.BonjourDevice] {
+        if !forceRefresh,
+           let cached = bonjourDeviceCache,
+           Date().timeIntervalSince(cached.fetchedAt) < bonjourDeviceRefreshInterval {
+            return cached.devices
+        }
+        let devices = await PyMobileDevice.listBonjourMobileDevices()
+        bonjourDeviceCache = (devices, Date())
+        return devices
     }
 
     private func listLibimobiledeviceEntries() async -> [PyMobileDevice.DeviceEntry] {
@@ -173,8 +194,13 @@ final class DeviceManager: ObservableObject {
     func fetchDeviceInfo(
         udid: String,
         connectionType: DeviceInfo.ConnectionType = .usb,
+        discoveryInfo: [String: String] = [:],
         forceRefresh: Bool = false
     ) async -> DeviceInfo? {
+        if !discoveryInfo.isEmpty {
+            return deviceInfo(fromDiscoveryInfo: discoveryInfo, udid: udid, connectionType: connectionType)
+        }
+
         // Primary: pymobiledevice3
         let info = await PyMobileDevice.deviceInfo(udid: udid)
         if !info.isEmpty {
@@ -271,6 +297,29 @@ final class DeviceManager: ObservableObject {
             isActivated: liInfo["ActivationState"] == "Activated",
             basebandVersion: liInfo["BasebandVersion"],
             activationState: liInfo["ActivationState"],
+            connectionType: connectionType
+        )
+    }
+
+    private func deviceInfo(
+        fromDiscoveryInfo info: [String: String],
+        udid: String,
+        connectionType: DeviceInfo.ConnectionType
+    ) -> DeviceInfo {
+        DeviceInfo(
+            id: udid,
+            name: info["DeviceName"] ?? "Wireless iPhone/iPad",
+            model: info["ProductType"] ?? info["DeviceClass"] ?? "Unknown",
+            modelNumber: info["ModelNumber"] ?? "",
+            productType: info["ProductType"] ?? "",
+            iosVersion: info["ProductVersion"] ?? "",
+            buildVersion: info["BuildVersion"] ?? "",
+            serialNumber: info["SerialNumber"] ?? "",
+            wifiAddress: info["WiFiAddress"] ?? info["ip"] ?? info["Identifier"] ?? "",
+            bluetoothAddress: info["BluetoothAddress"] ?? "",
+            isPaired: true,
+            isActivated: info["ActivationState"].map { $0 == "Activated" } ?? true,
+            activationState: info["ActivationState"],
             connectionType: connectionType
         )
     }

--- a/Sources/Phosphor/Services/FileTransferManager.swift
+++ b/Sources/Phosphor/Services/FileTransferManager.swift
@@ -345,6 +345,13 @@ final class FileTransferManager: ObservableObject {
 
     /// Delete a file on the device.
     func deleteFile(_ entry: FileEntry) async throws {
+        guard !entry.isDirectory else {
+            throw NSError(
+                domain: "Phosphor",
+                code: 400,
+                userInfo: [NSLocalizedDescriptionKey: "Directory deletion is not supported from the file browser."]
+            )
+        }
         if usesAFC {
             let success = await PyMobileDevice.afcRemove(path: entry.path, udid: deviceUDID)
             if !success { throw CocoaError(.fileWriteUnknown) }

--- a/Sources/Phosphor/Services/LiveDeviceBrowser.swift
+++ b/Sources/Phosphor/Services/LiveDeviceBrowser.swift
@@ -157,7 +157,7 @@ final class LiveDeviceBrowser: ObservableObject {
         let fm = FileManager.default
         try? fm.createDirectory(atPath: tmpDir, withIntermediateDirectories: true)
 
-        let localPath = (tmpDir as NSString).appendingPathComponent(photo.name)
+        let localPath = (tmpDir as NSString).appendingPathComponent(uniqueLocalName(for: photo))
         if fm.fileExists(atPath: localPath) { return localPath } // Already downloaded
 
         let success = await PyMobileDevice.afcPull(remotePath: photo.path, localPath: localPath, udid: udid)
@@ -211,6 +211,13 @@ final class LiveDeviceBrowser: ObservableObject {
 
     // MARK: - Export
 
+    private func uniqueLocalName(for photo: LivePhoto) -> String {
+        let stem = photo.path
+            .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+            .replacingOccurrences(of: "/", with: "_")
+        return stem.isEmpty ? photo.name : stem
+    }
+
     func exportPhoto(_ photo: LivePhoto, to destination: String) async throws {
         let fm = FileManager.default
         let destDir = (destination as NSString).deletingLastPathComponent
@@ -233,7 +240,7 @@ final class LiveDeviceBrowser: ObservableObject {
         try? fm.createDirectory(atPath: directory, withIntermediateDirectories: true)
         var count = 0
         for photo in selectedPhotos {
-            let dest = (directory as NSString).appendingPathComponent(photo.name)
+            let dest = (directory as NSString).appendingPathComponent(uniqueLocalName(for: photo))
             do { try await exportPhoto(photo, to: dest); count += 1 } catch { continue }
         }
         return count

--- a/Sources/Phosphor/Services/MessageExporter.swift
+++ b/Sources/Phosphor/Services/MessageExporter.swift
@@ -489,12 +489,8 @@ final class MessageExporter {
         var count = 0
         for chat in chats {
             try onProgress?(count, chats.count, chat.title)
-            let safeName = chat.title
-                .replacingOccurrences(of: "/", with: "-")
-                .replacingOccurrences(of: ":", with: "-")
-                .prefix(50)
-            let filename = "\(safeName).\(format.fileExtension)"
-            let path = (directory as NSString).appendingPathComponent(String(filename))
+            let filename = exportFilename(for: chat, format: format)
+            let path = (directory as NSString).appendingPathComponent(filename)
             try exportChat(chatId: chat.id, format: format, to: path, options: options)
             count += 1
         }
@@ -518,6 +514,14 @@ final class MessageExporter {
     }
 
     // MARK: - Private Export Implementations
+
+    private func exportFilename(for chat: MessageChat, format: MessageExportFormat) -> String {
+        let safeName = chat.title
+            .replacingOccurrences(of: "/", with: "-")
+            .replacingOccurrences(of: ":", with: "-")
+            .prefix(50)
+        return "\(safeName)-chat-\(chat.id).\(format.fileExtension)"
+    }
 
     private func exportCSV(messages: [Message], chatTitle: String, to path: String) throws {
         let outputURL = URL(fileURLWithPath: path)
@@ -621,7 +625,14 @@ final class MessageExporter {
         return map
     }
 
+    private func removeAttachmentFolder(forHTMLPath htmlPath: String) {
+        let baseName = (htmlPath as NSString).deletingPathExtension
+        let dir = "\(baseName)_attachments"
+        try? FileManager.default.removeItem(atPath: dir)
+    }
+
     private func exportHTML(messages: [Message], chatTitle: String, to path: String, includeAttachments: Bool = true) throws {
+        removeAttachmentFolder(forHTMLPath: path)
         let attachmentMap = includeAttachments ? stageAttachments(messages: messages, htmlPath: path) : [:]
         let outputURL = URL(fileURLWithPath: path)
         try? FileManager.default.removeItem(at: outputURL)

--- a/Sources/Phosphor/Utilities/PyMobileDevice.swift
+++ b/Sources/Phosphor/Utilities/PyMobileDevice.swift
@@ -228,6 +228,27 @@ enum PyMobileDevice {
     struct DeviceEntry {
         let udid: String
         let connectionType: String // "USB" or "Network"
+        let discoveryMethod: String
+        let discoveryInfo: [String: String]
+
+        init(
+            udid: String,
+            connectionType: String,
+            discoveryMethod: String = "usbmux",
+            discoveryInfo: [String: String] = [:]
+        ) {
+            self.udid = udid
+            self.connectionType = connectionType
+            self.discoveryMethod = discoveryMethod
+            self.discoveryInfo = discoveryInfo
+        }
+    }
+
+    struct BonjourDevice: Hashable {
+        let id: String
+        let name: String
+        let host: String?
+        let serviceName: String
     }
 
     /// List connected devices with connection type (USB vs Network/Wi-Fi).
@@ -253,8 +274,13 @@ enum PyMobileDevice {
 
         if entries.isEmpty {
             let fallback = await runAsync(["usbmux", "list"])
-            guard fallback.succeeded else { return [] }
-            entries = parseUsbmuxDeviceEntries(from: fallback.output, defaultConnectionType: "USB")
+            if fallback.succeeded {
+                entries = parseUsbmuxDeviceEntries(from: fallback.output, defaultConnectionType: "USB")
+            }
+        }
+
+        if entries.isEmpty {
+            entries = await listMobdev2DeviceEntries()
         }
 
         return mergeDeviceEntries(entries)
@@ -263,8 +289,60 @@ enum PyMobileDevice {
     /// List devices currently reachable over network/Wi-Fi with connection metadata.
     static func listNetworkDeviceEntries() async -> [DeviceEntry] {
         let result = await runAsync(["usbmux", "list", "--network"], timeout: 10)
+        let entries = result.succeeded
+            ? parseUsbmuxDeviceEntries(from: result.output, defaultConnectionType: "Network")
+            : []
+        return entries.isEmpty ? await listMobdev2DeviceEntries() : entries
+    }
+
+    /// List devices advertised by pymobiledevice3's mobdev2 Bonjour backend.
+    ///
+    /// This is the closest CLI path to Finder's wireless discovery on current
+    /// iOS/macOS releases. Unlike raw dns-sd TXT identifiers, mobdev2 returns
+    /// the real `UniqueDeviceID`, so Phosphor can present the device and try
+    /// pymobiledevice3 operations with `--mobdev2`.
+    static func listMobdev2DeviceEntries() async -> [DeviceEntry] {
+        let result = await runAsync(["bonjour", "mobdev2", "--timeout", "3"], timeout: 6)
         guard result.succeeded else { return [] }
-        return parseUsbmuxDeviceEntries(from: result.output, defaultConnectionType: "Network")
+        return parseMobdev2DeviceEntries(from: result.output)
+    }
+
+    /// List iOS devices advertised through Apple's Bonjour MobileDevice service.
+    ///
+    /// Finder can show a wirelessly paired device through this path even when
+    /// usbmux/lockdown tools cannot open a backup-capable connection yet. These
+    /// entries are discovery hints only; callers should not treat them as backup
+    /// targets because the Bonjour TXT identifier is not the device UDID.
+    static func listBonjourMobileDevices(timeout: TimeInterval = 3) async -> [BonjourDevice] {
+        let browse = await Shell.runAsync(
+            "/usr/bin/dns-sd",
+            arguments: ["-B", "_apple-mobdev2._tcp", "local"],
+            timeout: timeout
+        )
+        let serviceNames = parseBonjourBrowseOutput(browse.stdout)
+        guard !serviceNames.isEmpty else { return [] }
+
+        var devices: [BonjourDevice] = []
+        var seenIds: Set<String> = []
+        for serviceName in serviceNames {
+            let resolve = await Shell.runAsync(
+                "/usr/bin/dns-sd",
+                arguments: ["-L", serviceName, "_apple-mobdev2._tcp", "local"],
+                timeout: timeout
+            )
+            let host = parseBonjourHost(from: resolve.stdout)
+            let identifier = parseBonjourIdentifier(from: resolve.stdout)
+            let id = identifier ?? host ?? serviceName
+            guard seenIds.insert(id).inserted else { continue }
+            devices.append(BonjourDevice(
+                id: id,
+                name: displayName(forBonjourHost: host) ?? "Wireless iPhone/iPad",
+                host: host,
+                serviceName: serviceName
+            ))
+        }
+
+        return devices
     }
 
     private static func parseUsbmuxDeviceEntries(
@@ -301,6 +379,38 @@ enum PyMobileDevice {
             .map { DeviceEntry(udid: $0, connectionType: defaultConnectionType) }
     }
 
+    private static func parseMobdev2DeviceEntries(from output: String) -> [DeviceEntry] {
+        guard let data = output.data(using: .utf8),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [[String: Any]] else {
+            return []
+        }
+
+        var byUdid: [String: DeviceEntry] = [:]
+        var orderedUdids: [String] = []
+        for entry in json {
+            guard let udid = entry["UniqueDeviceID"] as? String else { continue }
+            if byUdid[udid] == nil { orderedUdids.append(udid) }
+
+            var info: [String: String] = [:]
+            for (key, value) in entry {
+                if let string = value as? String {
+                    info[key] = string
+                } else if let number = value as? NSNumber {
+                    info[key] = "\(number)"
+                }
+            }
+
+            byUdid[udid] = DeviceEntry(
+                udid: udid,
+                connectionType: "Network",
+                discoveryMethod: "mobdev2",
+                discoveryInfo: info
+            )
+        }
+
+        return orderedUdids.compactMap { byUdid[$0] }
+    }
+
     private static func mergeDeviceEntries(_ entries: [DeviceEntry]) -> [DeviceEntry] {
         var byUdid: [String: DeviceEntry] = [:]
         var orderedUdids: [String] = []
@@ -315,6 +425,50 @@ enum PyMobileDevice {
         }
 
         return orderedUdids.compactMap { byUdid[$0] }
+    }
+
+    private static func parseBonjourBrowseOutput(_ output: String) -> [String] {
+        var serviceNames: [String] = []
+        var seen: Set<String> = []
+
+        for line in output.components(separatedBy: "\n") {
+            guard line.contains(" Add "),
+                  let range = line.range(of: "_apple-mobdev2._tcp.") else { continue }
+            let name = String(line[range.upperBound...]).trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !name.isEmpty, seen.insert(name).inserted else { continue }
+            serviceNames.append(name)
+        }
+
+        return serviceNames
+    }
+
+    private static func parseBonjourHost(from output: String) -> String? {
+        for line in output.components(separatedBy: "\n") where line.contains(" can be reached at ") {
+            guard let start = line.range(of: " can be reached at ")?.upperBound else { continue }
+            let suffix = line[start...]
+            guard let end = suffix.range(of: ":")?.lowerBound else { continue }
+            let host = String(suffix[..<end]).trimmingCharacters(in: .whitespacesAndNewlines)
+            if !host.isEmpty { return host }
+        }
+        return nil
+    }
+
+    private static func parseBonjourIdentifier(from output: String) -> String? {
+        for token in output.components(separatedBy: .whitespacesAndNewlines) {
+            guard token.hasPrefix("identifier=") else { continue }
+            let id = String(token.dropFirst("identifier=".count)).trimmingCharacters(in: .whitespacesAndNewlines)
+            if !id.isEmpty { return id }
+        }
+        return nil
+    }
+
+    private static func displayName(forBonjourHost host: String?) -> String? {
+        guard var name = host?.trimmingCharacters(in: .whitespacesAndNewlines), !name.isEmpty else { return nil }
+        if name.hasSuffix(".") { name.removeLast() }
+        if name.hasSuffix(".local") {
+            name = String(name.dropLast(".local".count))
+        }
+        return name.replacingOccurrences(of: "\\032", with: " ")
     }
 
     // MARK: - Device Info
@@ -561,12 +715,14 @@ enum PyMobileDevice {
         directory: String,
         udid: String? = nil,
         full: Bool = true,
+        preferNetwork: Bool = false,
         onOutput: @escaping (String) -> Void,
         onError: @escaping (String) -> Void = { _ in },
         completion: @escaping (Int32) -> Void
     ) -> Process? {
         var args = ["backup2", "backup"]
         if full { args.append("--full") }
+        if preferNetwork { args.append("--mobdev2") }
         if let udid { args += ["--udid", udid] }
         args.append(directory)
 

--- a/Sources/Phosphor/Utilities/PyMobileDevice.swift
+++ b/Sources/Phosphor/Utilities/PyMobileDevice.swift
@@ -229,7 +229,7 @@ enum PyMobileDevice {
         let udid: String
         let connectionType: String // "USB" or "Network"
         let discoveryMethod: String
-        let discoveryInfo: [String: String]
+        var discoveryInfo: [String: String]
 
         init(
             udid: String,
@@ -279,28 +279,24 @@ enum PyMobileDevice {
             }
         }
 
-        if entries.isEmpty {
-            entries = await listMobdev2DeviceEntries()
-        }
-
         return mergeDeviceEntries(entries)
     }
 
     /// List devices currently reachable over network/Wi-Fi with connection metadata.
     static func listNetworkDeviceEntries() async -> [DeviceEntry] {
         let result = await runAsync(["usbmux", "list", "--network"], timeout: 10)
-        let entries = result.succeeded
-            ? parseUsbmuxDeviceEntries(from: result.output, defaultConnectionType: "Network")
-            : []
-        return entries.isEmpty ? await listMobdev2DeviceEntries() : entries
+        guard result.succeeded else { return [] }
+        return parseUsbmuxDeviceEntries(from: result.output, defaultConnectionType: "Network")
     }
 
     /// List devices advertised by pymobiledevice3's mobdev2 Bonjour backend.
     ///
     /// This is the closest CLI path to Finder's wireless discovery on current
     /// iOS/macOS releases. Unlike raw dns-sd TXT identifiers, mobdev2 returns
-    /// the real `UniqueDeviceID`, so Phosphor can present the device and try
-    /// pymobiledevice3 operations with `--mobdev2`.
+    /// the real `UniqueDeviceID`, but it is still a discovery hint: current
+    /// pymobiledevice3 backup commands may prompt when the same device is
+    /// advertised on several addresses, which is unsafe in Phosphor's non-TTY
+    /// process runner.
     static func listMobdev2DeviceEntries() async -> [DeviceEntry] {
         let result = await runAsync(["bonjour", "mobdev2", "--timeout", "3"], timeout: 6)
         guard result.succeeded else { return [] }
@@ -314,6 +310,18 @@ enum PyMobileDevice {
     /// entries are discovery hints only; callers should not treat them as backup
     /// targets because the Bonjour TXT identifier is not the device UDID.
     static func listBonjourMobileDevices(timeout: TimeInterval = 3) async -> [BonjourDevice] {
+        let mobdev2Devices = await listMobdev2DeviceEntries()
+        if !mobdev2Devices.isEmpty {
+            return mobdev2Devices.map { entry in
+                BonjourDevice(
+                    id: entry.udid,
+                    name: entry.discoveryInfo["DeviceName"] ?? "Wireless iPhone/iPad",
+                    host: entry.discoveryInfo["ip"] ?? entry.discoveryInfo["Identifier"],
+                    serviceName: "mobdev2"
+                )
+            }
+        }
+
         let browse = await Shell.runAsync(
             "/usr/bin/dns-sd",
             arguments: ["-B", "_apple-mobdev2._tcp", "local"],
@@ -389,8 +397,6 @@ enum PyMobileDevice {
         var orderedUdids: [String] = []
         for entry in json {
             guard let udid = entry["UniqueDeviceID"] as? String else { continue }
-            if byUdid[udid] == nil { orderedUdids.append(udid) }
-
             var info: [String: String] = [:]
             for (key, value) in entry {
                 if let string = value as? String {
@@ -399,6 +405,16 @@ enum PyMobileDevice {
                     info[key] = "\(number)"
                 }
             }
+
+            if var existing = byUdid[udid] {
+                for (key, value) in info where existing.discoveryInfo[key] == nil {
+                    existing.discoveryInfo[key] = value
+                }
+                byUdid[udid] = existing
+                continue
+            }
+
+            orderedUdids.append(udid)
 
             byUdid[udid] = DeviceEntry(
                 udid: udid,
@@ -722,7 +738,11 @@ enum PyMobileDevice {
     ) -> Process? {
         var args = ["backup2", "backup"]
         if full { args.append("--full") }
-        if preferNetwork { args.append("--mobdev2") }
+        // `--mobdev2` can prompt when the same wireless device is advertised on
+        // multiple addresses, which crashes in Phosphor's non-interactive
+        // Process runner. For Wi-Fi backups, let the libimobiledevice fallback
+        // use `idevicebackup2 -n` instead of invoking an interactive CLI path.
+        _ = preferNetwork
         if let udid { args += ["--udid", udid] }
         args.append(directory)
 

--- a/Sources/Phosphor/Utilities/Shell.swift
+++ b/Sources/Phosphor/Utilities/Shell.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Darwin
 
 /// Runs shell commands and captures output. Core utility for all libimobiledevice interactions.
 enum Shell {
@@ -10,6 +11,53 @@ enum Shell {
 
         var succeeded: Bool { exitCode == 0 }
         var output: String { stdout.trimmingCharacters(in: .whitespacesAndNewlines) }
+    }
+
+    private final class AsyncCommandState: @unchecked Sendable {
+        private let lock = NSLock()
+        private var stdoutData = Data()
+        private var stderrData = Data()
+        private var didFinish = false
+
+        func append(_ data: Data, toStdout: Bool) {
+            guard !data.isEmpty else { return }
+            lock.lock()
+            if toStdout {
+                stdoutData.append(data)
+            } else {
+                stderrData.append(data)
+            }
+            lock.unlock()
+        }
+
+        func hasFinished() -> Bool {
+            lock.lock()
+            let value = didFinish
+            lock.unlock()
+            return value
+        }
+
+        func finish(timedOut: Bool, timeout: TimeInterval, exitCode: Int32) -> Result? {
+            lock.lock()
+            guard !didFinish else {
+                lock.unlock()
+                return nil
+            }
+            didFinish = true
+            let stdout = stdoutData
+            var stderr = String(data: stderrData, encoding: .utf8) ?? ""
+            if timedOut {
+                let timeoutMessage = "Command timed out after \(Int(timeout))s"
+                stderr = stderr.isEmpty ? timeoutMessage : stderr + "\n" + timeoutMessage
+            }
+            lock.unlock()
+
+            return Result(
+                exitCode: timedOut ? -2 : exitCode,
+                stdout: String(data: stdout, encoding: .utf8) ?? "",
+                stderr: stderr
+            )
+        }
     }
 
     private static func environmentWithToolPaths() -> [String: String] {
@@ -37,17 +85,27 @@ enum Shell {
         process.standardError = stderrPipe
         process.environment = environmentWithToolPaths()
 
-        do {
-            try process.run()
-        } catch {
-            return Result(exitCode: -1, stdout: "", stderr: "Failed to launch: \(error.localizedDescription)")
-        }
-
         let stdoutQueue = DispatchQueue(label: "com.phosphor.shell.stdout")
         let stderrQueue = DispatchQueue(label: "com.phosphor.shell.stderr")
         var stdoutData = Data()
         var stderrData = Data()
         let readGroup = DispatchGroup()
+        let waitSemaphore = DispatchSemaphore(value: 0)
+
+        // Use Process.terminationHandler rather than blocking a global dispatch
+        // worker on a synchronous process wait. Phosphor may run many short device CLI
+        // probes; tying up one worker per process can exhaust libdispatch's soft
+        // thread limit and leave the app running but unresponsive.
+        process.terminationHandler = { _ in
+            waitSemaphore.signal()
+        }
+
+        do {
+            try process.run()
+        } catch {
+            process.terminationHandler = nil
+            return Result(exitCode: -1, stdout: "", stderr: "Failed to launch: \(error.localizedDescription)")
+        }
 
         readGroup.enter()
         stdoutQueue.async {
@@ -61,20 +119,20 @@ enum Shell {
             readGroup.leave()
         }
 
-        let waitSemaphore = DispatchSemaphore(value: 0)
-        DispatchQueue.global(qos: .utility).async {
-            process.waitUntilExit()
-            waitSemaphore.signal()
-        }
-
         var timedOut = false
         if waitSemaphore.wait(timeout: .now() + timeout) == .timedOut {
             timedOut = true
             process.terminate()
             if waitSemaphore.wait(timeout: .now() + 2) == .timedOut {
                 process.interrupt()
+                if waitSemaphore.wait(timeout: .now() + 1) == .timedOut {
+                    Darwin.kill(process.processIdentifier, SIGKILL)
+                    _ = waitSemaphore.wait(timeout: .now() + 1)
+                }
             }
         }
+
+        process.terminationHandler = nil
 
         _ = readGroup.wait(timeout: .now() + 2)
 
@@ -94,9 +152,77 @@ enum Shell {
     /// Run a command asynchronously.
     static func runAsync(_ command: String, arguments: [String] = [], timeout: TimeInterval = 300) async -> Result {
         await withCheckedContinuation { continuation in
-            DispatchQueue.global(qos: .userInitiated).async {
-                let result = run(command, arguments: arguments, timeout: timeout)
+            let process = Process()
+            let stdoutPipe = Pipe()
+            let stderrPipe = Pipe()
+            let state = AsyncCommandState()
+
+            process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+            process.arguments = [command] + arguments
+            process.standardOutput = stdoutPipe
+            process.standardError = stderrPipe
+            process.environment = environmentWithToolPaths()
+
+            @Sendable func finish(timedOut: Bool) {
+                stdoutPipe.fileHandleForReading.readabilityHandler = nil
+                stderrPipe.fileHandleForReading.readabilityHandler = nil
+                state.append(stdoutPipe.fileHandleForReading.availableData, toStdout: true)
+                state.append(stderrPipe.fileHandleForReading.availableData, toStdout: false)
+
+                guard let result = state.finish(
+                    timedOut: timedOut,
+                    timeout: timeout,
+                    exitCode: process.terminationStatus
+                ) else {
+                    return
+                }
+
+                process.terminationHandler = nil
                 continuation.resume(returning: result)
+            }
+
+            stdoutPipe.fileHandleForReading.readabilityHandler = { handle in
+                state.append(handle.availableData, toStdout: true)
+            }
+
+            stderrPipe.fileHandleForReading.readabilityHandler = { handle in
+                state.append(handle.availableData, toStdout: false)
+            }
+
+            process.terminationHandler = { _ in
+                finish(timedOut: false)
+            }
+
+            do {
+                try process.run()
+            } catch {
+                process.terminationHandler = nil
+                stdoutPipe.fileHandleForReading.readabilityHandler = nil
+                stderrPipe.fileHandleForReading.readabilityHandler = nil
+                continuation.resume(returning: Result(
+                    exitCode: -1,
+                    stdout: "",
+                    stderr: "Failed to launch: \(error.localizedDescription)"
+                ))
+                return
+            }
+
+            Task {
+                let nanoseconds = UInt64(max(timeout, 0) * 1_000_000_000)
+                try? await Task.sleep(nanoseconds: nanoseconds)
+                guard !state.hasFinished() else { return }
+
+                process.terminate()
+                try? await Task.sleep(nanoseconds: 2_000_000_000)
+                guard !state.hasFinished() else { return }
+
+                process.interrupt()
+                try? await Task.sleep(nanoseconds: 1_000_000_000)
+                guard !state.hasFinished() else { return }
+
+                Darwin.kill(process.processIdentifier, SIGKILL)
+                try? await Task.sleep(nanoseconds: 1_000_000_000)
+                finish(timedOut: true)
             }
         }
     }

--- a/Sources/Phosphor/Utilities/Shell.swift
+++ b/Sources/Phosphor/Utilities/Shell.swift
@@ -18,6 +18,19 @@ enum Shell {
         private var stdoutData = Data()
         private var stderrData = Data()
         private var didFinish = false
+        private var watchdog: Task<Void, Never>?
+
+        /// Hand the timeout watchdog to the state so it can be cancelled the moment the
+        /// command finishes. Without this the watchdog sleeps the full timeout (default
+        /// 300s) after the process already exited, holding the pipe file descriptors open
+        /// the whole time — under Phosphor's frequent device probes that leaks fds.
+        func attachWatchdog(_ task: Task<Void, Never>) {
+            lock.lock()
+            let alreadyFinished = didFinish
+            if !alreadyFinished { watchdog = task }
+            lock.unlock()
+            if alreadyFinished { task.cancel() }
+        }
 
         func append(_ data: Data, toStdout: Bool) {
             guard !data.isEmpty else { return }
@@ -44,6 +57,8 @@ enum Shell {
                 return nil
             }
             didFinish = true
+            let pendingWatchdog = watchdog
+            watchdog = nil
             let stdout = stdoutData
             var stderr = String(data: stderrData, encoding: .utf8) ?? ""
             if timedOut {
@@ -51,6 +66,9 @@ enum Shell {
                 stderr = stderr.isEmpty ? timeoutMessage : stderr + "\n" + timeoutMessage
             }
             lock.unlock()
+
+            // Free the watchdog's captured Process/pipe references immediately.
+            pendingWatchdog?.cancel()
 
             return Result(
                 exitCode: timedOut ? -2 : exitCode,
@@ -169,10 +187,13 @@ enum Shell {
                 state.append(stdoutPipe.fileHandleForReading.availableData, toStdout: true)
                 state.append(stderrPipe.fileHandleForReading.availableData, toStdout: false)
 
+                // On the timed-out path the process may not be reaped yet; reading
+                // terminationStatus while it is still running throws. state.finish
+                // ignores the exit code for timeouts, so pass a placeholder there.
                 guard let result = state.finish(
                     timedOut: timedOut,
                     timeout: timeout,
-                    exitCode: process.terminationStatus
+                    exitCode: timedOut ? -1 : process.terminationStatus
                 ) else {
                     return
                 }
@@ -207,23 +228,24 @@ enum Shell {
                 return
             }
 
-            Task {
+            let watchdogTask = Task {
                 let nanoseconds = UInt64(max(timeout, 0) * 1_000_000_000)
                 try? await Task.sleep(nanoseconds: nanoseconds)
-                guard !state.hasFinished() else { return }
+                guard !Task.isCancelled, !state.hasFinished() else { return }
 
                 process.terminate()
                 try? await Task.sleep(nanoseconds: 2_000_000_000)
-                guard !state.hasFinished() else { return }
+                guard !Task.isCancelled, !state.hasFinished() else { return }
 
                 process.interrupt()
                 try? await Task.sleep(nanoseconds: 1_000_000_000)
-                guard !state.hasFinished() else { return }
+                guard !Task.isCancelled, !state.hasFinished() else { return }
 
                 Darwin.kill(process.processIdentifier, SIGKILL)
                 try? await Task.sleep(nanoseconds: 1_000_000_000)
                 finish(timedOut: true)
             }
+            state.attachWatchdog(watchdogTask)
         }
     }
 

--- a/Sources/Phosphor/ViewModels/BackupViewModel.swift
+++ b/Sources/Phosphor/ViewModels/BackupViewModel.swift
@@ -11,6 +11,7 @@ final class BackupViewModel: ObservableObject {
     @Published var progressText = ""
     @Published var showAlert = false
     @Published var alertMessage = ""
+    @Published var backupIssue: BackupManager.BackupFailure?
     @Published var loadError: String?
 
     // Browser state
@@ -23,6 +24,13 @@ final class BackupViewModel: ObservableObject {
     let backupManager = BackupManager()
     private var currentManifest: BackupManifest?
     private var sizeResolutionTask: Task<Void, Never>?
+    private var lastBackupRequest: BackupRequest?
+
+    private struct BackupRequest {
+        let udid: String
+        let incremental: Bool
+        let preferNetwork: Bool
+    }
 
     func loadBackups() {
         sizeResolutionTask?.cancel()
@@ -81,6 +89,7 @@ final class BackupViewModel: ObservableObject {
     }
 
     func createBackup(udid: String, incremental: Bool = false, preferNetwork: Bool = false) async {
+        lastBackupRequest = BackupRequest(udid: udid, incremental: incremental, preferNetwork: preferNetwork)
         isCreating = true
         progressText = "Preparing..."
 
@@ -96,9 +105,38 @@ final class BackupViewModel: ObservableObject {
         }
 
         isCreating = false
-        alertMessage = success ? "Backup completed" : (backupManager.lastError ?? "Backup failed")
-        showAlert = true
-        if success { loadBackups() }
+        if success {
+            alertMessage = "Backup completed"
+            showAlert = true
+            loadBackups()
+        } else if let failure = backupManager.lastBackupFailure {
+            backupIssue = failure
+        } else {
+            alertMessage = backupManager.lastError ?? "Backup failed"
+            showAlert = true
+        }
+    }
+
+    func deleteIncompleteBackupAndRunFull(udid: String, preferNetwork: Bool) async {
+        do {
+            try BackupManager.deleteIncompleteBackup(for: udid)
+            backupIssue = nil
+            loadBackups()
+            await createBackup(udid: udid, incremental: false, preferNetwork: preferNetwork)
+        } catch {
+            backupIssue = BackupManager.BackupFailure(
+                title: "Could Not Delete Incomplete Backup",
+                message: "Phosphor could not remove the incomplete backup folder. Choose another backup folder or delete it manually, then try a full backup again.",
+                technicalDetails: error.localizedDescription,
+                recoveryAction: .openBackupSettings
+            )
+        }
+    }
+
+    func retryLastBackup() async {
+        guard let request = lastBackupRequest else { return }
+        backupIssue = nil
+        await createBackup(udid: request.udid, incremental: request.incremental, preferNetwork: request.preferNetwork)
     }
 
     // MARK: - Browsing

--- a/Sources/Phosphor/ViewModels/BackupViewModel.swift
+++ b/Sources/Phosphor/ViewModels/BackupViewModel.swift
@@ -141,8 +141,18 @@ final class BackupViewModel: ObservableObject {
 
     // MARK: - Browsing
 
+    private func clearBrowserState() {
+        selectedBackup = nil
+        currentManifest = nil
+        browserDomains = []
+        browserFiles = []
+        currentDomain = nil
+        searchQuery = ""
+        searchResults = []
+    }
+
     func openBackupBrowser(_ backup: BackupInfo) {
-        selectedBackup = backup
+        clearBrowserState()
         currentManifest = backupManager.openManifest(for: backup)
 
         guard let manifest = currentManifest else {
@@ -154,7 +164,9 @@ final class BackupViewModel: ObservableObject {
 
         do {
             browserDomains = try manifest.domains()
+            selectedBackup = backup
         } catch {
+            clearBrowserState()
             alertMessage = "Failed to read backup: \(error.localizedDescription)"
             showAlert = true
         }

--- a/Sources/Phosphor/ViewModels/BackupViewModel.swift
+++ b/Sources/Phosphor/ViewModels/BackupViewModel.swift
@@ -117,18 +117,51 @@ final class BackupViewModel: ObservableObject {
         }
     }
 
-    func deleteIncompleteBackupAndRunFull(udid: String, preferNetwork: Bool) async {
+    private func recoveryUdid(for issue: BackupManager.BackupFailure) -> String? {
+        issue.udid ?? lastBackupRequest?.udid
+    }
+
+    private func recoveryPrefersNetwork(for udid: String) -> Bool {
+        lastBackupRequest?.udid == udid ? (lastBackupRequest?.preferNetwork ?? false) : false
+    }
+
+    func runFullBackup(for issue: BackupManager.BackupFailure) async {
+        guard let udid = recoveryUdid(for: issue) else {
+            backupIssue = BackupManager.BackupFailure(
+                title: "Could Not Start Full Backup",
+                message: "Phosphor could not identify which device needs the full backup. Re-select the device and start a full backup manually.",
+                technicalDetails: issue.technicalDetails,
+                recoveryAction: nil
+            )
+            return
+        }
+        backupIssue = nil
+        await createBackup(udid: udid, incremental: false, preferNetwork: recoveryPrefersNetwork(for: udid))
+    }
+
+    func deleteIncompleteBackupAndRunFull(for issue: BackupManager.BackupFailure) async {
+        guard let udid = recoveryUdid(for: issue), let path = issue.recoveryPath else {
+            backupIssue = BackupManager.BackupFailure(
+                title: "Could Not Move Incomplete Backup",
+                message: "Phosphor could not identify the incomplete backup folder. Delete it manually or choose another backup folder, then run a full backup again.",
+                technicalDetails: issue.technicalDetails,
+                recoveryAction: .openBackupSettings
+            )
+            return
+        }
         do {
-            try BackupManager.deleteIncompleteBackup(for: udid)
+            try BackupManager.deleteIncompleteBackup(for: udid, expectedPath: path)
             backupIssue = nil
             loadBackups()
-            await createBackup(udid: udid, incremental: false, preferNetwork: preferNetwork)
+            await createBackup(udid: udid, incremental: false, preferNetwork: recoveryPrefersNetwork(for: udid))
         } catch {
             backupIssue = BackupManager.BackupFailure(
-                title: "Could Not Delete Incomplete Backup",
-                message: "Phosphor could not remove the incomplete backup folder. Choose another backup folder or delete it manually, then try a full backup again.",
+                title: "Could Not Move Incomplete Backup",
+                message: "Phosphor could not move the incomplete backup folder to Trash. Choose another backup folder or move it manually, then try a full backup again.",
                 technicalDetails: error.localizedDescription,
-                recoveryAction: .openBackupSettings
+                recoveryAction: .openBackupSettings,
+                udid: udid,
+                recoveryPath: path
             )
         }
     }

--- a/Sources/Phosphor/ViewModels/BackupViewModel.swift
+++ b/Sources/Phosphor/ViewModels/BackupViewModel.swift
@@ -37,7 +37,16 @@ final class BackupViewModel: ObservableObject {
         backupManager.discoverBackups()
         backups = backupManager.backups
         loadError = backupManager.lastError
+        reconcileSelectedBackupAfterReload()
         resolveBackupSizesInBackground(for: backups)
+    }
+
+    private func reconcileSelectedBackupAfterReload() {
+        guard let selectedBackup else { return }
+        guard backups.contains(where: { $0.id == selectedBackup.id && $0.path == selectedBackup.path }) else {
+            clearBrowserState()
+            return
+        }
     }
 
     private func resolveBackupSizesInBackground(for snapshot: [BackupInfo]) {
@@ -184,7 +193,8 @@ final class BackupViewModel: ObservableObject {
         searchResults = []
     }
 
-    func openBackupBrowser(_ backup: BackupInfo) {
+    @discardableResult
+    func openBackupBrowser(_ backup: BackupInfo) -> Bool {
         clearBrowserState()
         currentManifest = backupManager.openManifest(for: backup)
 
@@ -192,16 +202,18 @@ final class BackupViewModel: ObservableObject {
             // openManifest swallows the error into backupManager.lastError; surface it.
             alertMessage = backupManager.lastError ?? "Failed to open backup."
             showAlert = true
-            return
+            return false
         }
 
         do {
             browserDomains = try manifest.domains()
             selectedBackup = backup
+            return true
         } catch {
             clearBrowserState()
             alertMessage = "Failed to read backup: \(error.localizedDescription)"
             showAlert = true
+            return false
         }
     }
 

--- a/Sources/Phosphor/ViewModels/DeviceViewModel.swift
+++ b/Sources/Phosphor/ViewModels/DeviceViewModel.swift
@@ -7,6 +7,7 @@ import Combine
 final class DeviceViewModel: ObservableObject {
 
     @Published var devices: [DeviceInfo] = []
+    @Published var nearbyWirelessDevices: [PyMobileDevice.BonjourDevice] = []
     @Published var selectedDevice: DeviceInfo?
     @Published var isRefreshing = false
     @Published var showPairAlert = false
@@ -23,6 +24,12 @@ final class DeviceViewModel: ObservableObject {
             }
             .store(in: &cancellables)
 
+        deviceManager.$nearbyWirelessDevices
+            .sink { [weak self] devices in
+                self?.nearbyWirelessDevices = devices
+            }
+            .store(in: &cancellables)
+
         deviceManager.$selectedDevice
             .sink { [weak self] device in
                 self?.selectedDevice = device
@@ -36,6 +43,7 @@ final class DeviceViewModel: ObservableObject {
         isRefreshing = true
         await deviceManager.scanForDevices(forceRefresh: true)
         devices = deviceManager.connectedDevices
+        nearbyWirelessDevices = deviceManager.nearbyWirelessDevices
         selectedDevice = deviceManager.selectedDevice
         isRefreshing = false
     }

--- a/Sources/Phosphor/Views/Backup/BackupBrowserView.swift
+++ b/Sources/Phosphor/Views/Backup/BackupBrowserView.swift
@@ -72,6 +72,13 @@ struct BackupBrowserView: View {
         .onChange(of: searchText) { _, newValue in
             backupVM.searchBackup(newValue)
         }
+        .onChange(of: backupVM.selectedBackup?.id) { _, _ in
+            selectedFiles.removeAll()
+            searchText = ""
+        }
+        .onChange(of: backupVM.currentDomain) { _, _ in
+            selectedFiles.removeAll()
+        }
         .onChange(of: showExportSheet) { _, show in
             guard show else { return }
             showExportSheet = false

--- a/Sources/Phosphor/Views/Backup/BackupListView.swift
+++ b/Sources/Phosphor/Views/Backup/BackupListView.swift
@@ -262,7 +262,7 @@ struct BackupListView: View {
     }
 
     private func shouldOfferIncremental(for device: DeviceInfo) -> Bool {
-        backupVM.backups.contains { backup in
+        BackupManager.hasExistingBackup(for: device.id) && backupVM.backups.contains { backup in
             backup.udid == device.id || backup.id == device.id
         }
     }
@@ -640,8 +640,13 @@ struct BackupScheduleSheet: View {
                             .frame(width: 100)
                         }
 
-                        Toggle("Wi-Fi only (skip if USB not available)", isOn: $scheduler.schedule.wifiOnly)
+                        Toggle("Wi-Fi only (skip if Wi-Fi is not available)", isOn: $scheduler.schedule.wifiOnly)
                         Toggle("Incremental only (faster)", isOn: $scheduler.schedule.incrementalOnly)
+                        if scheduler.schedule.incrementalOnly {
+                            Text("The first scheduled run will create the required full backup if this device does not already have complete backup metadata.")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                        }
                     }
                 }
 

--- a/Sources/Phosphor/Views/Backup/BackupListView.swift
+++ b/Sources/Phosphor/Views/Backup/BackupListView.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 /// Lists all discovered iOS backups with metadata. Allows creating new backups and managing existing ones.
@@ -43,6 +44,8 @@ struct BackupListView: View {
             .padding(20)
 
             Divider()
+
+            backupStateNotice
 
             if backupVM.isCreating {
                 backupProgressView
@@ -94,6 +97,14 @@ struct BackupListView: View {
         } message: {
             Text(backupVM.alertMessage)
         }
+        .sheet(item: $backupVM.backupIssue) { issue in
+            BackupIssueSheet(
+                issue: issue,
+                primaryActionTitle: backupIssueActionTitle(for: issue),
+                primaryAction: { handleBackupIssueAction(issue.recoveryAction) },
+                dismiss: { backupVM.backupIssue = nil }
+            )
+        }
         .alert("Full Wi-Fi Backup?", isPresented: $showFullWiFiBackupConfirm) {
             Button("Run Full Wi-Fi Backup") {
                 if let udid = pendingFullWiFiBackupUDID {
@@ -108,7 +119,7 @@ struct BackupListView: View {
                 pendingFullWiFiBackupPrefersNetwork = false
             }
         } message: {
-            Text("This device is connected over Wi-Fi. Full backups can be much slower and more sensitive to sleep/lock/network interruptions. Incremental Wi-Fi Backup is recommended unless you specifically need a full backup.")
+            Text(fullWiFiBackupConfirmationMessage)
         }
         .sheet(isPresented: $showScheduleSheet) {
             BackupScheduleSheet()
@@ -145,6 +156,44 @@ struct BackupListView: View {
         } label: {
             Label("New Backup", systemImage: "plus")
         }
+    }
+
+
+    @ViewBuilder
+    private var backupStateNotice: some View {
+        if let device = deviceVM.selectedDevice {
+            let state = backupState(for: device)
+            BackupStateNotice(title: state.title, detail: state.detail, icon: state.icon, tint: state.tint)
+                .padding(.horizontal, 20)
+                .padding(.top, 12)
+        }
+    }
+
+    private func backupState(for device: DeviceInfo) -> (title: String, detail: String, icon: String, tint: Color) {
+        let hasCompleteBackup = shouldOfferIncremental(for: device)
+        if device.connectionType == .wifi {
+            if hasCompleteBackup {
+                return (
+                    "Wi-Fi backup ready",
+                    "Incremental Wi-Fi backups are available. Keep the device unlocked and on the same network while the backup runs.",
+                    "wifi",
+                    .blue
+                )
+            }
+            return (
+                "First backup must be full",
+                "USB is recommended for the first backup. Wi-Fi is supported, but it is slower and more sensitive to sleep, lock, and network interruptions.",
+                "externaldrive.badge.plus",
+                .orange
+            )
+        }
+
+        return (
+            hasCompleteBackup ? "USB backup ready" : "USB recommended for first backup",
+            hasCompleteBackup ? "USB is the fastest and most reliable way to refresh this backup." : "Create a full USB backup first. After that, incremental backups can update only changed files.",
+            "cable.connector",
+            .green
+        )
     }
 
     @ViewBuilder
@@ -202,9 +251,54 @@ struct BackupListView: View {
         return "Create Backup"
     }
 
+    private var fullWiFiBackupConfirmationMessage: String {
+        guard let device = deviceVM.selectedDevice else {
+            return "This device is connected over Wi-Fi. Full backups can be slower and more sensitive to interruptions."
+        }
+        if shouldOfferIncremental(for: device) {
+            return "This device is connected over Wi-Fi. Full backups can be much slower and more sensitive to sleep, lock, and network interruptions. Incremental Wi-Fi Backup is recommended unless you specifically need a full backup."
+        }
+        return "This is the first backup for this device, so it must be a full backup. USB is recommended for the first backup; Wi-Fi is supported but slower and more sensitive to sleep, lock, and network interruptions."
+    }
+
     private func shouldOfferIncremental(for device: DeviceInfo) -> Bool {
         backupVM.backups.contains { backup in
             backup.udid == device.id || backup.id == device.id
+        }
+    }
+
+
+    private func backupIssueActionTitle(for issue: BackupManager.BackupFailure) -> String? {
+        switch issue.recoveryAction {
+        case .runFullBackup:
+            return "Run Full Backup"
+        case .deleteIncompleteAndRunFull:
+            return "Delete Incomplete Backup & Run Full"
+        case .openBackupSettings:
+            return "Open Backup Settings"
+        case .retry:
+            return "Retry"
+        case .none:
+            return nil
+        }
+    }
+
+    private func handleBackupIssueAction(_ action: BackupManager.RecoveryAction?) {
+        switch action {
+        case .runFullBackup:
+            guard let device = deviceVM.selectedDevice else { return }
+            backupVM.backupIssue = nil
+            Task { await backupVM.createBackup(udid: device.id, incremental: false, preferNetwork: device.connectionType == .wifi) }
+        case .deleteIncompleteAndRunFull:
+            guard let device = deviceVM.selectedDevice else { return }
+            Task { await backupVM.deleteIncompleteBackupAndRunFull(udid: device.id, preferNetwork: device.connectionType == .wifi) }
+        case .openBackupSettings:
+            backupVM.backupIssue = nil
+            NSApp.sendAction(Selector(("showSettingsWindow:")), to: nil, from: nil)
+        case .retry:
+            Task { await backupVM.retryLastBackup() }
+        case .none:
+            backupVM.backupIssue = nil
         }
     }
 
@@ -285,6 +379,89 @@ struct BackupListView: View {
         .padding(.horizontal, 20)
         .padding(.vertical, 12)
         .background(Color.orange.opacity(0.08))
+    }
+}
+
+
+struct BackupStateNotice: View {
+    let title: String
+    let detail: String
+    let icon: String
+    let tint: Color
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 10) {
+            Image(systemName: icon)
+                .foregroundStyle(tint)
+                .font(.system(size: 16, weight: .semibold))
+                .frame(width: 20)
+
+            VStack(alignment: .leading, spacing: 3) {
+                Text(title)
+                    .font(.system(size: 13, weight: .semibold))
+                Text(detail)
+                    .font(.system(size: 12))
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+        }
+        .padding(12)
+        .background(tint.opacity(0.08))
+        .clipShape(RoundedRectangle(cornerRadius: 10))
+    }
+}
+
+struct BackupIssueSheet: View {
+    let issue: BackupManager.BackupFailure
+    let primaryActionTitle: String?
+    let primaryAction: () -> Void
+    let dismiss: () -> Void
+    @State private var showTechnicalDetails = false
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack(alignment: .top, spacing: 12) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundStyle(.orange)
+                    .font(.system(size: 24))
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(issue.title)
+                        .font(.title3.weight(.semibold))
+                    Text(issue.message)
+                        .foregroundStyle(.secondary)
+                        .textSelection(.enabled)
+                }
+            }
+
+            if let details = issue.technicalDetails, !details.isEmpty {
+                DisclosureGroup("Technical details", isExpanded: $showTechnicalDetails) {
+                    ScrollView {
+                        Text(details)
+                            .font(.system(.caption, design: .monospaced))
+                            .textSelection(.enabled)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(8)
+                    }
+                    .frame(minHeight: 90, maxHeight: 220)
+                    .background(Color.secondary.opacity(0.08))
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+                }
+            }
+
+            HStack {
+                Spacer()
+                Button("Cancel") { dismiss() }
+                if let primaryActionTitle {
+                    Button(primaryActionTitle, role: issue.recoveryAction == .deleteIncompleteAndRunFull ? .destructive : nil) {
+                        primaryAction()
+                    }
+                    .buttonStyle(.borderedProminent)
+                }
+            }
+        }
+        .padding(24)
+        .frame(width: 520)
     }
 }
 

--- a/Sources/Phosphor/Views/Backup/BackupListView.swift
+++ b/Sources/Phosphor/Views/Backup/BackupListView.swift
@@ -312,6 +312,7 @@ struct BackupListView: View {
             Task { await backupVM.runFullBackup(for: issue) }
         case .deleteIncompleteAndRunFull:
             pendingIncompleteBackupIssue = issue
+            backupVM.backupIssue = nil
             showIncompleteBackupTrashConfirm = true
         case .openBackupSettings:
             backupVM.backupIssue = nil
@@ -726,13 +727,9 @@ struct BackupScheduleSheet: View {
             }
             .formStyle(.grouped)
         }
-        .onChange(of: scheduler.schedule.enabled) { _, enabled in
-            if enabled {
-                scheduler.updateNextRunDate()
-                scheduler.startMonitoring()
-            } else {
-                scheduler.stopMonitoring()
-            }
-        }
+        .onChange(of: scheduler.schedule.enabled) { _, _ in scheduler.updateNextRunDate() }
+        .onChange(of: scheduler.schedule.frequency) { _, _ in scheduler.updateNextRunDate() }
+        .onChange(of: scheduler.schedule.preferredHour) { _, _ in scheduler.updateNextRunDate() }
+        .onChange(of: scheduler.schedule.preferredMinute) { _, _ in scheduler.updateNextRunDate() }
     }
 }

--- a/Sources/Phosphor/Views/Backup/BackupListView.swift
+++ b/Sources/Phosphor/Views/Backup/BackupListView.swift
@@ -59,9 +59,9 @@ struct BackupListView: View {
                     subtitle: "Back up your device, or pick an existing backup folder via New Backup -> Open Existing Backup Folder.",
                     action: {
                         guard let device = deviceVM.selectedDevice else { return }
-                        startBackup(for: device, incremental: device.connectionType == .wifi)
+                        startBackup(for: device, incremental: shouldOfferIncremental(for: device))
                     },
-                    actionLabel: deviceVM.selectedDevice?.connectionType == .wifi ? "Create Incremental Wi-Fi Backup" : (deviceVM.selectedDevice != nil ? "Create Backup" : nil)
+                    actionLabel: emptyStateBackupActionLabel
                 )
             } else {
                 List {
@@ -150,21 +150,31 @@ struct BackupListView: View {
     @ViewBuilder
     private var backupCreationButtons: some View {
         if deviceVM.selectedDevice?.connectionType == .wifi {
-            Button {
-                guard let device = deviceVM.selectedDevice else { return }
-                startBackup(for: device, incremental: true)
-            } label: {
-                Label("Incremental Wi-Fi Backup (Recommended)", systemImage: "wifi")
+            if let device = deviceVM.selectedDevice, shouldOfferIncremental(for: device) {
+                Button {
+                    startBackup(for: device, incremental: true)
+                } label: {
+                    Label("Incremental Wi-Fi Backup (Recommended)", systemImage: "wifi")
+                }
+                .disabled(deviceVM.selectedDevice == nil)
+            } else {
+                Button {
+                    guard let device = deviceVM.selectedDevice else { return }
+                    startBackup(for: device, incremental: false)
+                } label: {
+                    Label("First Wi-Fi Backup (Full)", systemImage: "externaldrive.badge.plus")
+                }
+                .disabled(deviceVM.selectedDevice == nil)
             }
-            .disabled(deviceVM.selectedDevice == nil)
 
-            Button {
-                guard let device = deviceVM.selectedDevice else { return }
-                startBackup(for: device, incremental: false)
-            } label: {
-                Label("Full Wi-Fi Backup (Slower)", systemImage: "externaldrive.badge.plus")
+            if let device = deviceVM.selectedDevice, shouldOfferIncremental(for: device) {
+                Button {
+                    startBackup(for: device, incremental: false)
+                } label: {
+                    Label("Full Wi-Fi Backup (Slower)", systemImage: "externaldrive.badge.plus")
+                }
+                .disabled(deviceVM.selectedDevice == nil)
             }
-            .disabled(deviceVM.selectedDevice == nil)
         } else {
             Button {
                 guard let device = deviceVM.selectedDevice else { return }
@@ -181,6 +191,20 @@ struct BackupListView: View {
                 Label("Incremental Backup", systemImage: "arrow.triangle.2.circlepath")
             }
             .disabled(deviceVM.selectedDevice == nil)
+        }
+    }
+
+    private var emptyStateBackupActionLabel: String? {
+        guard let device = deviceVM.selectedDevice else { return nil }
+        if device.connectionType == .wifi {
+            return shouldOfferIncremental(for: device) ? "Create Incremental Wi-Fi Backup" : "Create Full Wi-Fi Backup"
+        }
+        return "Create Backup"
+    }
+
+    private func shouldOfferIncremental(for device: DeviceInfo) -> Bool {
+        backupVM.backups.contains { backup in
+            backup.udid == device.id || backup.id == device.id
         }
     }
 

--- a/Sources/Phosphor/Views/Backup/BackupListView.swift
+++ b/Sources/Phosphor/Views/Backup/BackupListView.swift
@@ -6,6 +6,7 @@ struct BackupListView: View {
 
     @EnvironmentObject var deviceVM: DeviceViewModel
     @EnvironmentObject var backupVM: BackupViewModel
+    var onBrowseBackup: () -> Void = {}
     @State private var showDeleteConfirm = false
     @State private var backupToDelete: BackupInfo?
     @State private var showImportArchive = false
@@ -72,7 +73,9 @@ struct BackupListView: View {
                 List {
                     ForEach(backupVM.backups) { backup in
                         BackupRow(backup: backup) {
-                            backupVM.openBackupBrowser(backup)
+                            if backupVM.openBackupBrowser(backup) {
+                                onBrowseBackup()
+                            }
                         } onDelete: {
                             backupToDelete = backup
                             showDeleteConfirm = true

--- a/Sources/Phosphor/Views/Backup/BackupListView.swift
+++ b/Sources/Phosphor/Views/Backup/BackupListView.swift
@@ -15,6 +15,8 @@ struct BackupListView: View {
     @State private var showFullWiFiBackupConfirm = false
     @State private var pendingFullWiFiBackupUDID: String?
     @State private var pendingFullWiFiBackupPrefersNetwork = false
+    @State private var showIncompleteBackupTrashConfirm = false
+    @State private var pendingIncompleteBackupIssue: BackupManager.BackupFailure?
 
     var body: some View {
         VStack(spacing: 0) {
@@ -101,9 +103,22 @@ struct BackupListView: View {
             BackupIssueSheet(
                 issue: issue,
                 primaryActionTitle: backupIssueActionTitle(for: issue),
-                primaryAction: { handleBackupIssueAction(issue.recoveryAction) },
+                primaryAction: { handleBackupIssueAction(issue) },
                 dismiss: { backupVM.backupIssue = nil }
             )
+        }
+        .alert("Move Incomplete Backup to Trash?", isPresented: $showIncompleteBackupTrashConfirm) {
+            Button("Move to Trash & Run Full Backup", role: .destructive) {
+                if let issue = pendingIncompleteBackupIssue {
+                    Task { await backupVM.deleteIncompleteBackupAndRunFull(for: issue) }
+                }
+                pendingIncompleteBackupIssue = nil
+            }
+            Button("Cancel", role: .cancel) {
+                pendingIncompleteBackupIssue = nil
+            }
+        } message: {
+            Text(incompleteBackupTrashConfirmationMessage)
         }
         .alert("Full Wi-Fi Backup?", isPresented: $showFullWiFiBackupConfirm) {
             Button("Run Full Wi-Fi Backup") {
@@ -261,6 +276,13 @@ struct BackupListView: View {
         return "This is the first backup for this device, so it must be a full backup. USB is recommended for the first backup; Wi-Fi is supported but slower and more sensitive to sleep, lock, and network interruptions."
     }
 
+    private var incompleteBackupTrashConfirmationMessage: String {
+        guard let issue = pendingIncompleteBackupIssue else { return "This will move the incomplete backup folder to Trash." }
+        let path = issue.recoveryPath ?? issue.technicalDetails ?? "Unknown path"
+        let device = issue.udid.map { " for device \($0)" } ?? ""
+        return "This will move this incomplete backup folder\(device) to Trash, then run a full backup:\n\n\(path)\n\nPhosphor will not permanently delete the folder. You can restore it from Trash if needed."
+    }
+
     private func shouldOfferIncremental(for device: DeviceInfo) -> Bool {
         BackupManager.hasExistingBackup(for: device.id) && backupVM.backups.contains { backup in
             backup.udid == device.id || backup.id == device.id
@@ -283,15 +305,14 @@ struct BackupListView: View {
         }
     }
 
-    private func handleBackupIssueAction(_ action: BackupManager.RecoveryAction?) {
-        switch action {
+    private func handleBackupIssueAction(_ issue: BackupManager.BackupFailure) {
+        switch issue.recoveryAction {
         case .runFullBackup:
-            guard let device = deviceVM.selectedDevice else { return }
             backupVM.backupIssue = nil
-            Task { await backupVM.createBackup(udid: device.id, incremental: false, preferNetwork: device.connectionType == .wifi) }
+            Task { await backupVM.runFullBackup(for: issue) }
         case .deleteIncompleteAndRunFull:
-            guard let device = deviceVM.selectedDevice else { return }
-            Task { await backupVM.deleteIncompleteBackupAndRunFull(udid: device.id, preferNetwork: device.connectionType == .wifi) }
+            pendingIncompleteBackupIssue = issue
+            showIncompleteBackupTrashConfirm = true
         case .openBackupSettings:
             backupVM.backupIssue = nil
             NSApp.sendAction(Selector(("showSettingsWindow:")), to: nil, from: nil)
@@ -641,7 +662,7 @@ struct BackupScheduleSheet: View {
                         }
 
                         Toggle("Wi-Fi only (skip if Wi-Fi is not available)", isOn: $scheduler.schedule.wifiOnly)
-                        Toggle("Incremental only (faster)", isOn: $scheduler.schedule.incrementalOnly)
+                        Toggle("Incremental when possible (faster)", isOn: $scheduler.schedule.incrementalOnly)
                         if scheduler.schedule.incrementalOnly {
                             Text("The first scheduled run will create the required full backup if this device does not already have complete backup metadata.")
                                 .font(.caption)

--- a/Sources/Phosphor/Views/Backup/BackupTimeMachineView.swift
+++ b/Sources/Phosphor/Views/Backup/BackupTimeMachineView.swift
@@ -7,6 +7,7 @@ struct BackupTimeMachineView: View {
 
     @EnvironmentObject var backupVM: BackupViewModel
     @EnvironmentObject var deviceVM: DeviceViewModel
+    var onBrowseBackup: () -> Void = {}
     @State private var selectedIndex: Int = 0
     @State private var isAnimating = false
     @State private var showRestoreConfirm = false
@@ -171,7 +172,9 @@ struct BackupTimeMachineView: View {
                         .controlSize(.small)
 
                         Button("Browse") {
-                            backupVM.openBackupBrowser(backup)
+                            if backupVM.openBackupBrowser(backup) {
+                                onBrowseBackup()
+                            }
                         }
                         .buttonStyle(.bordered)
                         .controlSize(.small)

--- a/Sources/Phosphor/Views/ContentView.swift
+++ b/Sources/Phosphor/Views/ContentView.swift
@@ -104,11 +104,11 @@ struct ContentView: View {
         case .devices:
             DeviceOverviewView()
         case .backups:
-            BackupListView()
+            BackupListView(onBrowseBackup: { selectedSection = .backupBrowser })
         case .backupBrowser:
             BackupBrowserView()
         case .timeMachine:
-            BackupTimeMachineView()
+            BackupTimeMachineView(onBrowseBackup: { selectedSection = .backupBrowser })
         case .messages:
             MessageListView()
         case .whatsapp:

--- a/Sources/Phosphor/Views/Device/DeviceOverviewView.swift
+++ b/Sources/Phosphor/Views/Device/DeviceOverviewView.swift
@@ -28,15 +28,74 @@ struct DeviceOverviewView: View {
                     storage = await diagnostics.getStorageBreakdown(udid: device.id)
                 }
             } else {
-                EmptyStateView(
-                    icon: "iphone.and.arrow.forward",
-                    title: "No Device Connected",
-                    subtitle: "Connect your iPhone, iPad, or iPod touch via USB to manage it with Phosphor.",
-                    action: { Task { await deviceVM.refresh() } },
-                    actionLabel: "Scan for Devices"
-                )
+                noDeviceView
             }
         }
+    }
+
+    private var noDeviceView: some View {
+        VStack(spacing: 16) {
+            Image(systemName: deviceVM.nearbyWirelessDevices.isEmpty ? "iphone.and.arrow.forward" : "wifi")
+                .font(.system(size: 44))
+                .foregroundStyle(.quaternary)
+
+            Text(deviceVM.nearbyWirelessDevices.isEmpty ? "No Device Connected" : "Wireless Device Nearby")
+                .font(.title3.weight(.semibold))
+                .foregroundStyle(.primary)
+
+            Text(deviceVM.nearbyWirelessDevices.isEmpty
+                 ? "Connect your iPhone, iPad, or iPod touch via USB to manage it with Phosphor."
+                 : "Finder can see a wireless iPhone/iPad, but Phosphor's backup tools cannot open a usbmux connection to it yet.")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .frame(maxWidth: 380)
+
+            if !deviceVM.nearbyWirelessDevices.isEmpty {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Finder-visible devices")
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundStyle(.secondary)
+
+                    ForEach(deviceVM.nearbyWirelessDevices, id: \.id) { device in
+                        HStack(spacing: 8) {
+                            Image(systemName: "iphone.radiowaves.left.and.right")
+                                .foregroundStyle(.blue)
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(device.name)
+                                    .font(.system(size: 13, weight: .medium))
+                                if let host = device.host {
+                                    Text(host)
+                                        .font(.system(size: 11, design: .monospaced))
+                                        .foregroundStyle(.secondary)
+                                }
+                            }
+                        }
+                    }
+                }
+                .padding(12)
+                .frame(maxWidth: 380, alignment: .leading)
+                .background(.regularMaterial)
+                .clipShape(RoundedRectangle(cornerRadius: 10))
+
+                Text("Unlock the device, plug it in once, tap Trust, enable Finder Wi-Fi sync, then unplug and scan again.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                    .frame(maxWidth: 380)
+            }
+
+            Button {
+                Task { await deviceVM.refresh() }
+            } label: {
+                Text("Scan for Devices")
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(.indigo)
+            .controlSize(.regular)
+            .padding(.top, 4)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
     // MARK: - Device Card

--- a/Sources/Phosphor/Views/Device/DeviceOverviewView.swift
+++ b/Sources/Phosphor/Views/Device/DeviceOverviewView.swift
@@ -39,7 +39,7 @@ struct DeviceOverviewView: View {
                 .font(.system(size: 44))
                 .foregroundStyle(.quaternary)
 
-            Text(deviceVM.nearbyWirelessDevices.isEmpty ? "No Device Connected" : "Wireless Device Nearby")
+            Text(deviceVM.nearbyWirelessDevices.isEmpty ? "No Device Connected" : "Nearby, Not Backup-Ready")
                 .font(.title3.weight(.semibold))
                 .foregroundStyle(.primary)
 

--- a/Sources/Phosphor/Views/Files/FileBrowserView.swift
+++ b/Sources/Phosphor/Views/Files/FileBrowserView.swift
@@ -10,6 +10,8 @@ struct FileBrowserView: View {
     @State private var showCopyToDevice = false
     @State private var isDragOver = false
     @State private var dragDropStatus: String?
+    @State private var pendingDeleteFile: FileTransferManager.FileEntry?
+    @State private var showDeleteConfirm = false
 
     var body: some View {
         VStack(spacing: 0) {
@@ -26,6 +28,24 @@ struct FileBrowserView: View {
             Button("OK") { fileManager.lastError = nil }
         } message: {
             Text(fileManager.lastError ?? "")
+        }
+        .alert("Delete File?", isPresented: $showDeleteConfirm) {
+            Button("Cancel", role: .cancel) { pendingDeleteFile = nil }
+            Button("Delete", role: .destructive) {
+                guard let entry = pendingDeleteFile else { return }
+                pendingDeleteFile = nil
+                Task {
+                    do {
+                        try await fileManager.deleteFile(entry)
+                    } catch {
+                        fileManager.lastError = "Could not delete \(entry.name): \(error.localizedDescription)"
+                    }
+                }
+            }
+        } message: {
+            if let entry = pendingDeleteFile {
+                Text("This will delete \(entry.name) from the connected device. This cannot be undone.")
+            }
         }
     }
 
@@ -141,9 +161,12 @@ struct FileBrowserView: View {
                                         Task { await fileManager.navigateInto(entry) }
                                     }
                                 }
-                                Divider()
-                                Button("Delete", role: .destructive) {
-                                    Task { try? await fileManager.deleteFile(entry) }
+                                if !entry.isDirectory {
+                                    Divider()
+                                    Button("Delete", role: .destructive) {
+                                        pendingDeleteFile = entry
+                                        showDeleteConfirm = true
+                                    }
                                 }
                             }
                     }

--- a/Sources/Phosphor/Views/Settings/SettingsView.swift
+++ b/Sources/Phosphor/Views/Settings/SettingsView.swift
@@ -169,8 +169,13 @@ struct SettingsView: View {
                         .frame(width: 100)
                     }
 
-                    Toggle("Wi-Fi backup only", isOn: $scheduler.schedule.wifiOnly)
-                    Toggle("Incremental backup (faster)", isOn: $scheduler.schedule.incrementalOnly)
+                    Toggle("Wi-Fi only (skip if Wi-Fi is not available)", isOn: $scheduler.schedule.wifiOnly)
+                    Toggle("Incremental when possible (faster)", isOn: $scheduler.schedule.incrementalOnly)
+                    if scheduler.schedule.incrementalOnly {
+                        Text("The first scheduled run will create the required full backup if this device does not already have complete backup metadata.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
                 }
             }
 
@@ -202,6 +207,10 @@ struct SettingsView: View {
         }
         .formStyle(.grouped)
         .padding()
+        .onChange(of: scheduler.schedule.enabled) { _, _ in scheduler.updateNextRunDate() }
+        .onChange(of: scheduler.schedule.frequency) { _, _ in scheduler.updateNextRunDate() }
+        .onChange(of: scheduler.schedule.preferredHour) { _, _ in scheduler.updateNextRunDate() }
+        .onChange(of: scheduler.schedule.preferredMinute) { _, _ in scheduler.updateNextRunDate() }
     }
 
     // MARK: - Dependencies

--- a/Sources/Phosphor/Views/SidebarView.swift
+++ b/Sources/Phosphor/Views/SidebarView.swift
@@ -128,7 +128,7 @@ struct SidebarView: View {
                     }
                 } else {
                     ForEach(deviceVM.devices) { device in
-                        sidebarButton(.devices) {
+                        sidebarButton(.devices, onSelect: { deviceVM.selectDevice(device) }) {
                             Label {
                                 HStack {
                                     VStack(alignment: .leading, spacing: 2) {
@@ -224,12 +224,14 @@ struct SidebarView: View {
     }
 
     /// Base button for sidebar items. Uses Button instead of List selection for reliability.
-    private func sidebarButton<Content: View>(_ section: SidebarSection, @ViewBuilder content: () -> Content) -> some View {
+    private func sidebarButton<Content: View>(
+        _ section: SidebarSection,
+        onSelect: (() -> Void)? = nil,
+        @ViewBuilder content: () -> Content
+    ) -> some View {
         Button {
             selection = section
-            if section == .devices, let first = deviceVM.devices.first {
-                deviceVM.selectDevice(first)
-            }
+            onSelect?()
         } label: {
             content()
                 .frame(maxWidth: .infinity, alignment: .leading)


### PR DESCRIPTION
## Summary
- harden Shell process handling to avoid tying up global dispatch workers during device CLI probes
- add SIGKILL fallback for timed-out commands that ignore graceful termination
- move regression coverage into modular checks and wire the unified runner into build/CI
- add focused stability checks for shell safety, message export, backup manifests, and device/backup discovery invariants
- improve Finder-visible wireless iPhone discovery with bounded pymobiledevice3 mobdev2 metadata
- keep mobdev2-only devices as nearby discovery hints instead of backup targets, avoiding non-TTY interactive backup prompts
- preserve Wi‑Fi backup fallback through non-interactive usbmux/libimobiledevice paths only
- require a complete existing metadata folder before running incremental backups, and make first Wi‑Fi backup actions full backups
- exclude Info.plist-only incomplete backup folders from normal backup discovery and incremental eligibility
- clear/reconcile selected backup and browser state after reloads, deletes, folder changes, and failed opens
- make Browse buttons navigate to Backup Browser only after manifest open succeeds
- clear local backup-browser file selections when selected backup/domain changes
- add structured backup failure sheets with collapsed technical details and recommended recovery actions
- bind recovery actions to the failed backup request UDID/path instead of the currently selected device
- detect incomplete/interrupted backup folders and offer delete-and-run-full recovery with explicit path confirmation
- move incomplete backup folders to Trash instead of permanently deleting them, after exact-path and backup-marker safety checks
- fix sidebar device rows so clicking a specific device selects that device instead of always selecting the first one
- require confirmation before deleting device files and block directory deletion from the file-browser service layer
- preserve backup domain/relative paths during selective extraction to avoid basename overwrites
- add first full Wi‑Fi confirmation to the app menu backup command
- keep the app-level scheduler monitoring so schedules enabled after launch actually run
- initialize missing next-run timestamps from separately opened settings/schedule sheets
- prevent duplicate Run Now scheduled backups while async device discovery is in flight
- make scheduled incremental backups run the required first full backup when no metadata exists yet
- clarify scheduled-backup UI copy for Wi‑Fi-only and incremental-when-possible behavior in both schedule UIs
- harden .phosphor archive import: import into active backup directory, reject unsafe tar paths, prevent overwriting existing backups, require complete backup metadata, and clean up failed extracts
- avoid message export filename collisions by including chat IDs in bulk export filenames
- clear stale HTML attachment folders before re-exporting
- avoid live photo temp/export collisions by deriving local names from full device paths
- distinguish Finder-visible-only, Wi‑Fi backup-ready, and first-backup states in the UI

## Verification
- Scripts/regression-tests.py — 31 checks passed
- git diff --check / git diff --cached --check — passed
- swift build — passed
- swift build -c release — passed
- bash Scripts/build.sh — passed and produced .build/Phosphor.app
- Local install smoke: /Applications/Phosphor.app launched from the verified bundle
- Static diff scan for hardcoded secrets/dangerous eval/shell patterns — no matches
