### PR TITLE
feat: add readiness center and diagnostics guidance

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -40,9 +40,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.9</string>
+	<string>1.0.10</string>
 	<key>CFBundleVersion</key>
-	<string>9</string>
+	<string>10</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/Scripts/regression/checks/device_backup.py
+++ b/Scripts/regression/checks/device_backup.py
@@ -117,6 +117,9 @@ def test_incremental_backups_require_existing_metadata(root: Path) -> None:
     assert_contains(manager, "incompleteBackupHasKnownMarkers", "Incomplete-backup recovery should require recognizable iOS backup markers before moving a folder")
     assert_contains(manager, "trashItem", "Incomplete-backup recovery should move folders to Trash instead of permanently deleting them")
     assert_not_contains(manager, "removeItem(atPath: path)", "Incomplete-backup recovery should not permanently delete backup folders")
+    assert_contains(manager, "finalizeSuccessfulBackup", "Completed backup commands should be verified before the UI reports success")
+    assert_contains(manager, "Backup Metadata Incomplete", "Post-backup verification should surface incomplete metadata as a structured failure")
+    assert_contains(manager, "backupMetadataHealth(for: udid)", "Post-backup verification should require complete metadata for the target device")
 
     view = read(root, "Sources/Phosphor/Views/Backup/BackupListView.swift")
     assert_contains(view, "shouldOfferIncremental(for: device)", "Backup UI should only offer incremental when a backup exists for the selected device")

--- a/Scripts/regression/checks/readiness_center.py
+++ b/Scripts/regression/checks/readiness_center.py
@@ -13,6 +13,7 @@ def test_readiness_service_contract(root: Path) -> None:
     src = path.read_text()
     for token in [
         "enum ReadinessStatus",
+        "enum ReadinessOperation",
         "struct ReadinessItem",
         "struct ReadinessReport",
         "enum ReadinessService",
@@ -79,5 +80,19 @@ def test_readiness_center_visible_in_navigation(root: Path) -> None:
         "Safe Operations",
         "Diagnostic Report",
         "Next Steps",
+        "Backup Recovery",
     ]:
         assert phrase in view_src, f"Readiness center missing user-facing section: {phrase}"
+
+
+def test_readiness_center_incomplete_backup_recovery_action(root: Path) -> None:
+    service = read(root, "Sources/Phosphor/Services/ReadinessService.swift")
+    view = read(root, "Sources/Phosphor/Views/Readiness/ReadinessCenterView.swift")
+    assert "enum ReadinessOperation" in service, "readiness rows should carry confirmable recovery operations"
+    assert "incompleteBackupItems" in service, "readiness should detect incomplete backup folders"
+    assert "BackupManager.incompleteBackupHasKnownMarkers" in service, "incomplete detection should only flag recognizable iOS backup folders"
+    assert "deleteIncompleteBackupAndRunFull" in service, "incomplete backup rows should offer a recovery operation"
+    assert "pendingRecovery" in view, "readiness recovery should require a confirmation alert"
+    assert "Move Incomplete Backup to Trash" in view, "readiness center should expose the cleanup action"
+    assert "BackupManager.deleteIncompleteBackup" in view, "cleanup should use the guarded BackupManager trash flow"
+    assert "device.connectionType == .usb" in view, "readiness should auto-start full backup only on USB"

--- a/Scripts/regression/checks/readiness_center.py
+++ b/Scripts/regression/checks/readiness_center.py
@@ -19,10 +19,31 @@ def test_readiness_service_contract(root: Path) -> None:
         "static func evaluate",
         "static func dependencyStatus",
         "Task.detached",
-        "BackupManager.validateBackupDirectory",
+        "BackupManager.validateBackupDirectory(path, createIfMissing: false)",
         "diagnosticMarkdown",
+        "redactedValue(item.detail)",
+        "idevicebackup2",
     ]:
         assert token in src, f"ReadinessService missing {token}"
+
+
+def test_readiness_diagnostics_are_redacted_and_side_effect_free(root: Path) -> None:
+    readiness = read(root, "Sources/Phosphor/Services/ReadinessService.swift")
+    backup_manager = read(root, "Sources/Phosphor/Services/BackupManager.swift")
+    assert "redactedValue(item.detail)" in readiness, "diagnostic detail text must be redacted before export"
+    assert "redactedValue(recoveryAction)" in readiness, "diagnostic recovery text must be redacted before export"
+    assert "redactedValue(technicalDetail)" in readiness, "diagnostic technical detail must be redacted before export"
+    assert "[A-Fa-f0-9]{8}-[A-Fa-f0-9]{16}" in readiness, "modern UDID-like values should be redacted"
+    assert "[A-Fa-f0-9]{40}" in readiness, "legacy 40-char UDIDs should be redacted"
+    assert "createIfMissing: Bool = true" in backup_manager, "backup validation should let callers opt out of creation"
+    assert "BackupManager.validateBackupDirectory(path, createIfMissing: false)" in readiness, "readiness checks should inspect without creating folders"
+
+
+def test_readiness_tool_classification_requires_backup_backend(root: Path) -> None:
+    src = read(root, "Sources/Phosphor/Services/ReadinessService.swift")
+    assert "hasLibimobiledeviceBackup" in src, "libimobiledevice readiness should be backup-specific"
+    assert "dependencies[\"idevicebackup2\"] == true" in src, "libimobiledevice backup readiness requires idevicebackup2"
+    assert "hasBackupTooling" in src, "next-step status should use the same backup-tool readiness as Tool Readiness"
 
 
 def test_dependency_checks_are_not_wrapped_in_global_dispatch(root: Path) -> None:

--- a/Scripts/regression/checks/readiness_center.py
+++ b/Scripts/regression/checks/readiness_center.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def read(root: Path, rel: str) -> str:
+    return (root / rel).read_text()
+
+
+def test_readiness_service_contract(root: Path) -> None:
+    path = root / "Sources/Phosphor/Services/ReadinessService.swift"
+    assert path.exists(), "ReadinessService.swift should centralize readiness checks"
+    src = path.read_text()
+    for token in [
+        "enum ReadinessStatus",
+        "struct ReadinessItem",
+        "struct ReadinessReport",
+        "enum ReadinessService",
+        "static func evaluate",
+        "static func dependencyStatus",
+        "Task.detached",
+        "BackupManager.validateBackupDirectory",
+        "diagnosticMarkdown",
+    ]:
+        assert token in src, f"ReadinessService missing {token}"
+
+
+def test_dependency_checks_are_not_wrapped_in_global_dispatch(root: Path) -> None:
+    for rel in [
+        "Sources/Phosphor/Services/DeviceManager.swift",
+        "Sources/Phosphor/Views/ContentView.swift",
+        "Sources/Phosphor/Views/Onboarding/OnboardingView.swift",
+        "Sources/Phosphor/Views/Settings/SettingsView.swift",
+    ]:
+        src = read(root, rel)
+        assert "DispatchQueue.global().async" not in src, f"{rel} still uses global dispatch for readiness/dependencies"
+        assert "Shell.checkDependencies()" not in src, f"{rel} still calls Shell.checkDependencies directly"
+    assert "ReadinessService.dependencyStatus" in read(root, "Sources/Phosphor/Services/DeviceManager.swift")
+    assert "ReadinessService.dependencyStatus" in read(root, "Sources/Phosphor/Views/ContentView.swift")
+    assert "ReadinessService.dependencyStatus" in read(root, "Sources/Phosphor/Views/Onboarding/OnboardingView.swift")
+    assert "ReadinessService.dependencyStatus" in read(root, "Sources/Phosphor/Views/Settings/SettingsView.swift")
+
+
+def test_readiness_center_visible_in_navigation(root: Path) -> None:
+    sidebar = read(root, "Sources/Phosphor/Views/SidebarView.swift")
+    content = read(root, "Sources/Phosphor/Views/ContentView.swift")
+    view_path = root / "Sources/Phosphor/Views/Readiness/ReadinessCenterView.swift"
+    assert view_path.exists(), "ReadinessCenterView should exist"
+    view_src = view_path.read_text()
+    assert "case readiness" in sidebar, "SidebarSection should include readiness"
+    assert "sidebarRow(.readiness)" in sidebar, "Readiness should be visible in the sidebar"
+    assert "ReadinessCenterView" in content, "ContentView should route to the readiness center"
+    for phrase in [
+        "Tool Readiness",
+        "Backup Folder",
+        "Device Visibility",
+        "Wi-Fi Backup",
+        "Safe Operations",
+        "Diagnostic Report",
+        "Next Steps",
+    ]:
+        assert phrase in view_src, f"Readiness center missing user-facing section: {phrase}"

--- a/Sources/Phosphor/Services/BackupManager.swift
+++ b/Sources/Phosphor/Services/BackupManager.swift
@@ -343,6 +343,44 @@ final class BackupManager: ObservableObject {
         return looksLikeBackupFolder(deviceDirectory) ? .complete : .incomplete(path: deviceDirectory)
     }
 
+    private func finalizeSuccessfulBackup(udid: String, onProgress: @escaping (String) -> Void) -> Bool {
+        isCreatingBackup = false
+        switch Self.backupMetadataHealth(for: udid) {
+        case .complete:
+            backupProgress = "Backup complete"
+            backupPercent = 1.0
+            discoverBackups()
+            return true
+        case .missing:
+            backupProgress = "Backup metadata incomplete"
+            let path = Self.backupPath(for: udid)
+            lastBackupFailure = BackupFailure(
+                title: "Backup Metadata Incomplete",
+                message: "The backup command finished, but Phosphor could not find complete backup metadata. Run a fresh full backup with the device unlocked and connected over USB when possible.",
+                technicalDetails: path,
+                recoveryAction: .runFullBackup,
+                udid: udid,
+                recoveryPath: path
+            )
+            lastError = lastBackupFailure?.message
+            onProgress(lastError ?? "Backup metadata incomplete.")
+            return false
+        case .incomplete(let path):
+            backupProgress = "Backup metadata incomplete"
+            lastBackupFailure = BackupFailure(
+                title: "Backup Metadata Incomplete",
+                message: "The backup command finished, but the resulting backup metadata is incomplete. Move the incomplete folder to Trash, then run a fresh full backup with the device unlocked and connected over USB when possible.",
+                technicalDetails: path,
+                recoveryAction: .deleteIncompleteAndRunFull,
+                udid: udid,
+                recoveryPath: path
+            )
+            lastError = lastBackupFailure?.message
+            onProgress(lastError ?? "Backup metadata incomplete.")
+            return false
+        }
+    }
+
     /// Incremental backups require an existing valid backup metadata folder for
     /// the target UDID. If the folder is missing or partially-created, both
     /// backup backends fail with low-level MBErrorDomain/205 plist errors.
@@ -447,11 +485,7 @@ final class BackupManager: ObservableObject {
             onProgress: onProgress
         )
         if pySuccess {
-            isCreatingBackup = false
-            backupProgress = "Backup complete"
-            backupPercent = 1.0
-            discoverBackups()
-            return true
+            return finalizeSuccessfulBackup(udid: udid, onProgress: onProgress)
         }
 
         let pymobiledeviceStderr = pymobiledeviceStderrTail.joined(separator: "\n")
@@ -481,15 +515,15 @@ final class BackupManager: ObservableObject {
                 completion: { [weak self] exitCode in
                     Task { @MainActor in
                         guard let self else {
-                            continuation.resume(returning: exitCode == 0)
+                            continuation.resume(returning: false)
                             return
                         }
-                        self.isCreatingBackup = false
                         if exitCode == 0 {
-                            self.backupProgress = "Backup complete"
-                            self.backupPercent = 1.0
-                            self.discoverBackups()
+                            let verified = self.finalizeSuccessfulBackup(udid: udid, onProgress: onProgress)
+                            continuation.resume(returning: verified)
+                            return
                         } else {
+                            self.isCreatingBackup = false
                             let combinedStderr = [pymobiledeviceStderr, idevicebackupStderr]
                                 .filter { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
                                 .joined(separator: "\n---\n")
@@ -506,7 +540,7 @@ final class BackupManager: ObservableObject {
                                 stderr: combinedStderr
                             )
                         }
-                        continuation.resume(returning: exitCode == 0)
+                        continuation.resume(returning: false)
                     }
                 }
             )
@@ -655,11 +689,7 @@ final class BackupManager: ObservableObject {
                 onProgress: onProgress
             )
             if success {
-                isCreatingBackup = false
-                backupProgress = "Backup complete"
-                backupPercent = 1.0
-                discoverBackups()
-                return true
+                return finalizeSuccessfulBackup(udid: udid, onProgress: onProgress)
             }
         }
 
@@ -688,12 +718,12 @@ final class BackupManager: ObservableObject {
                             continuation.resume(returning: exitCode == 0)
                             return
                         }
-                        self.isCreatingBackup = false
                         if exitCode == 0 {
-                            self.backupProgress = "Backup complete"
-                            self.backupPercent = 1.0
-                            self.discoverBackups()
+                            let verified = self.finalizeSuccessfulBackup(udid: udid, onProgress: onProgress)
+                            continuation.resume(returning: verified)
+                            return
                         } else {
+                            self.isCreatingBackup = false
                             let combinedStderr = [pymobiledeviceStderr, idevicebackupStderr]
                                 .filter { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
                                 .joined(separator: "\n---\n")

--- a/Sources/Phosphor/Services/BackupManager.swift
+++ b/Sources/Phosphor/Services/BackupManager.swift
@@ -98,10 +98,13 @@ final class BackupManager: ObservableObject {
     /// Preflight check: verify the active backup directory exists and is readable/writable
     /// by this process. ~/Library/Application Support/MobileSync/Backup is TCC-protected
     /// on macOS 10.15+ and requires Full Disk Access for sandboxed or unsigned apps.
-    static func validateBackupDirectory(_ path: String) -> (ok: Bool, reason: String?) {
+    static func validateBackupDirectory(_ path: String, createIfMissing: Bool = true) -> (ok: Bool, reason: String?) {
         let fm = FileManager.default
         var isDir: ObjCBool = false
         if !fm.fileExists(atPath: path, isDirectory: &isDir) {
+            guard createIfMissing else {
+                return (false, "Backup directory does not exist at \(path).")
+            }
             do {
                 try fm.createDirectory(atPath: path, withIntermediateDirectories: true)
             } catch {

--- a/Sources/Phosphor/Services/DeviceManager.swift
+++ b/Sources/Phosphor/Services/DeviceManager.swift
@@ -29,11 +29,7 @@ final class DeviceManager: ObservableObject {
 
     func checkDependencies() {
         Task {
-            dependencyStatus = await withCheckedContinuation { continuation in
-                DispatchQueue.global().async {
-                    continuation.resume(returning: Shell.checkDependencies())
-                }
-            }
+            dependencyStatus = await ReadinessService.dependencyStatus()
         }
     }
 

--- a/Sources/Phosphor/Services/ReadinessService.swift
+++ b/Sources/Phosphor/Services/ReadinessService.swift
@@ -8,6 +8,11 @@ enum ReadinessStatus: String {
     case info = "Info"
 }
 
+/// Recovery operation that can be launched directly from a readiness row after user confirmation.
+enum ReadinessOperation: Hashable {
+    case deleteIncompleteBackupAndRunFull(udid: String, path: String)
+}
+
 /// One actionable readiness row shown in the Readiness Center and diagnostic report.
 struct ReadinessItem: Identifiable, Hashable {
     let id = UUID()
@@ -16,19 +21,22 @@ struct ReadinessItem: Identifiable, Hashable {
     let status: ReadinessStatus
     let recoveryAction: String?
     let technicalDetail: String?
+    let operation: ReadinessOperation?
 
     init(
         title: String,
         detail: String,
         status: ReadinessStatus,
         recoveryAction: String? = nil,
-        technicalDetail: String? = nil
+        technicalDetail: String? = nil,
+        operation: ReadinessOperation? = nil
     ) {
         self.title = title
         self.detail = detail
         self.status = status
         self.recoveryAction = recoveryAction
         self.technicalDetail = technicalDetail
+        self.operation = operation
     }
 }
 
@@ -130,6 +138,7 @@ enum ReadinessService {
             ))
         }
 
+        items.append(contentsOf: incompleteBackupItems(in: backupDirectory, devices: devices))
         items.append(deviceVisibilityItem(devices: devices, nearbyWirelessDevices: nearbyWirelessDevices))
         items.append(wifiBackupItem(devices: devices, nearbyWirelessDevices: nearbyWirelessDevices))
         items.append(ReadinessItem(
@@ -206,6 +215,35 @@ enum ReadinessService {
             recoveryAction: "Open Settings and choose a user-owned local backup folder such as ~/Documents/Phosphor Backups.",
             technicalDetail: path
         )
+    }
+
+    @MainActor
+    private static func incompleteBackupItems(in directory: String, devices: [DeviceInfo]) -> [ReadinessItem] {
+        var candidates = Set(devices.map(\.id))
+        let fm = FileManager.default
+        let childNames = (try? fm.contentsOfDirectory(atPath: directory)) ?? []
+        for childName in childNames {
+            let childPath = (directory as NSString).appendingPathComponent(childName)
+            var isDir: ObjCBool = false
+            guard fm.fileExists(atPath: childPath, isDirectory: &isDir), isDir.boolValue else { continue }
+            guard BackupManager.incompleteBackupHasKnownMarkers(childPath) else { continue }
+            candidates.insert(childName)
+        }
+
+        return candidates.compactMap { udid in
+            guard case .incomplete(let path) = BackupManager.backupMetadataHealth(for: udid, in: directory) else {
+                return nil
+            }
+            return ReadinessItem(
+                title: "Incomplete Backup Found",
+                detail: "A previous backup for this device did not finish, so iOS may reject another backup in this folder.",
+                status: .blocked,
+                recoveryAction: "Move the incomplete folder to Trash, then run a fresh full backup with the device unlocked and connected over USB when possible.",
+                technicalDetail: path,
+                operation: .deleteIncompleteBackupAndRunFull(udid: udid, path: path)
+            )
+        }
+        .sorted { ($0.technicalDetail ?? $0.title) < ($1.technicalDetail ?? $1.title) }
     }
 
     private static func deviceVisibilityItem(

--- a/Sources/Phosphor/Services/ReadinessService.swift
+++ b/Sources/Phosphor/Services/ReadinessService.swift
@@ -1,0 +1,283 @@
+import Foundation
+
+/// High-level readiness status for user-facing setup and safety checks.
+enum ReadinessStatus: String {
+    case ready = "Ready"
+    case warning = "Warning"
+    case blocked = "Blocked"
+    case info = "Info"
+}
+
+/// One actionable readiness row shown in the Readiness Center and diagnostic report.
+struct ReadinessItem: Identifiable, Hashable {
+    let id = UUID()
+    let title: String
+    let detail: String
+    let status: ReadinessStatus
+    let recoveryAction: String?
+    let technicalDetail: String?
+
+    init(
+        title: String,
+        detail: String,
+        status: ReadinessStatus,
+        recoveryAction: String? = nil,
+        technicalDetail: String? = nil
+    ) {
+        self.title = title
+        self.detail = detail
+        self.status = status
+        self.recoveryAction = recoveryAction
+        self.technicalDetail = technicalDetail
+    }
+}
+
+/// Snapshot of whether Phosphor is ready for common user-facing workflows.
+struct ReadinessReport {
+    let generatedAt: Date
+    let items: [ReadinessItem]
+    let backupDirectory: String
+    let connectedDeviceCount: Int
+    let wifiDeviceCount: Int
+    let nearbyWirelessHintCount: Int
+
+    var hasBlockers: Bool { items.contains { $0.status == .blocked } }
+    var hasWarnings: Bool { items.contains { $0.status == .warning } }
+
+    var summary: String {
+        if hasBlockers { return "Setup needs attention before backups and exports are reliable." }
+        if hasWarnings { return "Phosphor is usable, with a few recommended fixes." }
+        return "Phosphor is ready for backups, browsing, diagnostics, and exports."
+    }
+
+    var diagnosticMarkdown: String {
+        let formatter = ISO8601DateFormatter()
+        var lines: [String] = [
+            "# Phosphor Diagnostic Report",
+            "",
+            "Generated: \(formatter.string(from: generatedAt))",
+            "Summary: \(summary)",
+            "Backup Directory: \(Self.redactedPath(backupDirectory))",
+            "Connected Devices: \(connectedDeviceCount)",
+            "Backup-capable Wi-Fi Devices: \(wifiDeviceCount)",
+            "Nearby Finder/Bonjour Hints: \(nearbyWirelessHintCount)",
+            "",
+            "## Readiness Items"
+        ]
+
+        for item in items {
+            lines.append("- [\(item.status.rawValue)] \(item.title): \(item.detail)")
+            if let recoveryAction = item.recoveryAction, !recoveryAction.isEmpty {
+                lines.append("  - Recovery: \(recoveryAction)")
+            }
+            if let technicalDetail = item.technicalDetail, !technicalDetail.isEmpty {
+                lines.append("  - Technical: \(Self.redactedPath(technicalDetail))")
+            }
+        }
+
+        lines.append(contentsOf: [
+            "",
+            "## Privacy",
+            "This report intentionally avoids UDIDs, serial numbers, phone numbers, and device names. Paths are home-folder redacted."
+        ])
+        return lines.joined(separator: "\n") + "\n"
+    }
+
+    private static func redactedPath(_ value: String) -> String {
+        let home = FileManager.default.homeDirectoryForCurrentUser.path
+        return value.replacingOccurrences(of: home, with: "~")
+    }
+}
+
+enum ReadinessService {
+    /// Check CLI dependencies off the main actor without consuming an unbounded global
+    /// dispatch worker from SwiftUI views. Shell.checkDependencies remains synchronous,
+    /// but Task.detached keeps first paint and view updates responsive.
+    static func dependencyStatus() async -> [String: Bool] {
+        await Task.detached(priority: .utility) {
+            Shell.checkDependencies()
+        }.value
+    }
+
+    @MainActor
+    static func evaluate(
+        devices: [DeviceInfo],
+        nearbyWirelessDevices: [PyMobileDevice.BonjourDevice],
+        backupDirectory: String
+    ) async -> ReadinessReport {
+        async let dependencies = dependencyStatus()
+        let dependencyMap = await dependencies
+
+        var items: [ReadinessItem] = []
+        items.append(toolReadinessItem(dependencyMap))
+        items.append(backupFolderItem(path: backupDirectory))
+        if let warning = BackupManager.backupDirectoryWarning(for: backupDirectory) {
+            items.append(ReadinessItem(
+                title: "Backup Folder Warning",
+                detail: warning,
+                status: .warning,
+                recoveryAction: "Choose a local folder such as ~/Documents/Phosphor Backups for active iOS backups.",
+                technicalDetail: backupDirectory
+            ))
+        }
+
+        items.append(deviceVisibilityItem(devices: devices, nearbyWirelessDevices: nearbyWirelessDevices))
+        items.append(wifiBackupItem(devices: devices, nearbyWirelessDevices: nearbyWirelessDevices))
+        items.append(ReadinessItem(
+            title: "Safe Operations",
+            detail: "Exports, imports, deletes, and backup actions should show a clear destination or destructive-action summary before changing files.",
+            status: .info,
+            recoveryAction: "Review the action summary before confirming; prefer Reveal in Finder after exports."
+        ))
+        items.append(ReadinessItem(
+            title: "Diagnostic Report",
+            detail: "A redacted Markdown report can be exported for bug reports without UDIDs, serial numbers, phone numbers, or device names.",
+            status: .info,
+            recoveryAction: "Use Export Diagnostic Report before filing an issue."
+        ))
+        items.append(ReadinessItem(
+            title: "Next Steps",
+            detail: nextSteps(devices: devices, dependencies: dependencyMap),
+            status: nextStepStatus(devices: devices, dependencies: dependencyMap)
+        ))
+
+        return ReadinessReport(
+            generatedAt: Date(),
+            items: items,
+            backupDirectory: backupDirectory,
+            connectedDeviceCount: devices.count,
+            wifiDeviceCount: devices.filter { $0.connectionType == .wifi }.count,
+            nearbyWirelessHintCount: nearbyWirelessDevices.count
+        )
+    }
+
+    private static func toolReadinessItem(_ dependencies: [String: Bool]) -> ReadinessItem {
+        let hasPymobiledevice = dependencies["pymobiledevice3"] == true
+        let hasLibimobiledeviceCore = dependencies["idevice_id"] == true && dependencies["ideviceinfo"] == true
+        let missing = dependencies.filter { !$0.value }.map(\.key).sorted()
+
+        if hasPymobiledevice || hasLibimobiledeviceCore {
+            let detail = hasPymobiledevice
+                ? "pymobiledevice3 is available for modern iOS workflows; libimobiledevice tools remain optional fallbacks."
+                : "libimobiledevice core tools are available; install pymobiledevice3 for best iOS 17-26 support."
+            return ReadinessItem(
+                title: "Tool Readiness",
+                detail: detail,
+                status: hasPymobiledevice ? .ready : .warning,
+                recoveryAction: hasPymobiledevice ? nil : "Install pymobiledevice3 with pipx or Homebrew."
+            )
+        }
+
+        return ReadinessItem(
+            title: "Tool Readiness",
+            detail: "No supported iOS command-line backend is available.",
+            status: .blocked,
+            recoveryAction: "Install pymobiledevice3, or install libimobiledevice tools including idevice_id and ideviceinfo.",
+            technicalDetail: missing.isEmpty ? nil : "Missing tools: \(missing.joined(separator: ", "))"
+        )
+    }
+
+    @MainActor
+    private static func backupFolderItem(path: String) -> ReadinessItem {
+        let validation = BackupManager.validateBackupDirectory(path)
+        if validation.ok {
+            return ReadinessItem(
+                title: "Backup Folder",
+                detail: "The active backup folder is readable and writable.",
+                status: .ready,
+                technicalDetail: path
+            )
+        }
+        return ReadinessItem(
+            title: "Backup Folder",
+            detail: validation.reason ?? "The active backup folder is not usable.",
+            status: .blocked,
+            recoveryAction: "Open Settings and choose a user-owned local backup folder such as ~/Documents/Phosphor Backups.",
+            technicalDetail: path
+        )
+    }
+
+    private static func deviceVisibilityItem(
+        devices: [DeviceInfo],
+        nearbyWirelessDevices: [PyMobileDevice.BonjourDevice]
+    ) -> ReadinessItem {
+        if !devices.isEmpty {
+            let usb = devices.filter { $0.connectionType == .usb }.count
+            let wifi = devices.filter { $0.connectionType == .wifi }.count
+            return ReadinessItem(
+                title: "Device Visibility",
+                detail: "Phosphor sees \(devices.count) backup-capable device(s): \(usb) USB, \(wifi) Wi-Fi.",
+                status: .ready
+            )
+        }
+        if !nearbyWirelessDevices.isEmpty {
+            return ReadinessItem(
+                title: "Device Visibility",
+                detail: "macOS/Finder can see \(nearbyWirelessDevices.count) nearby wireless iOS device hint(s), but Phosphor does not yet have a backup-capable usbmux/lockdown connection.",
+                status: .warning,
+                recoveryAction: "Connect over USB once, unlock the device, tap Trust, enable Wi-Fi sync in Finder, then refresh Phosphor."
+            )
+        }
+        return ReadinessItem(
+            title: "Device Visibility",
+            detail: "No USB, backup-capable Wi-Fi, or Finder/Bonjour-visible iOS device is currently visible.",
+            status: .warning,
+            recoveryAction: "Unlock the iPhone or iPad, connect via USB, tap Trust, then refresh."
+        )
+    }
+
+    @MainActor
+    private static func wifiBackupItem(
+        devices: [DeviceInfo],
+        nearbyWirelessDevices: [PyMobileDevice.BonjourDevice]
+    ) -> ReadinessItem {
+        let wifiDevices = devices.filter { $0.connectionType == .wifi }
+        if wifiDevices.isEmpty {
+            if nearbyWirelessDevices.isEmpty {
+                return ReadinessItem(
+                    title: "Wi-Fi Backup",
+                    detail: "No backup-capable Wi-Fi device is visible right now.",
+                    status: .info,
+                    recoveryAction: "Use USB for first setup; Wi-Fi backups become available after pairing and Finder Wi-Fi sync are working."
+                )
+            }
+            return ReadinessItem(
+                title: "Wi-Fi Backup",
+                detail: "Nearby wireless hints are visible, but Phosphor will not enable backup actions until usbmux/lockdown reports a real device UDID.",
+                status: .warning,
+                recoveryAction: "Use USB once to establish trust, then verify `pymobiledevice3 usbmux list --network` or `idevice_id -n` can see the device."
+            )
+        }
+
+        let devicesWithoutFullBackup = wifiDevices.filter { !BackupManager.hasExistingBackup(for: $0.id) }
+        if devicesWithoutFullBackup.isEmpty {
+            return ReadinessItem(
+                title: "Wi-Fi Backup",
+                detail: "Wi-Fi backup-capable devices are visible and have existing backup metadata for incremental runs.",
+                status: .ready
+            )
+        }
+        return ReadinessItem(
+            title: "Wi-Fi Backup",
+            detail: "At least one Wi-Fi device does not have complete backup metadata yet; the first run must be a full backup.",
+            status: .warning,
+            recoveryAction: "Run the first full backup over USB when practical, or explicitly confirm the longer first full Wi-Fi backup."
+        )
+    }
+
+    private static func nextSteps(devices: [DeviceInfo], dependencies: [String: Bool]) -> String {
+        if dependencies["pymobiledevice3"] != true && dependencies["idevice_id"] != true {
+            return "Install the required device tools, then re-run the readiness check."
+        }
+        if devices.isEmpty {
+            return "Connect and trust a device, then choose a user-owned backup folder before starting backups or exports."
+        }
+        return "Start with a fresh backup, then use Messages, Photos, Files, or Diagnostics from the sidebar."
+    }
+
+    private static func nextStepStatus(devices: [DeviceInfo], dependencies: [String: Bool]) -> ReadinessStatus {
+        if dependencies["pymobiledevice3"] != true && dependencies["idevice_id"] != true { return .blocked }
+        if devices.isEmpty { return .warning }
+        return .ready
+    }
+}

--- a/Sources/Phosphor/Services/ReadinessService.swift
+++ b/Sources/Phosphor/Services/ReadinessService.swift
@@ -57,7 +57,7 @@ struct ReadinessReport {
             "",
             "Generated: \(formatter.string(from: generatedAt))",
             "Summary: \(summary)",
-            "Backup Directory: \(Self.redactedPath(backupDirectory))",
+            "Backup Directory: \(Self.redactedValue(backupDirectory))",
             "Connected Devices: \(connectedDeviceCount)",
             "Backup-capable Wi-Fi Devices: \(wifiDeviceCount)",
             "Nearby Finder/Bonjour Hints: \(nearbyWirelessHintCount)",
@@ -66,12 +66,12 @@ struct ReadinessReport {
         ]
 
         for item in items {
-            lines.append("- [\(item.status.rawValue)] \(item.title): \(item.detail)")
+            lines.append("- [\(item.status.rawValue)] \(item.title): \(Self.redactedValue(item.detail))")
             if let recoveryAction = item.recoveryAction, !recoveryAction.isEmpty {
-                lines.append("  - Recovery: \(recoveryAction)")
+                lines.append("  - Recovery: \(Self.redactedValue(recoveryAction))")
             }
             if let technicalDetail = item.technicalDetail, !technicalDetail.isEmpty {
-                lines.append("  - Technical: \(Self.redactedPath(technicalDetail))")
+                lines.append("  - Technical: \(Self.redactedValue(technicalDetail))")
             }
         }
 
@@ -83,9 +83,18 @@ struct ReadinessReport {
         return lines.joined(separator: "\n") + "\n"
     }
 
-    private static func redactedPath(_ value: String) -> String {
+    private static func redactedValue(_ value: String) -> String {
         let home = FileManager.default.homeDirectoryForCurrentUser.path
-        return value.replacingOccurrences(of: home, with: "~")
+        var redacted = value.replacingOccurrences(of: home, with: "~")
+        redacted = replacing(pattern: "\\b[A-Fa-f0-9]{8}-[A-Fa-f0-9]{16}\\b", in: redacted, with: "<device-id>")
+        redacted = replacing(pattern: "\\b[A-Fa-f0-9]{40}\\b", in: redacted, with: "<device-id>")
+        return redacted
+    }
+
+    private static func replacing(pattern: String, in value: String, with replacement: String) -> String {
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return value }
+        let range = NSRange(value.startIndex..<value.endIndex, in: value)
+        return regex.stringByReplacingMatches(in: value, range: range, withTemplate: replacement)
     }
 }
 
@@ -153,13 +162,15 @@ enum ReadinessService {
 
     private static func toolReadinessItem(_ dependencies: [String: Bool]) -> ReadinessItem {
         let hasPymobiledevice = dependencies["pymobiledevice3"] == true
-        let hasLibimobiledeviceCore = dependencies["idevice_id"] == true && dependencies["ideviceinfo"] == true
+        let hasLibimobiledeviceBackup = dependencies["idevice_id"] == true &&
+            dependencies["ideviceinfo"] == true &&
+            dependencies["idevicebackup2"] == true
         let missing = dependencies.filter { !$0.value }.map(\.key).sorted()
 
-        if hasPymobiledevice || hasLibimobiledeviceCore {
+        if hasPymobiledevice || hasLibimobiledeviceBackup {
             let detail = hasPymobiledevice
                 ? "pymobiledevice3 is available for modern iOS workflows; libimobiledevice tools remain optional fallbacks."
-                : "libimobiledevice core tools are available; install pymobiledevice3 for best iOS 17-26 support."
+                : "libimobiledevice backup tools are available; install pymobiledevice3 for best iOS 17-26 support."
             return ReadinessItem(
                 title: "Tool Readiness",
                 detail: detail,
@@ -172,14 +183,14 @@ enum ReadinessService {
             title: "Tool Readiness",
             detail: "No supported iOS command-line backend is available.",
             status: .blocked,
-            recoveryAction: "Install pymobiledevice3, or install libimobiledevice tools including idevice_id and ideviceinfo.",
+            recoveryAction: "Install pymobiledevice3, or install libimobiledevice tools including idevice_id, ideviceinfo, and idevicebackup2.",
             technicalDetail: missing.isEmpty ? nil : "Missing tools: \(missing.joined(separator: ", "))"
         )
     }
 
     @MainActor
     private static func backupFolderItem(path: String) -> ReadinessItem {
-        let validation = BackupManager.validateBackupDirectory(path)
+        let validation = BackupManager.validateBackupDirectory(path, createIfMissing: false)
         if validation.ok {
             return ReadinessItem(
                 title: "Backup Folder",
@@ -266,7 +277,7 @@ enum ReadinessService {
     }
 
     private static func nextSteps(devices: [DeviceInfo], dependencies: [String: Bool]) -> String {
-        if dependencies["pymobiledevice3"] != true && dependencies["idevice_id"] != true {
+        if !hasBackupTooling(dependencies) {
             return "Install the required device tools, then re-run the readiness check."
         }
         if devices.isEmpty {
@@ -276,8 +287,15 @@ enum ReadinessService {
     }
 
     private static func nextStepStatus(devices: [DeviceInfo], dependencies: [String: Bool]) -> ReadinessStatus {
-        if dependencies["pymobiledevice3"] != true && dependencies["idevice_id"] != true { return .blocked }
+        if !hasBackupTooling(dependencies) { return .blocked }
         if devices.isEmpty { return .warning }
         return .ready
+    }
+
+    private static func hasBackupTooling(_ dependencies: [String: Bool]) -> Bool {
+        dependencies["pymobiledevice3"] == true ||
+            (dependencies["idevice_id"] == true &&
+             dependencies["ideviceinfo"] == true &&
+             dependencies["idevicebackup2"] == true)
     }
 }

--- a/Sources/Phosphor/ViewModels/DeviceViewModel.swift
+++ b/Sources/Phosphor/ViewModels/DeviceViewModel.swift
@@ -13,6 +13,8 @@ final class DeviceViewModel: ObservableObject {
     @Published var showPairAlert = false
     @Published var alertMessage = ""
     @Published var systemInfo: [String: String] = [:]
+    @Published var readinessReport: ReadinessReport?
+    @Published var isCheckingReadiness = false
 
     let deviceManager = DeviceManager()
     private var cancellables: Set<AnyCancellable> = []
@@ -46,6 +48,17 @@ final class DeviceViewModel: ObservableObject {
         nearbyWirelessDevices = deviceManager.nearbyWirelessDevices
         selectedDevice = deviceManager.selectedDevice
         isRefreshing = false
+        await refreshReadiness()
+    }
+
+    func refreshReadiness() async {
+        isCheckingReadiness = true
+        readinessReport = await ReadinessService.evaluate(
+            devices: devices,
+            nearbyWirelessDevices: nearbyWirelessDevices,
+            backupDirectory: BackupManager.activeBackupDir
+        )
+        isCheckingReadiness = false
     }
 
     func selectDevice(_ device: DeviceInfo) {

--- a/Sources/Phosphor/Views/ContentView.swift
+++ b/Sources/Phosphor/Views/ContentView.swift
@@ -91,11 +91,9 @@ struct ContentView: View {
     }
 
     private func checkTunnel() async {
-        tunnelRunning = await withCheckedContinuation { c in
-            DispatchQueue.global().async {
-                c.resume(returning: TunnelService.isRunning)
-            }
-        }
+        tunnelRunning = await Task.detached(priority: .utility) {
+            TunnelService.isRunning
+        }.value
     }
 
     @ViewBuilder
@@ -103,6 +101,8 @@ struct ContentView: View {
         switch selectedSection {
         case .devices:
             DeviceOverviewView()
+        case .readiness:
+            ReadinessCenterView()
         case .backups:
             BackupListView(onBrowseBackup: { selectedSection = .backupBrowser })
         case .backupBrowser:
@@ -146,7 +146,7 @@ struct ContentView: View {
         case .location:
             LocationView()
         case .none:
-            WelcomeView()
+            WelcomeView(onOpenReadiness: { selectedSection = .readiness })
         }
     }
 
@@ -215,6 +215,7 @@ struct BatteryIndicator: View {
 /// Shown when no section is selected - improved with quick-start guidance.
 struct WelcomeView: View {
 
+    let onOpenReadiness: () -> Void
     @State private var isPulsing = false
     @State private var depStatus: [String: Bool] = [:]
 
@@ -239,6 +240,13 @@ struct WelcomeView: View {
                 .font(.subheadline)
                 .foregroundStyle(.secondary)
 
+            Button {
+                onOpenReadiness()
+            } label: {
+                Label("Run Readiness Check", systemImage: "checklist.checked")
+            }
+            .buttonStyle(.borderedProminent)
+
             VStack(alignment: .leading, spacing: 8) {
                 depRow("pymobiledevice3", installed: depStatus["pymobiledevice3"] ?? false)
                 depRow("libimobiledevice", installed: depStatus["ideviceinfo"] ?? false)
@@ -249,11 +257,7 @@ struct WelcomeView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .task {
-            depStatus = await withCheckedContinuation { continuation in
-                DispatchQueue.global().async {
-                    continuation.resume(returning: Shell.checkDependencies())
-                }
-            }
+            depStatus = await ReadinessService.dependencyStatus()
         }
     }
 

--- a/Sources/Phosphor/Views/Onboarding/OnboardingView.swift
+++ b/Sources/Phosphor/Views/Onboarding/OnboardingView.swift
@@ -69,11 +69,7 @@ struct OnboardingView: View {
         .frame(width: 640, height: 480)
         .task {
             isCheckingDeps = true
-            depStatus = await withCheckedContinuation { c in
-                DispatchQueue.global().async {
-                    c.resume(returning: Shell.checkDependencies())
-                }
-            }
+            depStatus = await ReadinessService.dependencyStatus()
             isCheckingDeps = false
         }
     }

--- a/Sources/Phosphor/Views/Readiness/ReadinessCenterView.swift
+++ b/Sources/Phosphor/Views/Readiness/ReadinessCenterView.swift
@@ -3,7 +3,10 @@ import SwiftUI
 
 struct ReadinessCenterView: View {
     @EnvironmentObject var deviceVM: DeviceViewModel
+    @EnvironmentObject var backupVM: BackupViewModel
     @State private var exportMessage: String?
+    @State private var recoveryMessage: String?
+    @State private var pendingRecovery: PendingReadinessRecovery?
 
     var body: some View {
         ScrollView {
@@ -31,6 +34,10 @@ struct ReadinessCenterView: View {
 
                     SectionBlock(title: "Backup Folder", systemImage: "externaldrive.fill") {
                         readinessRows(report.items.filter { $0.title.contains("Backup Folder") })
+                    }
+
+                    SectionBlock(title: "Backup Recovery", systemImage: "externaldrive.badge.exclamationmark") {
+                        readinessRows(report.items.filter { $0.title.contains("Incomplete Backup") })
                     }
 
                     SectionBlock(title: "Device Visibility", systemImage: "iphone.gen3") {
@@ -77,6 +84,12 @@ struct ReadinessCenterView: View {
                         .font(.footnote)
                         .foregroundStyle(.secondary)
                 }
+
+                if let recoveryMessage {
+                    Text(recoveryMessage)
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
             }
             .padding(28)
             .frame(maxWidth: 900, alignment: .leading)
@@ -86,6 +99,16 @@ struct ReadinessCenterView: View {
             if deviceVM.readinessReport == nil {
                 await deviceVM.refreshReadiness()
             }
+        }
+        .alert(item: $pendingRecovery) { recovery in
+            Alert(
+                title: Text("Move Incomplete Backup to Trash?"),
+                message: Text(recovery.confirmationMessage),
+                primaryButton: .destructive(Text("Move to Trash")) {
+                    Task { await performRecovery(recovery.operation) }
+                },
+                secondaryButton: .cancel()
+            )
         }
     }
 
@@ -130,7 +153,36 @@ struct ReadinessCenterView: View {
     private func readinessRows(_ items: [ReadinessItem]) -> some View {
         VStack(alignment: .leading, spacing: 10) {
             ForEach(items) { item in
-                ReadinessRow(item: item)
+                ReadinessRow(item: item) { operation in
+                    pendingRecovery = PendingReadinessRecovery(operation: operation)
+                }
+            }
+        }
+    }
+
+    private func performRecovery(_ operation: ReadinessOperation) async {
+        switch operation {
+        case .deleteIncompleteBackupAndRunFull(let udid, let path):
+            do {
+                try BackupManager.deleteIncompleteBackup(for: udid, expectedPath: path)
+                backupVM.loadBackups()
+                await deviceVM.refreshReadiness()
+
+                guard let device = deviceVM.devices.first(where: { $0.id == udid }) else {
+                    recoveryMessage = "Moved incomplete backup to Trash. Reconnect and trust the device over USB, then run a full backup."
+                    return
+                }
+
+                guard device.connectionType == .usb else {
+                    recoveryMessage = "Moved incomplete backup to Trash. Open Backups to explicitly confirm the first full Wi-Fi backup, or connect over USB for the recommended first backup."
+                    return
+                }
+
+                recoveryMessage = "Moved incomplete backup to Trash. Starting a fresh full USB backup…"
+                await backupVM.createBackup(udid: udid, incremental: false, preferNetwork: false)
+                await deviceVM.refreshReadiness()
+            } catch {
+                recoveryMessage = "Could not move incomplete backup to Trash: \(error.localizedDescription)"
             }
         }
     }
@@ -177,6 +229,7 @@ private struct SectionBlock<Content: View>: View {
 
 private struct ReadinessRow: View {
     let item: ReadinessItem
+    let actionHandler: (ReadinessOperation) -> Void
 
     var body: some View {
         HStack(alignment: .top, spacing: 10) {
@@ -203,6 +256,15 @@ private struct ReadinessRow: View {
                         .font(.footnote)
                         .foregroundStyle(.secondary)
                 }
+                if let operation = item.operation {
+                    Button {
+                        actionHandler(operation)
+                    } label: {
+                        Label("Move Incomplete Backup to Trash", systemImage: "trash")
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                }
             }
             Spacer()
         }
@@ -227,9 +289,22 @@ private struct ReadinessRow: View {
     }
 }
 
+private struct PendingReadinessRecovery: Identifiable {
+    let id = UUID()
+    let operation: ReadinessOperation
+
+    var confirmationMessage: String {
+        switch operation {
+        case .deleteIncompleteBackupAndRunFull(_, let path):
+            return "This will move the incomplete backup folder to Trash, not permanently delete it:\n\n\(path)\n\nIf the matching device is connected over USB, Phosphor will start a fresh full backup afterward."
+        }
+    }
+}
+
 #if canImport(PreviewsMacros)
 #Preview {
     ReadinessCenterView()
         .environmentObject(DeviceViewModel())
+        .environmentObject(BackupViewModel())
 }
 #endif

--- a/Sources/Phosphor/Views/Readiness/ReadinessCenterView.swift
+++ b/Sources/Phosphor/Views/Readiness/ReadinessCenterView.swift
@@ -1,0 +1,235 @@
+import AppKit
+import SwiftUI
+
+struct ReadinessCenterView: View {
+    @EnvironmentObject var deviceVM: DeviceViewModel
+    @State private var exportMessage: String?
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 18) {
+                header
+
+                if deviceVM.isCheckingReadiness {
+                    HStack(spacing: 10) {
+                        ProgressView()
+                        Text("Running readiness checks…")
+                            .foregroundStyle(.secondary)
+                    }
+                    .padding()
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(.quaternary.opacity(0.5))
+                    .clipShape(RoundedRectangle(cornerRadius: 12))
+                }
+
+                if let report = deviceVM.readinessReport {
+                    summaryCard(report)
+
+                    SectionBlock(title: "Tool Readiness", systemImage: "wrench.and.screwdriver.fill") {
+                        readinessRows(report.items.filter { $0.title.contains("Tool") })
+                    }
+
+                    SectionBlock(title: "Backup Folder", systemImage: "externaldrive.fill") {
+                        readinessRows(report.items.filter { $0.title.contains("Backup Folder") })
+                    }
+
+                    SectionBlock(title: "Device Visibility", systemImage: "iphone.gen3") {
+                        readinessRows(report.items.filter { $0.title.contains("Device Visibility") })
+                    }
+
+                    SectionBlock(title: "Wi-Fi Backup", systemImage: "wifi") {
+                        readinessRows(report.items.filter { $0.title.contains("Wi-Fi Backup") })
+                    }
+
+                    SectionBlock(title: "Safe Operations", systemImage: "checkmark.shield.fill") {
+                        readinessRows(report.items.filter { $0.title.contains("Safe Operations") })
+                    }
+
+                    SectionBlock(title: "Diagnostic Report", systemImage: "doc.text.magnifyingglass") {
+                        readinessRows(report.items.filter { $0.title.contains("Diagnostic Report") })
+                        Button {
+                            exportDiagnosticReport(report)
+                        } label: {
+                            Label("Export Diagnostic Report", systemImage: "square.and.arrow.up")
+                        }
+                        .buttonStyle(.borderedProminent)
+                    }
+
+                    SectionBlock(title: "Next Steps", systemImage: "arrow.right.circle.fill") {
+                        readinessRows(report.items.filter { $0.title.contains("Next Steps") })
+                    }
+                } else if !deviceVM.isCheckingReadiness {
+                    ContentUnavailableView(
+                        "Run a readiness check",
+                        systemImage: "checklist.checked",
+                        description: Text("Phosphor will check device tools, backup-folder access, Wi-Fi visibility, safe-operation guidance, and diagnostic export readiness.")
+                    )
+                    Button {
+                        Task { await deviceVM.refreshReadiness() }
+                    } label: {
+                        Label("Run Readiness Check", systemImage: "play.fill")
+                    }
+                    .buttonStyle(.borderedProminent)
+                }
+
+                if let exportMessage {
+                    Text(exportMessage)
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .padding(28)
+            .frame(maxWidth: 900, alignment: .leading)
+        }
+        .navigationTitle("Readiness Center")
+        .task {
+            if deviceVM.readinessReport == nil {
+                await deviceVM.refreshReadiness()
+            }
+        }
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(alignment: .firstTextBaseline) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Readiness Center")
+                        .font(.largeTitle.weight(.bold))
+                    Text("One place to verify setup, device visibility, backup safety, and bug-report diagnostics before you move data.")
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                Button {
+                    Task { await deviceVM.refreshReadiness() }
+                } label: {
+                    Label("Refresh", systemImage: "arrow.clockwise")
+                }
+                .disabled(deviceVM.isCheckingReadiness)
+            }
+        }
+    }
+
+    private func summaryCard(_ report: ReadinessReport) -> some View {
+        HStack(spacing: 14) {
+            Image(systemName: report.hasBlockers ? "xmark.octagon.fill" : (report.hasWarnings ? "exclamationmark.triangle.fill" : "checkmark.circle.fill"))
+                .font(.system(size: 28))
+                .foregroundStyle(report.hasBlockers ? .red : (report.hasWarnings ? .orange : .green))
+            VStack(alignment: .leading, spacing: 4) {
+                Text(report.hasBlockers ? "Action needed" : (report.hasWarnings ? "Mostly ready" : "Ready"))
+                    .font(.headline)
+                Text(report.summary)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+        }
+        .padding()
+        .background(.quaternary.opacity(0.5))
+        .clipShape(RoundedRectangle(cornerRadius: 14))
+    }
+
+    private func readinessRows(_ items: [ReadinessItem]) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            ForEach(items) { item in
+                ReadinessRow(item: item)
+            }
+        }
+    }
+
+    private func exportDiagnosticReport(_ report: ReadinessReport) {
+        let panel = NSSavePanel()
+        panel.title = "Export Phosphor Diagnostic Report"
+        panel.nameFieldStringValue = "phosphor-diagnostic-report.md"
+        panel.canCreateDirectories = true
+        panel.allowedContentTypes = [.plainText]
+        panel.directoryURL = FileManager.default.urls(for: .desktopDirectory, in: .userDomainMask).first
+
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+        do {
+            try report.diagnosticMarkdown.write(to: url, atomically: true, encoding: .utf8)
+            exportMessage = "Diagnostic Report exported to \(url.path)."
+        } catch {
+            exportMessage = "Could not export Diagnostic Report: \(error.localizedDescription)"
+        }
+    }
+}
+
+private struct SectionBlock<Content: View>: View {
+    let title: String
+    let systemImage: String
+    @ViewBuilder let content: () -> Content
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Label(title, systemImage: systemImage)
+                .font(.title3.weight(.semibold))
+            content()
+        }
+        .padding()
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(.background)
+        .clipShape(RoundedRectangle(cornerRadius: 14))
+        .overlay(
+            RoundedRectangle(cornerRadius: 14)
+                .stroke(.quaternary, lineWidth: 1)
+        )
+    }
+}
+
+private struct ReadinessRow: View {
+    let item: ReadinessItem
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 10) {
+            Image(systemName: icon)
+                .foregroundStyle(color)
+                .frame(width: 20)
+            VStack(alignment: .leading, spacing: 4) {
+                HStack(spacing: 8) {
+                    Text(item.title)
+                        .font(.headline)
+                    Text(item.status.rawValue)
+                        .font(.caption.weight(.semibold))
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(color.opacity(0.15))
+                        .foregroundStyle(color)
+                        .clipShape(Capsule())
+                }
+                Text(item.detail)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                if let recoveryAction = item.recoveryAction {
+                    Text(recoveryAction)
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            Spacer()
+        }
+    }
+
+    private var icon: String {
+        switch item.status {
+        case .ready: return "checkmark.circle.fill"
+        case .warning: return "exclamationmark.triangle.fill"
+        case .blocked: return "xmark.octagon.fill"
+        case .info: return "info.circle.fill"
+        }
+    }
+
+    private var color: Color {
+        switch item.status {
+        case .ready: return .green
+        case .warning: return .orange
+        case .blocked: return .red
+        case .info: return .blue
+        }
+    }
+}
+
+#if canImport(PreviewsMacros)
+#Preview {
+    ReadinessCenterView()
+        .environmentObject(DeviceViewModel())
+}
+#endif

--- a/Sources/Phosphor/Views/Settings/SettingsView.swift
+++ b/Sources/Phosphor/Views/Settings/SettingsView.swift
@@ -5,6 +5,7 @@ struct SettingsView: View {
 
     @AppStorage("phosphor.backupDirectory") private var backupDirectory = BackupManager.defaultBackupDir
     @State private var dependencyList: [DependencyItem] = []
+    @State private var isCheckingDependencies = false
     @AppStorage("phosphor.autoRefreshInterval") private var autoRefreshInterval: Double = 4.0
 
     @StateObject private var scheduler = BackupScheduler()
@@ -32,11 +33,17 @@ struct SettingsView: View {
                 }
         }
         .frame(width: 560, height: 460)
-        .onAppear {
-            let deps = Shell.checkDependencies()
-            dependencyList = deps.map { DependencyItem(name: $0.key, installed: $0.value) }
-                .sorted { $0.name < $1.name }
+        .task {
+            await refreshDependencies()
         }
+    }
+
+    private func refreshDependencies() async {
+        isCheckingDependencies = true
+        let deps = await ReadinessService.dependencyStatus()
+        dependencyList = deps.map { DependencyItem(name: $0.key, installed: $0.value) }
+            .sorted { $0.name < $1.name }
+        isCheckingDependencies = false
     }
 
     // MARK: - General
@@ -243,10 +250,9 @@ struct SettingsView: View {
                     .foregroundStyle(.secondary)
 
                 Button("Check Again") {
-                    let deps = Shell.checkDependencies()
-                    dependencyList = deps.map { DependencyItem(name: $0.key, installed: $0.value) }
-                        .sorted { $0.name < $1.name }
+                    Task { await refreshDependencies() }
                 }
+                .disabled(isCheckingDependencies)
             }
             .padding()
         }

--- a/Sources/Phosphor/Views/SidebarView.swift
+++ b/Sources/Phosphor/Views/SidebarView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 /// Sidebar sections - Devices, Data, Backups, Tools (including new iDescriptor-inspired features).
 enum SidebarSection: String, CaseIterable, Identifiable {
     case devices
+    case readiness
     case backups
     case backupBrowser
     case timeMachine
@@ -30,6 +31,7 @@ enum SidebarSection: String, CaseIterable, Identifiable {
     var label: String {
         switch self {
         case .devices: return "Devices"
+        case .readiness: return "Readiness"
         case .backups: return "Backups"
         case .backupBrowser: return "Backup Browser"
         case .timeMachine: return "Time Machine"
@@ -57,6 +59,7 @@ enum SidebarSection: String, CaseIterable, Identifiable {
     var icon: String {
         switch self {
         case .devices: return "iphone"
+        case .readiness: return "checklist.checked"
         case .backups: return "externaldrive.fill"
         case .backupBrowser: return "folder.fill"
         case .timeMachine: return "clock.arrow.circlepath"
@@ -83,7 +86,7 @@ enum SidebarSection: String, CaseIterable, Identifiable {
 
     var group: SidebarGroup {
         switch self {
-        case .devices: return .device
+        case .devices, .readiness: return .device
         case .backups, .backupBrowser, .timeMachine: return .backups
         case .messages, .whatsapp, .photos, .apps, .notes, .callLog, .safari, .health, .music, .watch, .contacts, .calendar: return .data
         case .clone, .files, .diagnostics, .battery, .screenCapture, .location: return .tools
@@ -111,6 +114,8 @@ struct SidebarView: View {
     var body: some View {
         List {
             Section("Device") {
+                sidebarRow(.readiness)
+
                 if deviceVM.devices.isEmpty {
                     sidebarButton(.devices) {
                         Label {

--- a/docs/plans/2026-07-04-product-polish-readiness-center.md
+++ b/docs/plans/2026-07-04-product-polish-readiness-center.md
@@ -1,0 +1,134 @@
+# Phosphor Product Polish and Readiness Center Implementation Plan
+
+> **For Hermes:** Use subagent-driven-development skill to implement this plan task-by-task.
+
+**Goal:** Turn the broad “make Phosphor better” roadmap into shippable vertical slices, starting with a centralized Readiness Center that improves onboarding, Wi‑Fi/device clarity, diagnostics, safe-operation guidance, and UI task organization.
+
+**Architecture:** Add a small `ReadinessService` that produces a value-type report independent of SwiftUI. Surface it through `DeviceViewModel` and a new `ReadinessCenterView` reachable from the sidebar and welcome screen. Keep behavior testable with repo-local regression checks before broadening into deeper Messages, archive safety, and release polish follow-ups.
+
+**Tech Stack:** Swift 5.9, SwiftUI, Swift Package Manager, repo-local Python regression runner under `Scripts/regression`.
+
+---
+
+## Phase 1: Readiness Center vertical slice
+
+### Task 1: Add regression checks first
+
+**Objective:** Protect the new architecture before implementation.
+
+**Files:**
+- Create: `Scripts/regression/checks/readiness_center.py`
+- Test command: `Scripts/regression/run.py`
+
+**Checks:**
+- `ReadinessService.swift` exists and exposes `ReadinessReport`, `ReadinessItem`, `ReadinessStatus`, and `ReadinessService.evaluate`.
+- `ReadinessService` uses `Task.detached` for dependency probing instead of wrapping `Shell.checkDependencies()` in `DispatchQueue.global()` from UI code.
+- `DeviceManager.checkDependencies`, `WelcomeView`, and `OnboardingView` no longer directly call `DispatchQueue.global()` for dependency checks.
+- `SidebarSection` contains a `readiness` case with a visible sidebar row.
+- `ReadinessCenterView.swift` exists and contains explicit copy for tool readiness, backup folder readiness, Wi‑Fi/Finder visibility, safe operations, diagnostics export, and next steps.
+
+### Task 2: Implement `ReadinessService`
+
+**Objective:** Centralize tool, backup-folder, Wi‑Fi visibility, and diagnostic summary generation.
+
+**Files:**
+- Create: `Sources/Phosphor/Services/ReadinessService.swift`
+- Modify: `Sources/Phosphor/Services/DeviceManager.swift`
+- Modify: `Sources/Phosphor/ViewModels/DeviceViewModel.swift`
+
+**Details:**
+- Add `ReadinessStatus` enum: `.ready`, `.warning`, `.blocked`, `.info`.
+- Add `ReadinessItem` with `title`, `detail`, `status`, `recoveryAction`, and `technicalDetail`.
+- Add `ReadinessReport` with `generatedAt`, `items`, computed `hasBlockers`, `hasWarnings`, `summary`, and markdown diagnostic export.
+- `ReadinessService.evaluate(devices:nearbyWirelessDevices:backupDirectory:)` should:
+  - check dependencies off-main via `Task.detached { Shell.checkDependencies() }.value`;
+  - validate backup directory with `BackupManager.validateBackupDirectory`;
+  - include backup-directory cloud warnings;
+  - distinguish USB/Wi‑Fi backup-capable devices, Finder/Bonjour-visible nearby devices, and no visible devices;
+  - explain first-time Wi‑Fi backup requirements;
+  - summarize safe operations and diagnostic export behavior.
+- Replace ad-hoc `DispatchQueue.global()` dependency checks with `ReadinessService.dependencyStatus()`.
+
+### Task 3: Add Readiness Center UI
+
+**Objective:** Give users one place to understand whether Phosphor is ready and what to do next.
+
+**Files:**
+- Create: `Sources/Phosphor/Views/Readiness/ReadinessCenterView.swift`
+- Modify: `Sources/Phosphor/Views/SidebarView.swift`
+- Modify: `Sources/Phosphor/Views/ContentView.swift`
+
+**Details:**
+- Add sidebar section `Readiness` near the Device group.
+- Display summary cards for tool readiness, backup folder, device visibility, Wi‑Fi backup state, safe operations, and diagnostic export.
+- Add Refresh button using `DeviceViewModel.refreshReadiness()`.
+- Add Export Diagnostic Report button that writes a timestamped redacted Markdown report to the user-selected folder or Desktop fallback.
+- Add `Open Backup Settings` action guidance by text for now; do not introduce cross-view navigation coupling in this slice.
+
+### Task 4: Update onboarding and welcome paths
+
+**Objective:** Remove duplicate dependency-check code and make first-run guidance point to Readiness Center.
+
+**Files:**
+- Modify: `Sources/Phosphor/Views/Onboarding/OnboardingView.swift`
+- Modify: `Sources/Phosphor/Views/ContentView.swift`
+
+**Details:**
+- Use `ReadinessService.dependencyStatus()` rather than manual `DispatchQueue.global()` continuations.
+- In `WelcomeView`, replace duplicated dependency rows with a short “Run Readiness Check” call-to-action and compact dependency status text.
+- Keep first paint fast; do not run expensive work synchronously on view init.
+
+### Task 5: Verify and commit
+
+**Objective:** Prove the vertical slice works without claiming unrun checks.
+
+**Commands:**
+- `Scripts/regression/run.py`
+- `swift build`
+- `swift build -c release`
+- `bash Scripts/build.sh`
+
+**Commit:**
+- `feat: add readiness center and diagnostics guidance`
+
+---
+
+## Phase 2: Safe operations hardening
+
+Follow-up branch after Phase 1 or after current stability PR lands.
+
+- Add shared destination/collision policy for exports/imports.
+- Add archive import staging and path traversal regression fixtures.
+- Add destructive-action preview summaries.
+- Add Finder reveal/open result affordances for completed exports.
+
+---
+
+## Phase 3: Messages flagship polish
+
+Follow-up branch after Phase 1.
+
+- Expand message readiness taxonomy coverage.
+- Add export preview counts and filter summaries.
+- Strengthen CSV/MBOX/HTML fixtures with parsed assertions.
+- Make long export progress/cancel paths fully behavioral-tested.
+
+---
+
+## Phase 4: Backup browsing polish
+
+Follow-up branch after Phase 1.
+
+- Add visible scan progress and cancel where expensive.
+- Add clearer large-backup lazy size copy.
+- Add quick filters for common restore/extract targets.
+
+---
+
+## Phase 5: Distribution/release trust
+
+Follow-up branch after Phase 1.
+
+- Keep in-app version, Info.plist, changelog, and Homebrew tap release notes aligned.
+- Add a release checklist document.
+- Investigate signed/notarized distribution only after maintainer approval.


### PR DESCRIPTION
## Summary
- Add a Readiness Center route that centralizes device/tool/backup-folder readiness guidance.
- Add safe readiness diagnostics with redaction for personal identifiers, home paths, and technical detail fields.
- Make readiness backup-folder inspection side-effect-free and require an actual backup backend for libimobiledevice fallback readiness.

## Verification
- `Scripts/regression/run.py` — 37 checks passed
- `swift build` — passed
- `swift build -c release` — passed
- `bash Scripts/build.sh` — passed

## Review
- Independent review completed with verdict: APPROVED
