### PR TITLE
fix: harden backup cancellation and export state

### DIFF
--- a/Scripts/regression/checks/device_backup.py
+++ b/Scripts/regression/checks/device_backup.py
@@ -121,6 +121,9 @@ def test_incremental_backups_require_existing_metadata(root: Path) -> None:
     assert_contains(manager, "expectedPath", "Incomplete-backup recovery should validate the exact failed path before moving anything")
     assert_contains(manager, "incompleteBackupHasKnownMarkers", "Incomplete-backup recovery should require recognizable iOS backup markers before moving a folder")
     assert_contains(manager, "trashItem", "Incomplete-backup recovery should move folders to Trash instead of permanently deleting them")
+    assert_contains(manager, "finalizeSuccessfulBackup", "BackupManager should verify metadata before reporting backend exit 0 as success")
+    assert_contains(manager, "Backup Metadata Incomplete", "Post-backup metadata verification failure should surface a structured recovery issue")
+    assert_contains(manager, "let verified = self.finalizeSuccessfulBackup", "idevicebackup2 fallback success must also verify metadata before returning true")
     assert_not_contains(manager, "removeItem(atPath: path)", "Incomplete-backup recovery should not permanently delete backup folders")
 
     view = read(root, "Sources/Phosphor/Views/Backup/BackupListView.swift")

--- a/Scripts/regression/checks/device_backup.py
+++ b/Scripts/regression/checks/device_backup.py
@@ -87,6 +87,11 @@ def test_wifi_schedules_use_network_discovery_and_network_backup_flag(root: Path
     assert_contains(scheduler, "running required first full backup", "Scheduled first-full fallback should be logged clearly")
     assert_contains(scheduler, "able to notice a schedule that is enabled after launch", "App-level scheduler should keep monitoring so schedules enabled after launch can run")
     assert_contains(scheduler, "if schedule.nextRunDate == nil { updateNextRunDate() }", "Scheduler should initialize next run when a separate UI instance enables the schedule")
+    assert_contains(scheduler, "func scheduledTime(on date: Date) -> Date", "Scheduler should align non-hourly next runs to preferred wall-clock time")
+    assert_contains(scheduler, "components.hour = schedule.preferredHour", "Scheduler should use preferred hour even after a previous run exists")
+    assert_contains(scheduler, "components.minute = schedule.preferredMinute", "Scheduler should use preferred minute even after a previous run exists")
+    assert_contains(scheduler, "while next <= now", "Scheduler should advance preferred-time candidates until they are in the future")
+    assert_not_contains(scheduler, "next = lastRun.addingTimeInterval(schedule.frequency.interval)", "Scheduler should not drift nextRunDate to the last completion time")
     assert_contains(scheduler, "func runNow() async {\n        guard !isRunningScheduledBackup else { return }\n        isRunningScheduledBackup = true", "Run Now should set the running guard before async device discovery")
 
     view = read(root, "Sources/Phosphor/Views/Backup/BackupListView.swift")

--- a/Scripts/regression/checks/message_export.py
+++ b/Scripts/regression/checks/message_export.py
@@ -136,14 +136,44 @@ def test_stale_export_completion_model_requires_current_operation_and_backup(roo
 
 def test_message_exports_escape_csv_and_mbox_headers(root: Path) -> None:
     src = read(root, "Sources/Phosphor/Services/MessageExporter.swift")
-    assert_contains(src, "private func csvField", "CSV export should centralize RFC-4180 escaping and spreadsheet formula neutralization")
-    assert_contains(src, '["=", "+", "-", "@"].contains', "CSV export should neutralize spreadsheet formula-leading cells")
-    assert_contains(src, "fields.map(csvField)", "CSV export should escape every field, not only message text")
+    helper = read(root, "Sources/Phosphor/Utilities/CSVExport.swift")
+    assert_contains(helper, "enum CSVExport", "CSV export escaping should be centralized for all CSV surfaces")
+    assert_contains(helper, "static func field", "CSV helper should expose field escaping")
+    assert_contains(helper, "drop(while:", "CSV helper should detect formula payloads after leading whitespace")
+    assert_contains(helper, '["=", "+", "-", "@"].contains', "CSV helper should neutralize spreadsheet formula-leading cells")
+    assert_contains(src, "fields.map(CSVExport.field)", "Message CSV export should escape every field, not only message text")
     assert_contains(src, "private func mboxToken", "MBOX export should sanitize Message-ID/boundary tokens")
     assert_contains(src, "private func headerToken", "MBOX export should sanitize MIME header tokens")
     assert_contains(src, ".replacingOccurrences(of: \"\\n\", with: \" \")", "MBOX header encoding should strip raw newlines")
     assert_contains(src, "embeddedAttachments", "MBOX export should collect every embeddable attachment")
     assert_contains(src, "for embedded in embeddedAttachments", "MBOX export should emit all non-payload attachments, not just the first")
+
+
+def test_csv_exports_share_formula_safe_helper(root: Path) -> None:
+    helper = read(root, "Sources/Phosphor/Utilities/CSVExport.swift")
+    assert_contains(helper, "static func row", "CSV helper should centralize whole-row creation")
+    for rel in [
+        "Sources/Phosphor/Services/CalendarExtractor.swift",
+        "Sources/Phosphor/Services/CallLogExtractor.swift",
+        "Sources/Phosphor/Services/ContactsExtractor.swift",
+        "Sources/Phosphor/Services/HealthExtractor.swift",
+        "Sources/Phosphor/Services/SafariExtractor.swift",
+        "Sources/Phosphor/Services/WhatsAppExporter.swift",
+    ]:
+        src = read(root, rel)
+        assert_contains(src, "CSVExport.row", f"{rel} should use the shared CSV escaping/formula-neutralization helper")
+
+
+def test_message_export_writers_check_cancellation_inside_long_loops(root: Path) -> None:
+    src = read(root, "Sources/Phosphor/Services/MessageExporter.swift")
+    assert_contains(src, "cancellationCheck: (() throws -> Void)?", "Message exports should accept a cancellation checkpoint")
+    for func_name in ["exportCSV", "exportPlainText", "exportHTML", "exportMbox", "exportJSON"]:
+        match = re.search(rf"private func {func_name}.*?(?=\n    private func|\n    ///|\Z)", src, re.S)
+        assert match is not None, f"{func_name} not found"
+        assert_contains(match.group(0), "try cancellationCheck?()", f"{func_name} should stop promptly during large single-chat exports")
+    stage = re.search(r"private func stageAttachments.*?(?=\n    private func|\n    ///|\Z)", src, re.S)
+    assert stage is not None, "stageAttachments should exist"
+    assert_contains(stage.group(0), "try cancellationCheck?()", "HTML attachment staging should be cancellable")
 
 
 def test_minimal_sms_schema_fixture_supports_limited_attachment_query(root: Path) -> None:

--- a/Scripts/regression/checks/message_export.py
+++ b/Scripts/regression/checks/message_export.py
@@ -66,6 +66,86 @@ def test_attachment_path_cache_invariants(root: Path) -> None:
     assert_contains(src, "missingAttachmentDiskPaths.insert(filename)", "resolver should store negative cache")
 
 
+def test_message_view_clears_stale_loaded_backup_and_preserves_readiness(root: Path) -> None:
+    view_model = read(root, "Sources/Phosphor/ViewModels/MessageViewModel.swift")
+    assert_contains(view_model, "func clear()", "MessageViewModel should expose a clear path for stale backup state")
+    assert_contains(view_model, "var loadedBackupPath", "MessageViewModel should expose the loaded backup path for UI reconciliation")
+    assert_contains(view_model, "exportOperationID", "Message exports should ignore stale detached task completions after clearing/switching backups")
+    assert_contains(view_model, "invalidateExportForBackupSwitch", "Switching backups should cancel and clear active export state")
+    assert_contains(view_model, "exportTask?.cancel()", "Switching/clearing backups should cancel active detached export work")
+    assert_contains(view_model, "self.exportOperationID == exportID", "Detached export completions should only update current export state")
+    assert_contains(view_model, "self.backupPath == backupPath", "Detached export completions should not update UI after the loaded backup changes")
+
+    view = read(root, "Sources/Phosphor/Views/Messages/MessageListView.swift")
+    assert_contains(view, ".onChange(of: backupVM.selectedBackup?.id)", "Messages should react when BackupViewModel clears or changes the selected backup")
+    assert_contains(view, ".onChange(of: backupVM.backups.map(\\.path))", "Messages should react when the backup folder/list changes")
+    assert_contains(view, "reconcileLoadedBackupWithAvailableBackups", "Messages should clear old chats when their backup path disappears")
+    assert_contains(view, "messageVM.clear()", "Messages should clear stale conversations/export state")
+    assert_contains(view, "messageVM.loadedBackupPath != nil && loadedBackupIsCurrent && messageVM.chats.isEmpty", "Messages readiness should render even when BackupViewModel selectedBackup is nil after manifest-open failure")
+    assert_contains(view, "guard loadedBackupIsCurrent", "Export actions should be gated to the currently loaded backup")
+
+
+def test_stale_export_completion_model_requires_current_operation_and_backup(root: Path) -> None:
+    del root
+    state = {
+        "exportOperationID": "export-1",
+        "backupPath": "/backups/A",
+        "isExporting": True,
+        "exportResult": None,
+    }
+
+    def complete(export_id: str, backup_path: str, result: str) -> None:
+        if state["exportOperationID"] != export_id or state["backupPath"] != backup_path:
+            return
+        state["isExporting"] = False
+        state["exportOperationID"] = None
+        state["exportResult"] = result
+
+    def fail_or_cancel(export_id: str, backup_path: str, message: str) -> None:
+        if state["exportOperationID"] != export_id or state["backupPath"] != backup_path:
+            return
+        state["isExporting"] = False
+        state["exportOperationID"] = None
+        state["alertMessage"] = message
+
+    def switch_backup(path: str) -> None:
+        if state["backupPath"] != path:
+            state["exportOperationID"] = None
+            state["isExporting"] = False
+        state["backupPath"] = path
+
+    state["exportOperationID"] = None  # MessageViewModel.clear()
+    complete("export-1", "/backups/A", "stale clear completion")
+    fail_or_cancel("export-1", "/backups/A", "stale clear failure")
+    assert state["exportResult"] is None, "cleared exports must ignore stale completions"
+    assert "alertMessage" not in state, "cleared exports must ignore stale failure/cancel alerts"
+
+    state.update(exportOperationID="export-2", backupPath="/backups/A", isExporting=True)
+    switch_backup("/backups/B")
+    complete("export-2", "/backups/A", "stale backup completion")
+    fail_or_cancel("export-2", "/backups/A", "stale backup failure")
+    assert state["exportResult"] is None, "backup switches must ignore completions from the old backup"
+    assert "alertMessage" not in state, "backup switches must ignore failure/cancel alerts from the old backup"
+    assert state["isExporting"] is False, "backup switches should not leave the export overlay stuck"
+
+    state.update(exportOperationID="export-3", backupPath="/backups/B", isExporting=True)
+    complete("export-3", "/backups/B", "current completion")
+    assert state["exportResult"] == "current completion"
+    assert state["isExporting"] is False
+
+
+def test_message_exports_escape_csv_and_mbox_headers(root: Path) -> None:
+    src = read(root, "Sources/Phosphor/Services/MessageExporter.swift")
+    assert_contains(src, "private func csvField", "CSV export should centralize RFC-4180 escaping and spreadsheet formula neutralization")
+    assert_contains(src, '["=", "+", "-", "@"].contains', "CSV export should neutralize spreadsheet formula-leading cells")
+    assert_contains(src, "fields.map(csvField)", "CSV export should escape every field, not only message text")
+    assert_contains(src, "private func mboxToken", "MBOX export should sanitize Message-ID/boundary tokens")
+    assert_contains(src, "private func headerToken", "MBOX export should sanitize MIME header tokens")
+    assert_contains(src, ".replacingOccurrences(of: \"\\n\", with: \" \")", "MBOX header encoding should strip raw newlines")
+    assert_contains(src, "embeddedAttachments", "MBOX export should collect every embeddable attachment")
+    assert_contains(src, "for embedded in embeddedAttachments", "MBOX export should emit all non-payload attachments, not just the first")
+
+
 def test_minimal_sms_schema_fixture_supports_limited_attachment_query(root: Path) -> None:
     del root
     with tempfile.TemporaryDirectory() as tmp:

--- a/Scripts/regression/checks/shell_safety.py
+++ b/Scripts/regression/checks/shell_safety.py
@@ -49,6 +49,98 @@ def test_shell_run_async_cancels_timeout_watchdog_on_finish(root: Path) -> None:
     assert "timedOut ? -1 : process.terminationStatus" in body, "runAsync must not read terminationStatus on the timed-out path (process may still be running)"
 
 
+def test_shell_run_streaming_has_bounded_timeout_and_force_kill(root: Path) -> None:
+    src = read(root, "Sources/Phosphor/Utilities/Shell.swift")
+    body = src[src.index("static func runStreaming("):src.index("    /// Terminate a long-running child")]
+    assert "timeout: TimeInterval?" in body, "Shell.runStreaming should let one-shot streams set a timeout"
+    assert "process.terminationHandler" in body, "Shell.runStreaming should complete through Process.terminationHandler"
+    assert "readabilityHandler" in body, "Shell.runStreaming should stream pipe output without blocking reader workers"
+    assert "SIGKILL" in body, "Shell.runStreaming should force-kill commands that ignore timeout termination"
+    assert "setTimeoutTask" in body, "Shell.runStreaming should cancel timeout sleeper tasks on normal completion"
+    assert "Task.isCancelled" in body, "Shell.runStreaming timeout task should stop promptly after finish cancels it"
+    assert "waitUntilExit()" not in body, "Shell.runStreaming must not block a worker in waitUntilExit()"
+    assert "DispatchQueue.global" not in body, "Shell.runStreaming must not allocate a global queue worker per process"
+
+
+def test_backup_streaming_callers_are_timeout_bounded_and_cancelable(root: Path) -> None:
+    backup = read(root, "Sources/Phosphor/Services/BackupManager.swift")
+    assert "streamingBackupTimeout" in backup, "backup streams should use a named timeout"
+    assert "streamingRestoreTimeout" in backup, "restore streams should use a named timeout"
+    assert "timeout: Self.streamingBackupTimeout" in backup, "backup subprocess streams must pass the backup timeout"
+    assert "timeout: Self.streamingRestoreTimeout" in backup, "restore subprocess streams must pass the restore timeout"
+    assert "activeProcess = Shell.runStreaming" in backup, "fallback streaming processes should be cancelable via activeProcess"
+    assert "beginCancellableOperation()" in backup, "backup/restore operations should use operation IDs rather than one shared cancellation boolean"
+    assert "cancelledOperationIDs.insert(activeOperationID)" in backup, "cancelBackup should mark the active operation canceled before killing the child"
+    assert "operationWasCancelled(operationID)" in backup, "cancelled primary streams should not fall through into fallback backups"
+    assert "lastOperationWasCancelled" in backup, "cancellation should be exposed separately from lastError/backup failures"
+    assert "if activeOperationID == id" in swift_block_after(backup, "private func markOperationCancelled"), "stale cancelled operations should not overwrite current operation UI state"
+    assert "backupCancelled" not in backup, "backup/restore cancellation must not use one shared mutable boolean"
+    assert "lastError = nil" in swift_block_after(backup, "func cancelBackup()"), "cancelBackup should not report user cancellation as an error"
+    assert "Shell.terminate(activeProcess)" in backup, "cancelBackup should escalate termination for stuck subprocesses"
+
+    backup_vm = read(root, "Sources/Phosphor/ViewModels/BackupViewModel.swift")
+    assert "backupManager.lastOperationWasCancelled" in backup_vm, "backup UI should not show failure alerts after user cancellation"
+    assert "backupOperationID" in backup_vm, "BackupViewModel should ignore stale backup task progress/completions"
+    assert "guard backupOperationID == operationID else { return }" in backup_vm, "stale backup completions should not update alerts or progress"
+
+    time_machine = read(root, "Sources/Phosphor/Views/Backup/BackupTimeMachineView.swift")
+    assert "lastOperationWasCancelled" in time_machine, "restore UI should not show a generic failure alert after cancellation"
+
+    diagnostics = read(root, "Sources/Phosphor/Services/DiagnosticsManager.swift")
+    assert "syslogStreamID" in diagnostics, "syslog streams should use an identity token so stopped/stale streams cannot update UI"
+    assert "let primaryProcess = PyMobileDevice.startSyslog" in diagnostics, "primary syslog launch should be assigned locally before mutating syslogProcess"
+    assert "if let primaryProcess" in diagnostics, "primary syslog process should only be stored after synchronous launch-failure completions finish"
+    assert "syslogProcess == nil" in diagnostics, "fallback launch should not overwrite or duplicate an already-installed process"
+    assert "if exitCode != 0, self.isStreamingSyslog" in diagnostics, "runtime pymobiledevice3 syslog failures should fall back while the stream is current"
+    assert "self.startSyslogFallback(udid: udid, streamID: streamID)" in diagnostics, "primary syslog completion should route runtime failures to fallback"
+    assert "guard syslogStreamID == streamID, isStreamingSyslog else { return }" in diagnostics, "fallback syslog should not start after Stop or a newer stream"
+    assert "guard let self, self.syslogStreamID == streamID else { return }" in diagnostics, "stale syslog output/completions should be ignored"
+    assert "syslogStreamID = nil" in swift_block_after(diagnostics, "func stopSyslog()"), "stopSyslog should invalidate stream identity before termination completions fire"
+    assert "syslogProcess = Shell.runStreaming" in diagnostics, "syslog fallback should be stoppable via syslogProcess"
+    assert "Shell.terminate(syslogProcess)" in diagnostics, "stopSyslog should escalate termination for stuck syslog children"
+
+
+def test_cancellation_token_model_prevents_cancelled_primary_from_starting_fallback(root: Path) -> None:
+    del root
+    active_operation_id: str | None = None
+    cancelled_operation_ids: set[str] = set()
+    fallback_started: list[str] = []
+    progress_text = ""
+
+    def begin(operation_id: str) -> str:
+        nonlocal active_operation_id
+        active_operation_id = operation_id
+        return operation_id
+
+    def cancel_current() -> None:
+        if active_operation_id is not None:
+            cancelled_operation_ids.add(active_operation_id)
+
+    def mark_cancelled(operation_id: str) -> None:
+        nonlocal active_operation_id, progress_text
+        if active_operation_id == operation_id:
+            progress_text = "Cancelled"
+            active_operation_id = None
+        cancelled_operation_ids.discard(operation_id)
+
+    def primary_completed(operation_id: str, exit_code: int) -> None:
+        if operation_id in cancelled_operation_ids:
+            mark_cancelled(operation_id)
+            return
+        if exit_code != 0:
+            fallback_started.append(operation_id)
+
+    first = begin("first")
+    cancel_current()
+    second = begin("second")
+    primary_completed(first, exit_code=1)
+    primary_completed(second, exit_code=0)
+
+    assert fallback_started == [], "a cancelled primary must not start fallback after a newer operation begins"
+    assert cancelled_operation_ids == set(), "cancelled operation IDs should be cleaned up when their completion arrives"
+    assert progress_text == "", "stale cancelled completions must not overwrite the current operation's UI"
+
+
 def test_no_crash_only_swift_shortcuts(root: Path) -> None:
     offenders: list[str] = []
     for path in (root / "Sources").rglob("*.swift"):

--- a/Sources/Phosphor/Services/BackupManager.swift
+++ b/Sources/Phosphor/Services/BackupManager.swift
@@ -12,6 +12,7 @@ final class BackupManager: ObservableObject {
     @Published var backupPercent: Double = 0
     @Published var lastError: String?
     @Published var lastBackupFailure: BackupFailure?
+    @Published var lastOperationWasCancelled = false
 
     enum RecoveryAction: String, Hashable {
         case runFullBackup
@@ -54,9 +55,46 @@ final class BackupManager: ObservableObject {
 
     /// Active backup process for cancellation.
     private var activeProcess: Process?
+    private var activeOperationID: UUID?
+    private var cancelledOperationIDs: Set<UUID> = []
+
+    private func beginCancellableOperation() -> UUID {
+        let id = UUID()
+        activeOperationID = id
+        lastOperationWasCancelled = false
+        return id
+    }
+
+    private func operationWasCancelled(_ id: UUID) -> Bool {
+        cancelledOperationIDs.contains(id)
+    }
+
+    private func finishOperation(_ id: UUID) {
+        if activeOperationID == id {
+            activeOperationID = nil
+            activeProcess = nil
+            isCreatingBackup = false
+        }
+        cancelledOperationIDs.remove(id)
+    }
+
+    private func markOperationCancelled(_ id: UUID, progress: String = "Cancelled") {
+        if activeOperationID == id {
+            lastOperationWasCancelled = true
+            backupProgress = progress
+            lastError = nil
+            lastBackupFailure = nil
+        }
+        finishOperation(id)
+    }
 
     /// Maximum number of trailing stderr lines to retain for diagnostics on failure.
     private static let stderrTailLineLimit = 20
+
+    /// Device backup/restore subprocesses should eventually complete. Bound them so
+    /// a wedged CLI cannot leave backup UI progress and checked continuations stuck forever.
+    private static let streamingBackupTimeout: TimeInterval = 6 * 60 * 60
+    private static let streamingRestoreTimeout: TimeInterval = 6 * 60 * 60
 
     /// Lines retained from the most recent pymobiledevice3 stderr stream.
     private var pymobiledeviceStderrTail: [String] = []
@@ -396,6 +434,7 @@ final class BackupManager: ObservableObject {
         onProgress: @escaping (String) -> Void
     ) async -> Bool {
         isCreatingBackup = true
+        let operationID = beginCancellableOperation()
         backupProgress = "Starting backup..."
         backupPercent = 0
         lastError = nil
@@ -405,7 +444,7 @@ final class BackupManager: ObservableObject {
         // (most commonly a Full Disk Access grant missing on the default location).
         let preflight = Self.validateBackupDirectory(Self.activeBackupDir)
         if !preflight.ok {
-            isCreatingBackup = false
+            finishOperation(operationID)
             backupProgress = "Backup failed"
             lastError = preflight.reason
             lastBackupFailure = BackupFailure(
@@ -421,7 +460,7 @@ final class BackupManager: ObservableObject {
         }
 
         if case .incomplete(let path) = Self.backupMetadataHealth(for: udid) {
-            isCreatingBackup = false
+            finishOperation(operationID)
             backupProgress = "Incomplete backup found"
             lastBackupFailure = BackupFailure(
                 title: "Incomplete Backup Found",
@@ -441,14 +480,19 @@ final class BackupManager: ObservableObject {
             udid: udid,
             full: true,
             preferNetwork: preferNetwork,
+            operationID: operationID,
             onProgress: onProgress
         )
         if pySuccess {
-            isCreatingBackup = false
+            finishOperation(operationID)
             backupProgress = "Backup complete"
             backupPercent = 1.0
             discoverBackups()
             return true
+        }
+        if operationWasCancelled(operationID) {
+            markOperationCancelled(operationID)
+            return false
         }
 
         let pymobiledeviceStderr = pymobiledeviceStderrTail.joined(separator: "\n")
@@ -461,9 +505,10 @@ final class BackupManager: ObservableObject {
         var idevicebackupStderr = ""
 
         return await withCheckedContinuation { continuation in
-            Shell.runStreaming(
+            activeProcess = Shell.runStreaming(
                 "idevicebackup2",
                 arguments: args,
+                timeout: Self.streamingBackupTimeout,
                 onOutput: { [weak self] output in
                     let trimmed = output.trimmingCharacters(in: .whitespacesAndNewlines)
                     self?.backupProgress = trimmed
@@ -481,8 +526,13 @@ final class BackupManager: ObservableObject {
                             continuation.resume(returning: exitCode == 0)
                             return
                         }
-                        self.isCreatingBackup = false
+                        if self.operationWasCancelled(operationID) {
+                            self.markOperationCancelled(operationID)
+                            continuation.resume(returning: false)
+                            return
+                        }
                         if exitCode == 0 {
+                            self.finishOperation(operationID)
                             self.backupProgress = "Backup complete"
                             self.backupPercent = 1.0
                             self.discoverBackups()
@@ -490,6 +540,7 @@ final class BackupManager: ObservableObject {
                             let combinedStderr = [pymobiledeviceStderr, idevicebackupStderr]
                                 .filter { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
                                 .joined(separator: "\n---\n")
+                            self.finishOperation(operationID)
                             self.backupProgress = "Backup failed"
                             let failure = Self.backupFailure(
                                 primary: "Both backup methods failed.",
@@ -524,6 +575,7 @@ final class BackupManager: ObservableObject {
         udid: String,
         full: Bool,
         preferNetwork: Bool,
+        operationID: UUID,
         onProgress: @escaping (String) -> Void
     ) async -> Bool {
         guard PyMobileDevice.available() else {
@@ -541,6 +593,7 @@ final class BackupManager: ObservableObject {
                 udid: udid,
                 full: full,
                 preferNetwork: preferNetwork,
+                timeout: Self.streamingBackupTimeout,
                 onOutput: { [weak self] output in
                     let trimmed = output.trimmingCharacters(in: .whitespacesAndNewlines)
                     if !trimmed.isEmpty {
@@ -574,8 +627,20 @@ final class BackupManager: ObservableObject {
                     }
                 },
                 completion: { [weak self] exitCode in
-                    self?.activeProcess = nil
-                    continuation.resume(returning: exitCode == 0)
+                    Task { @MainActor in
+                        guard let self else {
+                            continuation.resume(returning: exitCode == 0)
+                            return
+                        }
+                        if self.activeOperationID == operationID {
+                            self.activeProcess = nil
+                        }
+                        if self.operationWasCancelled(operationID) {
+                            continuation.resume(returning: false)
+                            return
+                        }
+                        continuation.resume(returning: exitCode == 0)
+                    }
                 }
             )
         }
@@ -588,6 +653,7 @@ final class BackupManager: ObservableObject {
         onProgress: @escaping (String) -> Void
     ) async -> Bool {
         isCreatingBackup = true
+        let operationID = beginCancellableOperation()
         backupProgress = "Starting incremental backup..."
         backupPercent = 0
         lastError = nil
@@ -595,7 +661,7 @@ final class BackupManager: ObservableObject {
 
         let preflight = Self.validateBackupDirectory(Self.activeBackupDir)
         if !preflight.ok {
-            isCreatingBackup = false
+            finishOperation(operationID)
             backupProgress = "Backup failed"
             lastError = preflight.reason
             lastBackupFailure = BackupFailure(
@@ -614,7 +680,7 @@ final class BackupManager: ObservableObject {
         case .complete:
             break
         case .missing:
-            isCreatingBackup = false
+            finishOperation(operationID)
             backupProgress = "Backup needs a full backup first"
             lastBackupFailure = BackupFailure(
                 title: "Full Backup Required",
@@ -628,7 +694,7 @@ final class BackupManager: ObservableObject {
             onProgress(lastError ?? "Run a full backup first.")
             return false
         case .incomplete(let path):
-            isCreatingBackup = false
+            finishOperation(operationID)
             backupProgress = "Incomplete backup found"
             lastBackupFailure = BackupFailure(
                 title: "Incomplete Backup Found",
@@ -649,14 +715,19 @@ final class BackupManager: ObservableObject {
                 udid: udid,
                 full: false,
                 preferNetwork: preferNetwork,
+                operationID: operationID,
                 onProgress: onProgress
             )
             if success {
-                isCreatingBackup = false
+                finishOperation(operationID)
                 backupProgress = "Backup complete"
                 backupPercent = 1.0
                 discoverBackups()
                 return true
+            }
+            if operationWasCancelled(operationID) {
+                markOperationCancelled(operationID)
+                return false
             }
         }
 
@@ -665,9 +736,10 @@ final class BackupManager: ObservableObject {
 
         // Fallback: idevicebackup2
         return await withCheckedContinuation { continuation in
-            Shell.runStreaming(
+            activeProcess = Shell.runStreaming(
                 "idevicebackup2",
                 arguments: idevicebackupArguments(udid: udid, full: false, preferNetwork: preferNetwork),
+                timeout: Self.streamingBackupTimeout,
                 onOutput: { [weak self] output in
                     let trimmed = output.trimmingCharacters(in: .whitespacesAndNewlines)
                     self?.backupProgress = trimmed
@@ -685,8 +757,13 @@ final class BackupManager: ObservableObject {
                             continuation.resume(returning: exitCode == 0)
                             return
                         }
-                        self.isCreatingBackup = false
+                        if self.operationWasCancelled(operationID) {
+                            self.markOperationCancelled(operationID)
+                            continuation.resume(returning: false)
+                            return
+                        }
                         if exitCode == 0 {
+                            self.finishOperation(operationID)
                             self.backupProgress = "Backup complete"
                             self.backupPercent = 1.0
                             self.discoverBackups()
@@ -694,6 +771,7 @@ final class BackupManager: ObservableObject {
                             let combinedStderr = [pymobiledeviceStderr, idevicebackupStderr]
                                 .filter { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
                                 .joined(separator: "\n---\n")
+                            self.finishOperation(operationID)
                             self.backupProgress = "Backup failed"
                             let failure = Self.backupFailure(
                                 primary: "Incremental backup failed via both backends.",
@@ -722,16 +800,29 @@ final class BackupManager: ObservableObject {
         udid: String,
         onProgress: @escaping (String) -> Void
     ) async -> Bool {
+        let operationID = beginCancellableOperation()
         // Primary: pymobiledevice3
         if PyMobileDevice.available() {
             return await withCheckedContinuation { continuation in
                 activeProcess = PyMobileDevice.restore(
                     directory: backupPath,
                     udid: udid,
+                    timeout: Self.streamingRestoreTimeout,
                     onOutput: { output in onProgress(output) },
                     completion: { [weak self] exitCode in
-                        self?.activeProcess = nil
-                        continuation.resume(returning: exitCode == 0)
+                        Task { @MainActor in
+                            guard let self else {
+                                continuation.resume(returning: exitCode == 0)
+                                return
+                            }
+                            if self.operationWasCancelled(operationID) {
+                                self.markOperationCancelled(operationID, progress: "Restore cancelled")
+                                continuation.resume(returning: false)
+                                return
+                            }
+                            self.finishOperation(operationID)
+                            continuation.resume(returning: exitCode == 0)
+                        }
                     }
                 )
             }
@@ -739,13 +830,26 @@ final class BackupManager: ObservableObject {
 
         // Fallback: idevicebackup2
         return await withCheckedContinuation { continuation in
-            Shell.runStreaming(
+            activeProcess = Shell.runStreaming(
                 "idevicebackup2",
                 arguments: ["restore", "--system", "--reboot", "-u", udid, backupPath],
+                timeout: Self.streamingRestoreTimeout,
                 onOutput: { output in onProgress(output) },
                 onError: { _ in },
-                completion: { exitCode in
-                    continuation.resume(returning: exitCode == 0)
+                completion: { [weak self] exitCode in
+                    Task { @MainActor in
+                        guard let self else {
+                            continuation.resume(returning: exitCode == 0)
+                            return
+                        }
+                        if self.operationWasCancelled(operationID) {
+                            self.markOperationCancelled(operationID, progress: "Restore cancelled")
+                            continuation.resume(returning: false)
+                            return
+                        }
+                        self.finishOperation(operationID)
+                        continuation.resume(returning: exitCode == 0)
+                    }
                 }
             )
         }
@@ -753,9 +857,15 @@ final class BackupManager: ObservableObject {
 
     /// Cancel an active backup/restore.
     func cancelBackup() {
-        activeProcess?.terminate()
-        activeProcess = nil
-        isCreatingBackup = false
+        if let activeOperationID {
+            cancelledOperationIDs.insert(activeOperationID)
+        }
+        lastOperationWasCancelled = true
+        lastError = nil
+        lastBackupFailure = nil
+        if let activeProcess {
+            Shell.terminate(activeProcess)
+        }
         backupProgress = "Cancelled"
     }
 

--- a/Sources/Phosphor/Services/BackupManager.swift
+++ b/Sources/Phosphor/Services/BackupManager.swift
@@ -426,6 +426,51 @@ final class BackupManager: ObservableObject {
 
     // MARK: - Backup Creation
 
+    private func finalizeSuccessfulBackup(
+        udid: String,
+        operationID: UUID,
+        onProgress: @escaping (String) -> Void
+    ) -> Bool {
+        switch Self.backupMetadataHealth(for: udid) {
+        case .complete:
+            finishOperation(operationID)
+            backupProgress = "Backup complete"
+            backupPercent = 1.0
+            discoverBackups()
+            onProgress("Backup complete")
+            return true
+        case .missing:
+            let path = Self.backupPath(for: udid)
+            finishOperation(operationID)
+            backupProgress = "Backup metadata incomplete"
+            lastBackupFailure = BackupFailure(
+                title: "Backup Metadata Incomplete",
+                message: "The backup command finished, but Phosphor could not find complete backup metadata. Run a fresh full backup with the device unlocked and connected over USB when possible.",
+                technicalDetails: path,
+                recoveryAction: .runFullBackup,
+                udid: udid,
+                recoveryPath: path
+            )
+            lastError = lastBackupFailure?.message
+            onProgress(lastError ?? "Backup metadata incomplete.")
+            return false
+        case .incomplete(let path):
+            finishOperation(operationID)
+            backupProgress = "Backup metadata incomplete"
+            lastBackupFailure = BackupFailure(
+                title: "Backup Metadata Incomplete",
+                message: "The backup command finished, but the resulting backup metadata is incomplete. Move the incomplete folder to Trash, then run a fresh full backup with the device unlocked and connected over USB when possible.",
+                technicalDetails: path,
+                recoveryAction: .deleteIncompleteAndRunFull,
+                udid: udid,
+                recoveryPath: path
+            )
+            lastError = lastBackupFailure?.message
+            onProgress(lastError ?? "Backup metadata incomplete.")
+            return false
+        }
+    }
+
     /// Create a new backup. pymobiledevice3 primary, idevicebackup2 fallback.
     func createBackup(
         udid: String,
@@ -484,11 +529,7 @@ final class BackupManager: ObservableObject {
             onProgress: onProgress
         )
         if pySuccess {
-            finishOperation(operationID)
-            backupProgress = "Backup complete"
-            backupPercent = 1.0
-            discoverBackups()
-            return true
+            return finalizeSuccessfulBackup(udid: udid, operationID: operationID, onProgress: onProgress)
         }
         if operationWasCancelled(operationID) {
             markOperationCancelled(operationID)
@@ -532,10 +573,9 @@ final class BackupManager: ObservableObject {
                             return
                         }
                         if exitCode == 0 {
-                            self.finishOperation(operationID)
-                            self.backupProgress = "Backup complete"
-                            self.backupPercent = 1.0
-                            self.discoverBackups()
+                            let verified = self.finalizeSuccessfulBackup(udid: udid, operationID: operationID, onProgress: onProgress)
+                            continuation.resume(returning: verified)
+                            return
                         } else {
                             let combinedStderr = [pymobiledeviceStderr, idevicebackupStderr]
                                 .filter { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
@@ -554,7 +594,7 @@ final class BackupManager: ObservableObject {
                                 stderr: combinedStderr
                             )
                         }
-                        continuation.resume(returning: exitCode == 0)
+                        continuation.resume(returning: false)
                     }
                 }
             )
@@ -719,11 +759,7 @@ final class BackupManager: ObservableObject {
                 onProgress: onProgress
             )
             if success {
-                finishOperation(operationID)
-                backupProgress = "Backup complete"
-                backupPercent = 1.0
-                discoverBackups()
-                return true
+                return finalizeSuccessfulBackup(udid: udid, operationID: operationID, onProgress: onProgress)
             }
             if operationWasCancelled(operationID) {
                 markOperationCancelled(operationID)
@@ -763,10 +799,9 @@ final class BackupManager: ObservableObject {
                             return
                         }
                         if exitCode == 0 {
-                            self.finishOperation(operationID)
-                            self.backupProgress = "Backup complete"
-                            self.backupPercent = 1.0
-                            self.discoverBackups()
+                            let verified = self.finalizeSuccessfulBackup(udid: udid, operationID: operationID, onProgress: onProgress)
+                            continuation.resume(returning: verified)
+                            return
                         } else {
                             let combinedStderr = [pymobiledeviceStderr, idevicebackupStderr]
                                 .filter { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
@@ -785,7 +820,7 @@ final class BackupManager: ObservableObject {
                                 stderr: combinedStderr
                             )
                         }
-                        continuation.resume(returning: exitCode == 0)
+                        continuation.resume(returning: false)
                     }
                 }
             )

--- a/Sources/Phosphor/Services/BackupScheduler.swift
+++ b/Sources/Phosphor/Services/BackupScheduler.swift
@@ -224,18 +224,47 @@ final class BackupScheduler: ObservableObject {
         }
 
         let calendar = Calendar.current
-        var next: Date
+        let now = Date()
+        let anchor = schedule.lastRunDate ?? now
 
-        if let lastRun = schedule.lastRunDate {
-            next = lastRun.addingTimeInterval(schedule.frequency.interval)
-        } else {
-            var components = calendar.dateComponents([.year, .month, .day], from: Date())
+        func scheduledTime(on date: Date) -> Date {
+            var components = calendar.dateComponents([.year, .month, .day, .hour], from: date)
             components.hour = schedule.preferredHour
             components.minute = schedule.preferredMinute
-            next = calendar.date(from: components) ?? Date()
-            if next <= Date() {
-                next = calendar.date(byAdding: .day, value: 1, to: next) ?? next
+            components.second = 0
+            return calendar.date(from: components) ?? date
+        }
+
+        func advance(_ date: Date) -> Date {
+            switch schedule.frequency {
+            case .hourly:
+                var components = calendar.dateComponents([.year, .month, .day, .hour], from: date)
+                components.minute = schedule.preferredMinute
+                components.second = 0
+                let aligned = calendar.date(from: components) ?? date
+                return calendar.date(byAdding: .hour, value: aligned <= date ? 1 : 0, to: aligned) ?? date.addingTimeInterval(schedule.frequency.interval)
+            case .daily:
+                return calendar.date(byAdding: .day, value: 1, to: date) ?? date.addingTimeInterval(schedule.frequency.interval)
+            case .weekly:
+                return calendar.date(byAdding: .day, value: 7, to: date) ?? date.addingTimeInterval(schedule.frequency.interval)
+            case .biweekly:
+                return calendar.date(byAdding: .day, value: 14, to: date) ?? date.addingTimeInterval(schedule.frequency.interval)
+            case .monthly:
+                return calendar.date(byAdding: .month, value: 1, to: date) ?? date.addingTimeInterval(schedule.frequency.interval)
             }
+        }
+
+        var next: Date
+        if schedule.frequency == .hourly {
+            next = advance(anchor)
+        } else if schedule.lastRunDate != nil {
+            next = scheduledTime(on: advance(anchor))
+        } else {
+            next = scheduledTime(on: now)
+        }
+
+        while next <= now {
+            next = schedule.frequency == .hourly ? advance(next) : scheduledTime(on: advance(next))
         }
 
         schedule.nextRunDate = next

--- a/Sources/Phosphor/Services/CalendarExtractor.swift
+++ b/Sources/Phosphor/Services/CalendarExtractor.swift
@@ -153,21 +153,21 @@ final class CalendarExtractor {
             .replacingOccurrences(of: "\r", with: "")
     }
 
-    /// Export as CSV with proper RFC 4180 escaping.
+    /// Export as CSV with RFC 4180 escaping plus spreadsheet formula neutralization.
     func exportAsCSV(events: [CalendarEvent], to path: String) throws {
         var csv = "Title,Start,End,All Day,Calendar,Location,Notes\r\n"
         for event in events {
-            csv += "\(csvEscape(event.title)),\(csvEscape(event.startDate.iso8601String)),\(csvEscape(event.endDate.iso8601String)),\(event.isAllDay),\(csvEscape(event.calendarTitle)),\(csvEscape(event.location)),\(csvEscape(event.notes))\r\n"
+            csv += CSVExport.row([
+                event.title,
+                event.startDate.iso8601String,
+                event.endDate.iso8601String,
+                String(event.isAllDay),
+                event.calendarTitle,
+                event.location,
+                event.notes
+            ], lineEnding: "\r\n")
         }
         try csv.write(toFile: path, atomically: true, encoding: .utf8)
-    }
-
-    /// RFC 4180 CSV escaping: double-quote fields containing commas, quotes, or newlines.
-    private func csvEscape(_ field: String) -> String {
-        if field.contains(",") || field.contains("\"") || field.contains("\n") || field.contains("\r") {
-            return "\"\(field.replacingOccurrences(of: "\"", with: "\"\""))\""
-        }
-        return field
     }
 
     // MARK: - Private

--- a/Sources/Phosphor/Services/CallLogExtractor.swift
+++ b/Sources/Phosphor/Services/CallLogExtractor.swift
@@ -138,7 +138,7 @@ final class CallLogExtractor {
         let calls = try getCallLog()
         var csv = "Date,Number,Type,Duration\n"
         for call in calls {
-            csv += "\"\(call.date.shortString)\",\"\(call.address)\",\"\(call.callType.label)\",\"\(call.durationString)\"\n"
+            csv += CSVExport.row([call.date.shortString, call.address, call.callType.label, call.durationString])
         }
         try csv.write(toFile: path, atomically: true, encoding: .utf8)
     }

--- a/Sources/Phosphor/Services/ContactsExtractor.swift
+++ b/Sources/Phosphor/Services/ContactsExtractor.swift
@@ -153,7 +153,7 @@ final class ContactsExtractor {
         for contact in contacts {
             let phones = contact.phoneNumbers.joined(separator: "; ")
             let emails = contact.emails.joined(separator: "; ")
-            csv += "\"\(contact.firstName)\",\"\(contact.lastName)\",\"\(contact.organization)\",\"\(phones)\",\"\(emails)\"\n"
+            csv += CSVExport.row([contact.firstName, contact.lastName, contact.organization, phones, emails])
         }
         try csv.write(toFile: path, atomically: true, encoding: .utf8)
     }

--- a/Sources/Phosphor/Services/DiagnosticsManager.swift
+++ b/Sources/Phosphor/Services/DiagnosticsManager.swift
@@ -10,6 +10,7 @@ final class DiagnosticsManager: ObservableObject {
 
     /// Active syslog process for proper termination.
     private var syslogProcess: Process?
+    private var syslogStreamID: UUID?
 
     struct BatteryDiagnostics {
         let currentCapacity: Int
@@ -173,51 +174,84 @@ final class DiagnosticsManager: ObservableObject {
 
     func startSyslog(udid: String) {
         guard !isStreamingSyslog else { return }
+        let streamID = UUID()
+        syslogStreamID = streamID
         isStreamingSyslog = true
         syslogLines = []
 
-        // Primary: pymobiledevice3 syslog
-        syslogProcess = PyMobileDevice.startSyslog(
+        // Primary: pymobiledevice3 syslog. Store the return value locally first:
+        // PyMobileDevice/Shell can synchronously call completion(-1) on launch
+        // failure, and that completion may already install the fallback process.
+        let primaryProcess = PyMobileDevice.startSyslog(
             udid: udid,
             onOutput: { [weak self] line in
-                guard let self else { return }
-                let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
-                guard !trimmed.isEmpty else { return }
-
-                if self.syslogLines.count > 5000 {
-                    self.syslogLines.removeFirst(500)
-                }
-                self.syslogLines.append(trimmed)
+                guard let self, self.syslogStreamID == streamID else { return }
+                self.appendSyslogLine(line)
             },
-            completion: { [weak self] _ in
-                self?.isStreamingSyslog = false
-                self?.syslogProcess = nil
+            completion: { [weak self] exitCode in
+                guard let self, self.syslogStreamID == streamID else { return }
+                self.syslogProcess = nil
+                if exitCode != 0, self.isStreamingSyslog {
+                    self.startSyslogFallback(udid: udid, streamID: streamID)
+                } else {
+                    self.isStreamingSyslog = false
+                    self.syslogStreamID = nil
+                }
             }
         )
+        if let primaryProcess {
+            // Do not overwrite a fallback that a synchronous launch-failure
+            // completion installed before PyMobileDevice.startSyslog returned.
+            if syslogStreamID == streamID, syslogProcess == nil {
+                syslogProcess = primaryProcess
+            } else {
+                Shell.terminate(primaryProcess)
+            }
+        }
 
-        // Fallback if pymobiledevice3 failed
+        // Fallback if pymobiledevice3 failed to launch and completion did not
+        // already install an idevicesyslog process.
+        if syslogStreamID == streamID, isStreamingSyslog, syslogProcess == nil {
+            startSyslogFallback(udid: udid, streamID: streamID)
+        }
+    }
+
+    private func appendSyslogLine(_ line: String) {
+        let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        if syslogLines.count > 5000 {
+            syslogLines.removeFirst(500)
+        }
+        syslogLines.append(trimmed)
+    }
+
+    private func startSyslogFallback(udid: String, streamID: UUID) {
+        guard syslogStreamID == streamID, isStreamingSyslog else { return }
+        syslogProcess = Shell.runStreaming(
+            "idevicesyslog",
+            arguments: ["-u", udid],
+            onOutput: { [weak self] line in
+                guard let self, self.syslogStreamID == streamID else { return }
+                self.appendSyslogLine(line)
+            },
+            completion: { [weak self] _ in
+                guard let self, self.syslogStreamID == streamID else { return }
+                self.syslogProcess = nil
+                self.isStreamingSyslog = false
+                self.syslogStreamID = nil
+            }
+        )
         if syslogProcess == nil {
-            Shell.runStreaming(
-                "idevicesyslog",
-                arguments: ["-u", udid],
-                onOutput: { [weak self] line in
-                    guard let self else { return }
-                    let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
-                    guard !trimmed.isEmpty else { return }
-                    if self.syslogLines.count > 5000 {
-                        self.syslogLines.removeFirst(500)
-                    }
-                    self.syslogLines.append(trimmed)
-                },
-                completion: { [weak self] _ in
-                    self?.isStreamingSyslog = false
-                }
-            )
+            isStreamingSyslog = false
+            syslogStreamID = nil
         }
     }
 
     func stopSyslog() {
-        syslogProcess?.terminate()
+        syslogStreamID = nil
+        if let syslogProcess {
+            Shell.terminate(syslogProcess)
+        }
         syslogProcess = nil
         isStreamingSyslog = false
     }

--- a/Sources/Phosphor/Services/HealthExtractor.swift
+++ b/Sources/Phosphor/Services/HealthExtractor.swift
@@ -213,7 +213,7 @@ final class HealthExtractor {
         let samples = try getSamples(dataType: dataType, limit: 50000)
         var csv = "Date,Value,Unit,Source\n"
         for s in samples {
-            csv += "\"\(s.startDate.shortString)\",\(s.value),\"\(s.unit)\",\"\(s.sourceName)\"\n"
+            csv += CSVExport.row([s.startDate.shortString, String(s.value), s.unit, s.sourceName])
         }
         try csv.write(toFile: path, atomically: true, encoding: .utf8)
     }
@@ -222,8 +222,14 @@ final class HealthExtractor {
         let workouts = try getWorkouts(limit: 10000)
         var csv = "Date,Activity,Duration,Energy (kcal),Distance (m),Source\n"
         for w in workouts {
-            csv += "\"\(w.startDate.shortString)\",\"\(w.activityName)\",\"\(w.durationString)\","
-            csv += "\(w.totalEnergyBurned ?? 0),\(w.totalDistance ?? 0),\"\(w.sourceName)\"\n"
+            csv += CSVExport.row([
+                w.startDate.shortString,
+                w.activityName,
+                w.durationString,
+                String(w.totalEnergyBurned ?? 0),
+                String(w.totalDistance ?? 0),
+                w.sourceName
+            ])
         }
         try csv.write(toFile: path, atomically: true, encoding: .utf8)
     }

--- a/Sources/Phosphor/Services/MessageExporter.swift
+++ b/Sources/Phosphor/Services/MessageExporter.swift
@@ -538,14 +538,31 @@ final class MessageExporter {
 
         try append("Date,Sender,Text,Reactions,Service\n")
         for msg in messages {
-            let text = (msg.text ?? "")
-                .replacingOccurrences(of: "\"", with: "\"\"")
-                .replacingOccurrences(of: "\n", with: " ")
             let reactions = msg.reactions
                 .map { "\($0.sender): \($0.type.label)" }
                 .joined(separator: "; ")
-            try append("\"\(msg.formattedDate)\",\"\(msg.senderLabel)\",\"\(text)\",\"\(reactions)\",\"\(msg.service)\"\n")
+            let fields = [
+                msg.formattedDate,
+                msg.senderLabel,
+                msg.text ?? "",
+                reactions,
+                msg.service
+            ]
+            try append(fields.map(csvField).joined(separator: ",") + "\n")
         }
+    }
+
+    private func csvField(_ raw: String) -> String {
+        var value = raw
+            .replacingOccurrences(of: "\r\n", with: " ")
+            .replacingOccurrences(of: "\n", with: " ")
+            .replacingOccurrences(of: "\r", with: " ")
+        if let first = value.drop(while: { $0 == " " || $0 == "\t" }).first,
+           ["=", "+", "-", "@"].contains(String(first)) {
+            value = "'" + value
+        }
+        value = value.replacingOccurrences(of: "\"", with: "\"\"")
+        return "\"\(value)\""
     }
 
     private func exportPlainText(messages: [Message], chatTitle: String, to path: String) throws {
@@ -809,8 +826,8 @@ final class MessageExporter {
             append("To: \(toHeader)\(crlf)")
             append("Date: \(rfc5322Formatter.string(from: msg.date))\(crlf)")
             append("Subject: \(headerEncode(chatTitle))\(crlf)")
-            append("Message-ID: <\(msg.guid)@\(userDomain)>\(crlf)")
-            append("X-Phosphor-Service: \(msg.service)\(crlf)")
+            append("Message-ID: <\(mboxToken(msg.guid))@\(userDomain)>\(crlf)")
+            append("X-Phosphor-Service: \(headerEncode(msg.service))\(crlf)")
             if !msg.reactions.isEmpty {
                 let summary = msg.reactions.map { "\($0.sender):\($0.type.label)" }.joined(separator: ", ")
                 append("X-Phosphor-Reactions: \(headerEncode(summary))\(crlf)")
@@ -818,37 +835,56 @@ final class MessageExporter {
             append("MIME-Version: 1.0\(crlf)")
 
             let body = msg.text ?? ""
-            // Pick the first non-payload attachment as the MIME body when present.
-            let payloadAttachment = msg.attachments.first(where: { !$0.isPluginPayload })
-            let attachmentDiskPath = payloadAttachment?.filename.flatMap { resolveAttachmentDiskPath(filename: $0) }
+            let inlineAttachments = msg.attachments.filter { !$0.isPluginPayload }
+            let embeddedAttachments: [(attachment: MessageAttachment, diskPath: String, data: Data)] = includeAttachments
+                ? inlineAttachments.compactMap { attachment in
+                    guard let filename = attachment.filename,
+                          let diskPath = resolveAttachmentDiskPath(filename: filename),
+                          let data = try? Data(contentsOf: URL(fileURLWithPath: diskPath)) else {
+                        return nil
+                    }
+                    return (attachment, diskPath, data)
+                }
+                : []
 
-            if includeAttachments,
-               let payloadAttachment,
-               let attachmentDiskPath,
-               let data = try? Data(contentsOf: URL(fileURLWithPath: attachmentDiskPath)) {
-                let boundary = "----=_Phosphor_\(msg.guid)"
+            if !embeddedAttachments.isEmpty {
+                let boundary = "----=_Phosphor_\(mboxToken(msg.guid))"
                 append("Content-Type: multipart/mixed; boundary=\"\(boundary)\"\(crlf)\(crlf)")
 
                 append("--\(boundary)\(crlf)")
                 append("Content-Type: text/plain; charset=UTF-8\(crlf)")
                 append("Content-Transfer-Encoding: 8bit\(crlf)\(crlf)")
-                append(mboxEscape(body.isEmpty ? "[Attachment]" : body) + crlf + crlf)
+                var bodyOut = body.isEmpty ? "[Attachment]" : body
+                let embeddedFilenames = Set(embeddedAttachments.compactMap { $0.attachment.filename })
+                let missingNames = inlineAttachments
+                    .filter { attachment in
+                        guard let filename = attachment.filename else { return true }
+                        return !embeddedFilenames.contains(filename)
+                    }
+                    .map(\.displayName)
+                if !missingNames.isEmpty {
+                    bodyOut += "\n\n[Attachment: \(missingNames.joined(separator: ", "))]"
+                }
+                append(mboxEscape(bodyOut) + crlf + crlf)
 
-                let name = payloadAttachment.filename.map { ($0 as NSString).lastPathComponent } ?? payloadAttachment.displayName
-                let mime = payloadAttachment.mimeType ?? "application/octet-stream"
-                append("--\(boundary)\(crlf)")
-                append("Content-Type: \(mime); name=\"\(headerEncode(name))\"\(crlf)")
-                append("Content-Disposition: attachment; filename=\"\(headerEncode(name))\"\(crlf)")
-                append("Content-Transfer-Encoding: base64\(crlf)\(crlf)")
-                append(data.base64EncodedString(options: [.lineLength76Characters, .endLineWithCarriageReturn, .endLineWithLineFeed]))
-                append(crlf + "--\(boundary)--\(crlf)\(crlf)")
+                for embedded in embeddedAttachments {
+                    let attachment = embedded.attachment
+                    let name = attachment.filename.map { ($0 as NSString).lastPathComponent } ?? attachment.displayName
+                    let mime = headerToken(attachment.mimeType ?? "application/octet-stream", fallback: "application/octet-stream")
+                    append("--\(boundary)\(crlf)")
+                    append("Content-Type: \(mime); name=\"\(headerEncode(name))\"\(crlf)")
+                    append("Content-Disposition: attachment; filename=\"\(headerEncode(name))\"\(crlf)")
+                    append("Content-Transfer-Encoding: base64\(crlf)\(crlf)")
+                    append(embedded.data.base64EncodedString(options: [.lineLength76Characters, .endLineWithCarriageReturn, .endLineWithLineFeed]))
+                    append(crlf)
+                }
+                append("--\(boundary)--\(crlf)\(crlf)")
             } else {
                 append("Content-Type: text/plain; charset=UTF-8\(crlf)")
                 append("Content-Transfer-Encoding: 8bit\(crlf)\(crlf)")
                 var bodyOut = body
-                let inlineAttachments = msg.attachments.filter { !$0.isPluginPayload }
                 if !inlineAttachments.isEmpty {
-                    let names = inlineAttachments.compactMap { $0.filename }.joined(separator: ", ")
+                    let names = inlineAttachments.map(\.displayName).joined(separator: ", ")
                     if !bodyOut.isEmpty { bodyOut += "\n\n" }
                     bodyOut += "[Attachment: \(names)]"
                 }
@@ -881,10 +917,25 @@ final class MessageExporter {
         return "\(local)@\(domain)"
     }
 
+    private func mboxToken(_ raw: String) -> String {
+        let cleaned = raw.filter { $0.isLetter || $0.isNumber || "._-+".contains($0) }
+        return cleaned.isEmpty ? UUID().uuidString : cleaned
+    }
+
+    private func headerToken(_ raw: String, fallback: String) -> String {
+        let cleaned = raw.filter { $0.isLetter || $0.isNumber || "/._-+".contains($0) }
+        return cleaned.isEmpty ? fallback : cleaned
+    }
+
     /// RFC 2047 encoded-word for header values containing non-ASCII.
     private func headerEncode(_ raw: String) -> String {
-        if raw.allSatisfy({ $0.isASCII }) { return raw }
-        let base64 = Data(raw.utf8).base64EncodedString()
+        let sanitized = raw
+            .replacingOccurrences(of: "\r\n", with: " ")
+            .replacingOccurrences(of: "\n", with: " ")
+            .replacingOccurrences(of: "\r", with: " ")
+            .replacingOccurrences(of: "\"", with: "'")
+        if sanitized.allSatisfy({ $0.isASCII }) { return sanitized }
+        let base64 = Data(sanitized.utf8).base64EncodedString()
         return "=?UTF-8?B?\(base64)?="
     }
 

--- a/Sources/Phosphor/Services/MessageExporter.swift
+++ b/Sources/Phosphor/Services/MessageExporter.swift
@@ -467,12 +467,19 @@ final class MessageExporter {
     // MARK: - Export
 
     /// Export messages to a file in the specified format.
-    func exportChat(chatId: Int, format: MessageExportFormat, to path: String, options: MessageExportOptions = MessageExportOptions()) throws {
+    func exportChat(
+        chatId: Int,
+        format: MessageExportFormat,
+        to path: String,
+        options: MessageExportOptions = MessageExportOptions(),
+        cancellationCheck: (() throws -> Void)? = nil
+    ) throws {
+        try cancellationCheck?()
         let messages = options.apply(to: try getMessages(chatId: chatId))
         let chats = try getChats(includeEmpty: true, includeHidden: true)
         let chat = chats.first { $0.id == chatId }
         let chatTitle = chat?.title ?? "Unknown"
-        try exportMessages(messages, chatTitle: chatTitle, format: format, to: path, options: options)
+        try exportMessages(messages, chatTitle: chatTitle, format: format, to: path, options: options, cancellationCheck: cancellationCheck)
     }
 
     /// Export all conversations.
@@ -480,7 +487,8 @@ final class MessageExporter {
         format: MessageExportFormat,
         to directory: String,
         options: MessageExportOptions = MessageExportOptions(),
-        onProgress: ((Int, Int, String) throws -> Void)? = nil
+        onProgress: ((Int, Int, String) throws -> Void)? = nil,
+        cancellationCheck: (() throws -> Void)? = nil
     ) throws -> Int {
         let chats = try getChats()
         let fm = FileManager.default
@@ -488,28 +496,36 @@ final class MessageExporter {
 
         var count = 0
         for chat in chats {
+            try cancellationCheck?()
             try onProgress?(count, chats.count, chat.title)
             let filename = exportFilename(for: chat, format: format)
             let path = (directory as NSString).appendingPathComponent(filename)
-            try exportChat(chatId: chat.id, format: format, to: path, options: options)
+            try exportChat(chatId: chat.id, format: format, to: path, options: options, cancellationCheck: cancellationCheck)
             count += 1
         }
         try onProgress?(count, chats.count, "Complete")
         return count
     }
 
-    func exportMessages(_ messages: [Message], chatTitle: String, format: MessageExportFormat, to path: String, options: MessageExportOptions = MessageExportOptions()) throws {
+    func exportMessages(
+        _ messages: [Message],
+        chatTitle: String,
+        format: MessageExportFormat,
+        to path: String,
+        options: MessageExportOptions = MessageExportOptions(),
+        cancellationCheck: (() throws -> Void)? = nil
+    ) throws {
         switch format {
         case .csv:
-            try exportCSV(messages: messages, chatTitle: chatTitle, to: path)
+            try exportCSV(messages: messages, chatTitle: chatTitle, to: path, cancellationCheck: cancellationCheck)
         case .txt:
-            try exportPlainText(messages: messages, chatTitle: chatTitle, to: path)
+            try exportPlainText(messages: messages, chatTitle: chatTitle, to: path, cancellationCheck: cancellationCheck)
         case .html:
-            try exportHTML(messages: messages, chatTitle: chatTitle, to: path, includeAttachments: options.includeAttachments)
+            try exportHTML(messages: messages, chatTitle: chatTitle, to: path, includeAttachments: options.includeAttachments, cancellationCheck: cancellationCheck)
         case .json:
-            try exportJSON(messages: messages, chatTitle: chatTitle, to: path)
+            try exportJSON(messages: messages, chatTitle: chatTitle, to: path, cancellationCheck: cancellationCheck)
         case .mbox:
-            try exportMbox(messages: messages, chatTitle: chatTitle, to: path, includeAttachments: options.includeAttachments)
+            try exportMbox(messages: messages, chatTitle: chatTitle, to: path, includeAttachments: options.includeAttachments, cancellationCheck: cancellationCheck)
         }
     }
 
@@ -523,7 +539,7 @@ final class MessageExporter {
         return "\(safeName)-chat-\(chat.id).\(format.fileExtension)"
     }
 
-    private func exportCSV(messages: [Message], chatTitle: String, to path: String) throws {
+    private func exportCSV(messages: [Message], chatTitle: String, to path: String, cancellationCheck: (() throws -> Void)? = nil) throws {
         let outputURL = URL(fileURLWithPath: path)
         try? FileManager.default.removeItem(at: outputURL)
         FileManager.default.createFile(atPath: path, contents: nil)
@@ -538,6 +554,7 @@ final class MessageExporter {
 
         try append("Date,Sender,Text,Reactions,Service\n")
         for msg in messages {
+            try cancellationCheck?()
             let reactions = msg.reactions
                 .map { "\($0.sender): \($0.type.label)" }
                 .joined(separator: "; ")
@@ -548,24 +565,11 @@ final class MessageExporter {
                 reactions,
                 msg.service
             ]
-            try append(fields.map(csvField).joined(separator: ",") + "\n")
+            try append(fields.map(CSVExport.field).joined(separator: ",") + "\n")
         }
     }
 
-    private func csvField(_ raw: String) -> String {
-        var value = raw
-            .replacingOccurrences(of: "\r\n", with: " ")
-            .replacingOccurrences(of: "\n", with: " ")
-            .replacingOccurrences(of: "\r", with: " ")
-        if let first = value.drop(while: { $0 == " " || $0 == "\t" }).first,
-           ["=", "+", "-", "@"].contains(String(first)) {
-            value = "'" + value
-        }
-        value = value.replacingOccurrences(of: "\"", with: "\"\"")
-        return "\"\(value)\""
-    }
-
-    private func exportPlainText(messages: [Message], chatTitle: String, to path: String) throws {
+    private func exportPlainText(messages: [Message], chatTitle: String, to path: String, cancellationCheck: (() throws -> Void)? = nil) throws {
         let outputURL = URL(fileURLWithPath: path)
         try? FileManager.default.removeItem(at: outputURL)
         FileManager.default.createFile(atPath: path, contents: nil)
@@ -583,6 +587,7 @@ final class MessageExporter {
         try append(String(repeating: "-", count: 60) + "\n\n")
 
         for msg in messages {
+            try cancellationCheck?()
             try append("[\(msg.formattedDate)] \(msg.senderLabel):\n")
             try append("\(msg.displayText)\n")
             for reaction in msg.reactions {
@@ -600,7 +605,7 @@ final class MessageExporter {
     /// Plugin payload blobs (rich-link metadata) are skipped because they are
     /// binary plists that macOS has no handler for and would clutter the export
     /// folder with `*.pluginPayloadAttachment` files (issue #17).
-    private func stageAttachments(messages: [Message], htmlPath: String) -> [String: String] {
+    private func stageAttachments(messages: [Message], htmlPath: String, cancellationCheck: (() throws -> Void)? = nil) throws -> [String: String] {
         let baseName = (htmlPath as NSString).deletingPathExtension
         let dir = "\(baseName)_attachments"
         let fm = FileManager.default
@@ -608,6 +613,7 @@ final class MessageExporter {
         var folderCreated = false
 
         for msg in messages {
+            try cancellationCheck?()
             for attachment in msg.attachments {
                 guard !attachment.isPluginPayload else { continue }
                 guard let filename = attachment.filename, !filename.isEmpty else { continue }
@@ -648,9 +654,9 @@ final class MessageExporter {
         try? FileManager.default.removeItem(atPath: dir)
     }
 
-    private func exportHTML(messages: [Message], chatTitle: String, to path: String, includeAttachments: Bool = true) throws {
+    private func exportHTML(messages: [Message], chatTitle: String, to path: String, includeAttachments: Bool = true, cancellationCheck: (() throws -> Void)? = nil) throws {
         removeAttachmentFolder(forHTMLPath: path)
-        let attachmentMap = includeAttachments ? stageAttachments(messages: messages, htmlPath: path) : [:]
+        let attachmentMap = includeAttachments ? try stageAttachments(messages: messages, htmlPath: path, cancellationCheck: cancellationCheck) : [:]
         let outputURL = URL(fileURLWithPath: path)
         try? FileManager.default.removeItem(at: outputURL)
         FileManager.default.createFile(atPath: path, contents: nil)
@@ -710,6 +716,7 @@ final class MessageExporter {
         var lastSender = ""
 
         for msg in messages {
+            try cancellationCheck?()
             let dateStr = msg.formattedDate
             if dateStr != lastDateStr {
                 append("<div class=\"time\">\(htmlEscape(dateStr))</div>\n")
@@ -779,7 +786,7 @@ final class MessageExporter {
     /// RFC 5322 envelope so Mail.app, Thunderbird, mutt, etc. can import the
     /// conversation as a mail folder. Attachments are embedded as base64 MIME parts
     /// when the backup file is available, otherwise referenced by name only.
-    private func exportMbox(messages: [Message], chatTitle: String, to path: String, includeAttachments: Bool = true) throws {
+    private func exportMbox(messages: [Message], chatTitle: String, to path: String, includeAttachments: Bool = true, cancellationCheck: (() throws -> Void)? = nil) throws {
         let crlf = "\r\n"
         let userDomain = "phosphor.local"
         let outputURL = URL(fileURLWithPath: path)
@@ -807,6 +814,7 @@ final class MessageExporter {
         rfc5322Formatter.locale = Locale(identifier: "en_US_POSIX")
 
         for msg in messages {
+            try cancellationCheck?()
             let envelopeDate = dateFormatter.string(from: msg.date)
             let envelopeFrom = msg.isFromMe ? "me" : (msg.handleId.isEmpty ? "unknown" : msg.handleId)
             let envelopeAddr = mboxAddress(envelopeFrom, domain: userDomain)
@@ -948,7 +956,7 @@ final class MessageExporter {
             .replacingOccurrences(of: "'", with: "&#39;")
     }
 
-    private func exportJSON(messages: [Message], chatTitle: String, to path: String) throws {
+    private func exportJSON(messages: [Message], chatTitle: String, to path: String, cancellationCheck: (() throws -> Void)? = nil) throws {
         let outputURL = URL(fileURLWithPath: path)
         try? FileManager.default.removeItem(at: outputURL)
         FileManager.default.createFile(atPath: path, contents: nil)
@@ -970,6 +978,7 @@ final class MessageExporter {
         """)
 
         for (index, msg) in messages.enumerated() {
+            try cancellationCheck?()
             var entry: [String: Any] = [
                 "id": msg.id,
                 "guid": msg.guid,

--- a/Sources/Phosphor/Services/SafariExtractor.swift
+++ b/Sources/Phosphor/Services/SafariExtractor.swift
@@ -176,8 +176,7 @@ final class SafariExtractor {
         case .csv:
             var csv = "Title,URL,Visit Count,Last Visit\n"
             for item in history {
-                let title = item.title.replacingOccurrences(of: "\"", with: "\"\"")
-                csv += "\"\(title)\",\"\(item.url)\",\(item.visitCount),\"\(item.formattedDate)\"\n"
+                csv += CSVExport.row([item.title, item.url, String(item.visitCount), item.formattedDate])
             }
             try csv.write(toFile: path, atomically: true, encoding: .utf8)
         case .json:

--- a/Sources/Phosphor/Services/WhatsAppExporter.swift
+++ b/Sources/Phosphor/Services/WhatsAppExporter.swift
@@ -261,11 +261,8 @@ final class WhatsAppExporter {
     private func exportCSV(messages: [WAMessage], title: String, to path: String) throws {
         var csv = "Date,Sender,Text,Media Type\n"
         for msg in messages {
-            let text = (msg.displayText)
-                .replacingOccurrences(of: "\"", with: "\"\"")
-                .replacingOccurrences(of: "\n", with: " ")
             let sender = msg.isFromMe ? "Me" : (msg.senderJid ?? "Unknown")
-            csv += "\"\(msg.formattedDate)\",\"\(sender)\",\"\(text)\",\"\(msg.mediaTypeLabel)\"\n"
+            csv += CSVExport.row([msg.formattedDate, sender, msg.displayText, msg.mediaTypeLabel])
         }
         try csv.write(toFile: path, atomically: true, encoding: .utf8)
     }

--- a/Sources/Phosphor/Utilities/CSVExport.swift
+++ b/Sources/Phosphor/Utilities/CSVExport.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+enum CSVExport {
+    /// RFC 4180-style CSV field escaping plus spreadsheet formula neutralization.
+    /// Prefixing formula-looking cells keeps exported iOS data from executing if
+    /// a user opens the CSV in Numbers, Excel, or Sheets.
+    static func field(_ raw: String) -> String {
+        var value = raw
+            .replacingOccurrences(of: "\r\n", with: " ")
+            .replacingOccurrences(of: "\n", with: " ")
+            .replacingOccurrences(of: "\r", with: " ")
+
+        if let first = value.drop(while: { $0 == " " || $0 == "\t" }).first,
+           ["=", "+", "-", "@"].contains(String(first)) {
+            value = "'" + value
+        }
+
+        value = value.replacingOccurrences(of: "\"", with: "\"\"")
+        return "\"\(value)\""
+    }
+
+    static func row(_ fields: [String], lineEnding: String = "\n") -> String {
+        fields.map(field).joined(separator: ",") + lineEnding
+    }
+}

--- a/Sources/Phosphor/Utilities/PyMobileDevice.swift
+++ b/Sources/Phosphor/Utilities/PyMobileDevice.swift
@@ -167,6 +167,7 @@ enum PyMobileDevice {
     @discardableResult
     static func runStreaming(
         _ subcommands: [String],
+        timeout: TimeInterval? = nil,
         onOutput: @escaping (String) -> Void,
         onError: @escaping (String) -> Void = { _ in },
         completion: @escaping (Int32) -> Void
@@ -177,45 +178,17 @@ enum PyMobileDevice {
             return nil
         }
 
-        let process = Process()
-        let stdoutPipe = Pipe()
-        let stderrPipe = Pipe()
-
-        process.executableURL = URL(fileURLWithPath: cmd.cmd)
-        process.arguments = cmd.args
-        process.standardOutput = stdoutPipe
-        process.standardError = stderrPipe
-        process.environment = ProcessInfo.processInfo.environment
-        process.environment?["PATH"] = extendedPath
-
-        stdoutPipe.fileHandleForReading.readabilityHandler = { handle in
-            let data = handle.availableData
-            if !data.isEmpty, let str = String(data: data, encoding: .utf8) {
-                DispatchQueue.main.async { onOutput(str) }
-            }
-        }
-
-        stderrPipe.fileHandleForReading.readabilityHandler = { handle in
-            let data = handle.availableData
-            if !data.isEmpty, let str = String(data: data, encoding: .utf8) {
-                DispatchQueue.main.async { onError(str) }
-            }
-        }
-
-        process.terminationHandler = { proc in
-            stdoutPipe.fileHandleForReading.readabilityHandler = nil
-            stderrPipe.fileHandleForReading.readabilityHandler = nil
-            DispatchQueue.main.async { completion(proc.terminationStatus) }
-        }
-
-        do {
-            try process.run()
-            return process
-        } catch {
-            onError("Failed to launch pymobiledevice3: \(error.localizedDescription)")
-            completion(-1)
-            return nil
-        }
+        var environment = ProcessInfo.processInfo.environment
+        environment["PATH"] = extendedPath
+        return Shell.runStreaming(
+            cmd.cmd,
+            arguments: cmd.args,
+            timeout: timeout,
+            environment: environment,
+            onOutput: onOutput,
+            onError: onError,
+            completion: completion
+        )
     }
 
     // MARK: - Device Discovery
@@ -732,6 +705,7 @@ enum PyMobileDevice {
         udid: String? = nil,
         full: Bool = true,
         preferNetwork: Bool = false,
+        timeout: TimeInterval? = 6 * 60 * 60,
         onOutput: @escaping (String) -> Void,
         onError: @escaping (String) -> Void = { _ in },
         completion: @escaping (Int32) -> Void
@@ -746,7 +720,7 @@ enum PyMobileDevice {
         if let udid { args += ["--udid", udid] }
         args.append(directory)
 
-        return runStreaming(args, onOutput: onOutput, onError: onError, completion: completion)
+        return runStreaming(args, timeout: timeout, onOutput: onOutput, onError: onError, completion: completion)
     }
 
     /// Restore a backup.
@@ -755,6 +729,7 @@ enum PyMobileDevice {
         udid: String? = nil,
         system: Bool = true,
         reboot: Bool = true,
+        timeout: TimeInterval? = 6 * 60 * 60,
         onOutput: @escaping (String) -> Void,
         completion: @escaping (Int32) -> Void
     ) -> Process? {
@@ -764,7 +739,7 @@ enum PyMobileDevice {
         if let udid { args += ["--udid", udid] }
         args.append(directory)
 
-        return runStreaming(args, onOutput: onOutput, completion: completion)
+        return runStreaming(args, timeout: timeout, onOutput: onOutput, completion: completion)
     }
 
     /// Check/change encryption.

--- a/Sources/Phosphor/Utilities/Shell.swift
+++ b/Sources/Phosphor/Utilities/Shell.swift
@@ -78,6 +78,44 @@ enum Shell {
         }
     }
 
+    private final class StreamingCommandState: @unchecked Sendable {
+        private let lock = NSLock()
+        private var didFinish = false
+        private var timeoutTask: Task<Void, Never>?
+
+        func hasFinished() -> Bool {
+            lock.lock()
+            let value = didFinish
+            lock.unlock()
+            return value
+        }
+
+        func setTimeoutTask(_ task: Task<Void, Never>) {
+            lock.lock()
+            if didFinish {
+                lock.unlock()
+                task.cancel()
+                return
+            }
+            timeoutTask = task
+            lock.unlock()
+        }
+
+        func finish() -> Bool {
+            lock.lock()
+            guard !didFinish else {
+                lock.unlock()
+                return false
+            }
+            didFinish = true
+            let task = timeoutTask
+            timeoutTask = nil
+            lock.unlock()
+            task?.cancel()
+            return true
+        }
+    }
+
     private static func environmentWithToolPaths() -> [String: String] {
         var environment = ProcessInfo.processInfo.environment
         let home = FileManager.default.homeDirectoryForCurrentUser.path
@@ -250,10 +288,17 @@ enum Shell {
     }
 
     /// Run a command with real-time output streaming via callback. Returns Process for termination.
+    ///
+    /// Long-running one-shot device operations (backup/restore) should pass a timeout so a
+    /// wedged child process cannot leave the UI waiting forever. Truly open-ended streams
+    /// such as syslog should keep the default `nil` timeout and be stopped explicitly by
+    /// the caller.
     @discardableResult
     static func runStreaming(
         _ command: String,
         arguments: [String] = [],
+        timeout: TimeInterval? = nil,
+        environment: [String: String]? = nil,
         onOutput: @escaping (String) -> Void,
         onError: @escaping (String) -> Void = { _ in },
         completion: @escaping (Int32) -> Void
@@ -261,12 +306,22 @@ enum Shell {
         let process = Process()
         let stdoutPipe = Pipe()
         let stderrPipe = Pipe()
+        let state = StreamingCommandState()
 
         process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
         process.arguments = [command] + arguments
         process.standardOutput = stdoutPipe
         process.standardError = stderrPipe
-        process.environment = environmentWithToolPaths()
+        process.environment = environment ?? environmentWithToolPaths()
+
+        @Sendable func finish(exitCode: Int32, timedOut: Bool = false) {
+            guard state.finish() else { return }
+            stdoutPipe.fileHandleForReading.readabilityHandler = nil
+            stderrPipe.fileHandleForReading.readabilityHandler = nil
+            process.terminationHandler = nil
+
+            DispatchQueue.main.async { completion(exitCode) }
+        }
 
         stdoutPipe.fileHandleForReading.readabilityHandler = { handle in
             let data = handle.availableData
@@ -283,18 +338,57 @@ enum Shell {
         }
 
         process.terminationHandler = { proc in
-            stdoutPipe.fileHandleForReading.readabilityHandler = nil
-            stderrPipe.fileHandleForReading.readabilityHandler = nil
-            DispatchQueue.main.async { completion(proc.terminationStatus) }
+            finish(exitCode: proc.terminationStatus)
         }
 
         do {
             try process.run()
-            return process
         } catch {
+            process.terminationHandler = nil
+            stdoutPipe.fileHandleForReading.readabilityHandler = nil
+            stderrPipe.fileHandleForReading.readabilityHandler = nil
             onError("Failed to launch: \(error.localizedDescription)")
             completion(-1)
             return nil
+        }
+
+        if let timeout {
+            let timeoutTask = Task {
+                let nanoseconds = UInt64(max(timeout, 0) * 1_000_000_000)
+                try? await Task.sleep(nanoseconds: nanoseconds)
+                guard !Task.isCancelled, !state.hasFinished() else { return }
+
+                let message = "Command timed out after \(Int(timeout))s"
+                DispatchQueue.main.async { onError(message) }
+                process.terminate()
+                try? await Task.sleep(nanoseconds: 2_000_000_000)
+                guard !Task.isCancelled, !state.hasFinished() else { return }
+
+                process.interrupt()
+                try? await Task.sleep(nanoseconds: 1_000_000_000)
+                guard !Task.isCancelled, !state.hasFinished() else { return }
+
+                Darwin.kill(process.processIdentifier, SIGKILL)
+                try? await Task.sleep(nanoseconds: 1_000_000_000)
+                guard !Task.isCancelled else { return }
+                finish(exitCode: -2, timedOut: true)
+            }
+            state.setTimeoutTask(timeoutTask)
+        }
+
+        return process
+    }
+
+    /// Terminate a long-running child and escalate if it ignores graceful shutdown.
+    static func terminate(_ process: Process) {
+        process.terminate()
+        Task {
+            try? await Task.sleep(nanoseconds: 2_000_000_000)
+            guard process.isRunning else { return }
+            process.interrupt()
+            try? await Task.sleep(nanoseconds: 1_000_000_000)
+            guard process.isRunning else { return }
+            Darwin.kill(process.processIdentifier, SIGKILL)
         }
     }
 

--- a/Sources/Phosphor/ViewModels/BackupViewModel.swift
+++ b/Sources/Phosphor/ViewModels/BackupViewModel.swift
@@ -25,6 +25,7 @@ final class BackupViewModel: ObservableObject {
     private var currentManifest: BackupManifest?
     private var sizeResolutionTask: Task<Void, Never>?
     private var lastBackupRequest: BackupRequest?
+    private var backupOperationID: UUID?
 
     private struct BackupRequest {
         let udid: String
@@ -98,26 +99,35 @@ final class BackupViewModel: ObservableObject {
     }
 
     func createBackup(udid: String, incremental: Bool = false, preferNetwork: Bool = false) async {
+        let operationID = UUID()
+        backupOperationID = operationID
         lastBackupRequest = BackupRequest(udid: udid, incremental: incremental, preferNetwork: preferNetwork)
         isCreating = true
         progressText = "Preparing..."
 
         let success: Bool
         if incremental {
-            success = await backupManager.createIncrementalBackup(udid: udid, preferNetwork: preferNetwork) { [weak self] text in
+            success = await backupManager.createIncrementalBackup(udid: udid, preferNetwork: preferNetwork) { [weak self, operationID] text in
+                guard self?.backupOperationID == operationID else { return }
                 self?.progressText = text
             }
         } else {
-            success = await backupManager.createBackup(udid: udid, preferNetwork: preferNetwork) { [weak self] text in
+            success = await backupManager.createBackup(udid: udid, preferNetwork: preferNetwork) { [weak self, operationID] text in
+                guard self?.backupOperationID == operationID else { return }
                 self?.progressText = text
             }
         }
 
+        guard backupOperationID == operationID else { return }
+        backupOperationID = nil
         isCreating = false
         if success {
             alertMessage = "Backup completed"
             showAlert = true
             loadBackups()
+        } else if backupManager.lastOperationWasCancelled {
+            // User-initiated cancellation is not a backup failure.
+            progressText = "Cancelled"
         } else if let failure = backupManager.lastBackupFailure {
             backupIssue = failure
         } else {

--- a/Sources/Phosphor/ViewModels/MessageViewModel.swift
+++ b/Sources/Phosphor/ViewModels/MessageViewModel.swift
@@ -264,7 +264,9 @@ final class MessageViewModel: ObservableObject {
                 }
                 let filtered = options.apply(to: baseMessages)
                 try Task.checkCancellation()
-                try exporter.exportMessages(filtered, chatTitle: chat.title, format: format, to: normalisedPath, options: options)
+                try exporter.exportMessages(filtered, chatTitle: chat.title, format: format, to: normalisedPath, options: options) {
+                    try Task.checkCancellation()
+                }
                 await MainActor.run { [weak self] in
                     guard let self, self.exportOperationID == exportID, self.backupPath == backupPath else { return }
                     self.isExporting = false
@@ -306,15 +308,23 @@ final class MessageViewModel: ObservableObject {
         exportTask = Task.detached(priority: .userInitiated) { [weak self, backupPath, exportID] in
             do {
                 let exporter = try MessageExporter(backupPath: backupPath, contacts: .empty)
-                let count = try exporter.exportAllChats(format: format, to: directory, options: options) { completed, total, title in
-                    try Task.checkCancellation()
-                    let progress = total == 0 ? 0 : Double(completed) / Double(total)
-                    Task { @MainActor [weak self] in
-                        guard let self, self.exportOperationID == exportID, self.backupPath == backupPath else { return }
-                        self.exportProgress = progress
-                        self.exportProgressText = completed >= total ? "Export complete" : "Exporting \(completed + 1) of \(total): \(title)"
+                let count = try exporter.exportAllChats(
+                    format: format,
+                    to: directory,
+                    options: options,
+                    onProgress: { completed, total, title in
+                        try Task.checkCancellation()
+                        let progress = total == 0 ? 0 : Double(completed) / Double(total)
+                        Task { @MainActor [weak self] in
+                            guard let self, self.exportOperationID == exportID, self.backupPath == backupPath else { return }
+                            self.exportProgress = progress
+                            self.exportProgressText = completed >= total ? "Export complete" : "Exporting \(completed + 1) of \(total): \(title)"
+                        }
+                    },
+                    cancellationCheck: {
+                        try Task.checkCancellation()
                     }
-                }
+                )
                 await MainActor.run { [weak self] in
                     guard let self, self.exportOperationID == exportID, self.backupPath == backupPath else { return }
                     self.isExporting = false

--- a/Sources/Phosphor/ViewModels/MessageViewModel.swift
+++ b/Sources/Phosphor/ViewModels/MessageViewModel.swift
@@ -114,8 +114,45 @@ final class MessageViewModel: ObservableObject {
     private var backupPath: String?
     private var exportCancelled = false
     private var exportTask: Task<Void, Never>?
+    private var exportOperationID: UUID?
+
+    var loadedBackupPath: String? { backupPath }
+
+    func clear() {
+        exportTask?.cancel()
+        exportTask = nil
+        exportOperationID = nil
+        exporter = nil
+        backupPath = nil
+        chats = []
+        selectedChat = nil
+        messages = []
+        searchQuery = ""
+        searchResults = []
+        isLoading = false
+        backupReadiness = .unknown
+        backupReadinessMessage = ""
+        isExporting = false
+        exportProgressText = ""
+        exportProgress = 0
+        exportResult = nil
+        exportCancelled = false
+    }
+
+    private func invalidateExportForBackupSwitch() {
+        exportTask?.cancel()
+        exportTask = nil
+        exportOperationID = nil
+        isExporting = false
+        exportProgressText = ""
+        exportProgress = 0
+        exportCancelled = false
+    }
 
     func loadChats(from backupPath: String) {
+        if self.backupPath != backupPath {
+            invalidateExportForBackupSwitch()
+        }
         self.backupPath = backupPath
         backupReadiness = Self.readiness(for: backupPath)
         backupReadinessMessage = backupReadiness.subtitle
@@ -211,8 +248,10 @@ final class MessageViewModel: ObservableObject {
         exportCancelled = false
         exportProgress = 0.1
         exportProgressText = "Exporting \(chat.title)…"
+        let exportID = UUID()
+        exportOperationID = exportID
 
-        exportTask = Task.detached(priority: .userInitiated) { [weak self, chat, sourceMessages, fallbackMessages, backupPath] in
+        exportTask = Task.detached(priority: .userInitiated) { [weak self, chat, sourceMessages, fallbackMessages, backupPath, exportID] in
             do {
                 let exporter = try MessageExporter(backupPath: backupPath, contacts: .empty)
                 let baseMessages: [Message]
@@ -227,22 +266,27 @@ final class MessageViewModel: ObservableObject {
                 try Task.checkCancellation()
                 try exporter.exportMessages(filtered, chatTitle: chat.title, format: format, to: normalisedPath, options: options)
                 await MainActor.run { [weak self] in
-                    guard let self else { return }
+                    guard let self, self.exportOperationID == exportID, self.backupPath == backupPath else { return }
                     self.isExporting = false
+                    self.exportOperationID = nil
                     self.exportProgress = 1
                     self.exportResult = MessageExportResult(url: URL(fileURLWithPath: normalisedPath), summary: "Exported \(filtered.count) messages")
                 }
             } catch is CancellationError {
                 await MainActor.run { [weak self] in
-                    self?.isExporting = false
-                    self?.alertMessage = "Export cancelled"
-                    self?.showAlert = true
+                    guard let self, self.exportOperationID == exportID, self.backupPath == backupPath else { return }
+                    self.isExporting = false
+                    self.exportOperationID = nil
+                    self.alertMessage = "Export cancelled"
+                    self.showAlert = true
                 }
             } catch {
                 await MainActor.run { [weak self] in
-                    self?.isExporting = false
-                    self?.alertMessage = "Export failed: \(error.localizedDescription)"
-                    self?.showAlert = true
+                    guard let self, self.exportOperationID == exportID, self.backupPath == backupPath else { return }
+                    self.isExporting = false
+                    self.exportOperationID = nil
+                    self.alertMessage = "Export failed: \(error.localizedDescription)"
+                    self.showAlert = true
                 }
             }
         }
@@ -256,35 +300,43 @@ final class MessageViewModel: ObservableObject {
         exportCancelled = false
         exportProgress = 0
         exportProgressText = "Preparing export…"
+        let exportID = UUID()
+        exportOperationID = exportID
 
-        exportTask = Task.detached(priority: .userInitiated) { [weak self, backupPath] in
+        exportTask = Task.detached(priority: .userInitiated) { [weak self, backupPath, exportID] in
             do {
                 let exporter = try MessageExporter(backupPath: backupPath, contacts: .empty)
                 let count = try exporter.exportAllChats(format: format, to: directory, options: options) { completed, total, title in
                     try Task.checkCancellation()
                     let progress = total == 0 ? 0 : Double(completed) / Double(total)
                     Task { @MainActor [weak self] in
-                        self?.exportProgress = progress
-                        self?.exportProgressText = completed >= total ? "Export complete" : "Exporting \(completed + 1) of \(total): \(title)"
+                        guard let self, self.exportOperationID == exportID, self.backupPath == backupPath else { return }
+                        self.exportProgress = progress
+                        self.exportProgressText = completed >= total ? "Export complete" : "Exporting \(completed + 1) of \(total): \(title)"
                     }
                 }
                 await MainActor.run { [weak self] in
-                    guard let self else { return }
+                    guard let self, self.exportOperationID == exportID, self.backupPath == backupPath else { return }
                     self.isExporting = false
+                    self.exportOperationID = nil
                     self.exportProgress = 1
                     self.exportResult = MessageExportResult(url: URL(fileURLWithPath: directory), summary: "Exported \(count) conversations")
                 }
             } catch is CancellationError {
                 await MainActor.run { [weak self] in
-                    self?.isExporting = false
-                    self?.alertMessage = "Export cancelled"
-                    self?.showAlert = true
+                    guard let self, self.exportOperationID == exportID, self.backupPath == backupPath else { return }
+                    self.isExporting = false
+                    self.exportOperationID = nil
+                    self.alertMessage = "Export cancelled"
+                    self.showAlert = true
                 }
             } catch {
                 await MainActor.run { [weak self] in
-                    self?.isExporting = false
-                    self?.alertMessage = "Export failed: \(error.localizedDescription)"
-                    self?.showAlert = true
+                    guard let self, self.exportOperationID == exportID, self.backupPath == backupPath else { return }
+                    self.isExporting = false
+                    self.exportOperationID = nil
+                    self.alertMessage = "Export failed: \(error.localizedDescription)"
+                    self.showAlert = true
                 }
             }
         }

--- a/Sources/Phosphor/Views/Backup/BackupTimeMachineView.swift
+++ b/Sources/Phosphor/Views/Backup/BackupTimeMachineView.swift
@@ -361,7 +361,7 @@ struct BackupTimeMachineView: View {
             isRestoring = false
             restoreProgress = nil
 
-            if !success {
+            if !success, !backupVM.backupManager.lastOperationWasCancelled {
                 backupVM.alertMessage = "Restore failed. Check device connection."
                 backupVM.showAlert = true
             }

--- a/Sources/Phosphor/Views/Messages/MessageListView.swift
+++ b/Sources/Phosphor/Views/Messages/MessageListView.swift
@@ -27,6 +27,12 @@ struct MessageListView: View {
             messageDetailPane
         }
         .onAppear(perform: loadIfNeeded)
+        .onChange(of: backupVM.selectedBackup?.id) { _, _ in
+            handleSelectedBackupChange()
+        }
+        .onChange(of: backupVM.backups.map(\.path)) { _, _ in
+            reconcileLoadedBackupWithAvailableBackups()
+        }
         .overlay(alignment: .bottom) {
             if messageVM.isExporting { exportProgressBar }
         }
@@ -54,10 +60,10 @@ struct MessageListView: View {
                 Text("Messages")
                     .font(.headline)
                 Spacer()
-                if !messageVM.chats.isEmpty {
+                if loadedBackupIsCurrent && !messageVM.chats.isEmpty {
                     exportAllMenu
                 }
-                if !messageVM.chats.isEmpty {
+                if loadedBackupIsCurrent && !messageVM.chats.isEmpty {
                     Text("\(messageVM.totalMessages) messages")
                         .font(.system(size: 11))
                         .foregroundStyle(.tertiary)
@@ -90,6 +96,14 @@ struct MessageListView: View {
 
             if messageVM.isLoading {
                 LoadingOverlay(message: "Loading messages...")
+            } else if messageVM.loadedBackupPath != nil && loadedBackupIsCurrent && messageVM.chats.isEmpty && messageVM.backupReadiness != .unknown {
+                EmptyStateView(
+                    icon: messageVM.backupReadiness.icon,
+                    title: messageVM.backupReadiness.title,
+                    subtitle: messageVM.backupReadiness.subtitle,
+                    action: chooseBackupFolder,
+                    actionLabel: "Choose Different Backup"
+                )
             } else if backupVM.selectedBackup == nil && backupVM.backups.isEmpty {
                 EmptyStateView(
                     icon: "message",
@@ -114,7 +128,7 @@ struct MessageListView: View {
                     },
                     actionLabel: backupVM.backups.isEmpty ? "Choose Backup Folder" : "Use Latest Backup"
                 )
-            } else if messageVM.chats.isEmpty {
+            } else if loadedBackupIsCurrent && messageVM.chats.isEmpty {
                 EmptyStateView(
                     icon: messageVM.backupReadiness.icon,
                     title: messageVM.backupReadiness.title,
@@ -316,7 +330,7 @@ struct MessageListView: View {
 
     private var messageDetailPane: some View {
         VStack(spacing: 0) {
-            if let chat = messageVM.selectedChat {
+            if let chat = messageVM.selectedChat, loadedBackupIsCurrent {
                 // Chat header
                 HStack {
                     Text(chat.title)
@@ -374,19 +388,32 @@ struct MessageListView: View {
                 EmptyStateView(
                     icon: "bubble.left.and.bubble.right",
                     title: "Select a Conversation",
-                    subtitle: messageVM.chats.isEmpty
-                        ? "Choose a backup to load messages."
-                        : "Choose a conversation from the list, or export every conversation at once.",
-                    action: messageVM.chats.isEmpty ? nil : {
+                    subtitle: loadedBackupIsCurrent && !messageVM.chats.isEmpty
+                        ? "Choose a conversation from the list, or export every conversation at once."
+                        : "Choose a backup to load messages.",
+                    action: loadedBackupIsCurrent && !messageVM.chats.isEmpty ? {
                         exportAllConversations(format: .html)
-                    },
-                    actionLabel: messageVM.chats.isEmpty ? nil : "Export All as HTML…"
+                    } : nil,
+                    actionLabel: loadedBackupIsCurrent && !messageVM.chats.isEmpty ? "Export All as HTML…" : nil
                 )
             }
         }
     }
 
     // MARK: - Helpers
+
+    private var loadedBackupIsCurrent: Bool {
+        guard let loadedPath = messageVM.loadedBackupPath else { return false }
+        guard backupVM.backups.contains(where: { $0.path == loadedPath }) else { return false }
+        if let selected = backupVM.selectedBackup {
+            return selected.path == loadedPath
+        }
+        // Some message-readable states (for example encrypted or unreadable backups)
+        // intentionally do not leave BackupViewModel.selectedBackup set because the
+        // manifest browser cannot open them. Keep their Messages readiness copy visible
+        // as long as the loaded backup still exists in the picker list.
+        return true
+    }
 
     private func loadIfNeeded() {
         if backupVM.backups.isEmpty {
@@ -415,10 +442,35 @@ struct MessageListView: View {
         guard backupVM.backups.map(\.path) != previousPaths else { return }
         if let latest = backupVM.backups.first {
             selectBackup(latest)
+        } else {
+            messageVM.clear()
+        }
+    }
+
+    private func handleSelectedBackupChange() {
+        if let backup = backupVM.selectedBackup {
+            if messageVM.loadedBackupPath != backup.path {
+                loadMessages(from: backup)
+            }
+        } else {
+            reconcileLoadedBackupWithAvailableBackups()
+        }
+    }
+
+    private func reconcileLoadedBackupWithAvailableBackups() {
+        guard let loadedPath = messageVM.loadedBackupPath else { return }
+        guard backupVM.backups.contains(where: { $0.path == loadedPath }) else {
+            messageVM.clear()
+            return
+        }
+        if let selected = backupVM.selectedBackup, selected.path != loadedPath {
+            loadMessages(from: selected)
         }
     }
 
     private func loadMessages(from backup: BackupInfo) {
+        searchText = ""
+        messageSearchText = ""
         messageVM.loadChats(from: backup.path)
         if messageVM.selectedChat == nil, let firstChat = messageVM.chats.first {
             messageVM.selectChat(firstChat)
@@ -430,7 +482,7 @@ struct MessageListView: View {
     /// single `UTType` per modifier and was rewriting `.html` to `.txt`
     /// (issue #17).
     private func exportSingleChat(format: MessageExportFormat) {
-        guard let chat = messageVM.selectedChat else { return }
+        guard loadedBackupIsCurrent, let chat = messageVM.selectedChat else { return }
         let panel = NSSavePanel()
         panel.title = "Export Conversation"
         panel.nameFieldStringValue = "\(safeFileName(chat.title)).\(format.fileExtension)"
@@ -451,6 +503,7 @@ struct MessageListView: View {
     }
 
     private func exportAllConversations(format: MessageExportFormat) {
+        guard loadedBackupIsCurrent else { return }
         let panel = NSOpenPanel()
         panel.canChooseFiles = false
         panel.canChooseDirectories = true


### PR DESCRIPTION
## Summary
- Tracks backup/restore cancellation by operation ID so cancelled primaries cannot fall through to fallback or surface as failures.
- Adds syslog runtime fallback from pymobiledevice3 to idevicesyslog while preserving Stop/stale-stream safety.
- Guards detached Messages export completions with export identity + backup path, and strengthens regression coverage.

## Verification
- `Scripts/regression-tests.py` — PASS 38 checks
- `swift build` — passed
- `swift build -c release` — passed
- `bash Scripts/build.sh` — passed
- `Scripts/benchmark-performance.sh` — passed (tree speedup ~5.86x, polling speedup ~1.55x)

Note: intentionally no version bump in this follow-up.
