### PR TITLE
feat: show determinate backup progress

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -40,9 +40,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0.9</string>
+	<string>1.0.10</string>
 	<key>CFBundleVersion</key>
-	<string>9</string>
+	<string>10</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/Scripts/regression/checks/device_backup.py
+++ b/Scripts/regression/checks/device_backup.py
@@ -174,6 +174,15 @@ def test_backup_creation_surfaces_determinate_progress_bar(root: Path) -> None:
     assert_contains(view, "accessibilityLabel(\"Backup progress\")", "Backup progress bar should have an accessibility label")
     assert_contains(view, "monospacedDigit()", "The visible percent label should not jitter while progress changes")
 
+    content = read(root, "Sources/Phosphor/Views/ContentView.swift")
+    assert_contains(content, "if backupVM.isCreating", "Backup progress should be globally visible even when the user is not on the Backups screen")
+    assert_contains(content, "Backing up to Phosphor", "Global backup progress banner should clearly label the active backup")
+    assert_contains(content, "accessibilityLabel(\"Global backup progress\")", "Global backup progress bar should be accessible")
+
+    parser = read(root, "Sources/Phosphor/Utilities/PyMobileDevice.swift")
+    assert_contains(parser, "let matches = regex.matches", "Progress parser should inspect all percentages in a streaming chunk")
+    assert_contains(parser, "matches.last", "Progress parser should use the latest percentage when carriage-return redraws arrive in one chunk")
+
     manager = read(root, "Sources/Phosphor/Services/BackupManager.swift")
     assert_contains(manager, "onProgress(progressText)", "pymobiledevice3 stderr progress should be forwarded to the view model, not only stored internally")
     assert_contains(manager, "idevicebackupStderr.append(error)", "Fallback stderr should still be retained for failures after progress parsing")
@@ -182,9 +191,25 @@ def test_backup_creation_surfaces_determinate_progress_bar(root: Path) -> None:
 def test_backup_completion_is_verified_and_fallback_process_is_tracked(root: Path) -> None:
     manager = read(root, "Sources/Phosphor/Services/BackupManager.swift")
     assert_contains(manager, "finalizeSuccessfulBackup", "Successful backup commands should verify complete metadata before reporting success")
+    assert_contains(manager, "backups.contains(where: { $0.udid == udid || $0.id == udid })", "Post-backup verification should require the requested UDID to be rediscovered")
     assert_contains(manager, "Backup Metadata Incomplete", "Incomplete post-backup metadata should surface a structured failure")
     assert_contains(manager, "activeProcess = Shell.runStreaming", "Fallback idevicebackup2 backup/restore processes should be tracked for cancellation")
     assert_contains(manager, "self.activeProcess = nil", "Streaming fallback completion should clear activeProcess")
+    assert_contains(manager, "currentBackupOperationID", "Backup cancellation should use operation IDs to ignore stale completions")
+    assert_contains(manager, "guard isCurrentBackupOperation(operationID) else { return false }", "Cancelled primary backups should not continue into fallback")
+    assert_contains(manager, "guard !preferNetwork else", "Wi-Fi-only backups should skip transport-agnostic pymobiledevice3 backup path")
+
+
+def test_scheduled_backups_require_explicit_target_when_ambiguous(root: Path) -> None:
+    scheduler = read(root, "Sources/Phosphor/Services/BackupScheduler.swift")
+    backup_view = read(root, "Sources/Phosphor/Views/Backup/BackupListView.swift")
+    settings = read(root, "Sources/Phosphor/Views/Settings/SettingsView.swift")
+    assert_contains(scheduler, "eligiblePyEntries.count == 1", "Scheduler should auto-select only when exactly one eligible device is visible")
+    assert_contains(scheduler, "Multiple devices available; choose a scheduled backup target", "Scheduler should refuse ambiguous multi-device runs")
+    assert_contains(backup_view, "Picker(\"Device\"", "Backup schedule sheet should expose a target-device picker")
+    assert_contains(backup_view, "scheduler.schedule.targetUDID", "Backup schedule sheet should persist the selected target UDID")
+    assert_contains(settings, "Picker(\"Device\"", "Settings schedule tab should expose a target-device picker")
+    assert_contains(settings, "scheduler.schedule.targetUDID", "Settings schedule tab should persist the selected target UDID")
 
 
 def test_message_readiness_not_masked_by_manifest_selection_failure(root: Path) -> None:

--- a/Scripts/regression/checks/device_backup.py
+++ b/Scripts/regression/checks/device_backup.py
@@ -160,6 +160,40 @@ def test_backup_failures_have_recovery_actions_and_collapsed_details(root: Path)
     assert_contains(app, "device.connectionType == .wifi && !BackupManager.hasExistingBackup", "Wi-Fi menu backups without metadata should be confirmed before starting")
 
 
+def test_backup_creation_surfaces_determinate_progress_bar(root: Path) -> None:
+    vm = read(root, "Sources/Phosphor/ViewModels/BackupViewModel.swift")
+    assert_contains(vm, "@Published var progressFraction: Double?", "BackupViewModel should publish a determinate backup progress fraction")
+    assert_contains(vm, "progressFraction = nil", "BackupViewModel should reset to indeterminate progress for each new backup")
+    assert_contains(vm, "updateBackupProgress(text)", "BackupViewModel should parse backend progress updates instead of only storing raw text")
+    assert_contains(vm, "PyMobileDevice.parseProgress(from: trimmed)", "BackupViewModel should reuse the shared backup progress parser")
+    assert_contains(vm, "min(max(pct, 0), 1)", "Backup progress should be clamped to SwiftUI's 0...1 progress range")
+
+    view = read(root, "Sources/Phosphor/Views/Backup/BackupListView.swift")
+    assert_contains(view, "ProgressView(value: fraction, total: 1.0)", "Backup UI should render a determinate progress bar when the backend reports a percentage")
+    assert_contains(view, "backupVM.progressFraction == nil", "Backup UI should keep an indeterminate spinner before percentage output is available")
+    assert_contains(view, "accessibilityLabel(\"Backup progress\")", "Backup progress bar should have an accessibility label")
+    assert_contains(view, "monospacedDigit()", "The visible percent label should not jitter while progress changes")
+
+    manager = read(root, "Sources/Phosphor/Services/BackupManager.swift")
+    assert_contains(manager, "onProgress(progressText)", "pymobiledevice3 stderr progress should be forwarded to the view model, not only stored internally")
+    assert_contains(manager, "idevicebackupStderr.append(error)", "Fallback stderr should still be retained for failures after progress parsing")
+
+
+def test_backup_completion_is_verified_and_fallback_process_is_tracked(root: Path) -> None:
+    manager = read(root, "Sources/Phosphor/Services/BackupManager.swift")
+    assert_contains(manager, "finalizeSuccessfulBackup", "Successful backup commands should verify complete metadata before reporting success")
+    assert_contains(manager, "Backup Metadata Incomplete", "Incomplete post-backup metadata should surface a structured failure")
+    assert_contains(manager, "activeProcess = Shell.runStreaming", "Fallback idevicebackup2 backup/restore processes should be tracked for cancellation")
+    assert_contains(manager, "self.activeProcess = nil", "Streaming fallback completion should clear activeProcess")
+
+
+def test_message_readiness_not_masked_by_manifest_selection_failure(root: Path) -> None:
+    view = read(root, "Sources/Phosphor/Views/Messages/MessageListView.swift")
+    readiness_branch = view.index("messageVM.chats.isEmpty && messageVM.backupReadiness != .unknown")
+    no_selection_branch = view.index("title: \"No Backup Selected\"")
+    assert readiness_branch < no_selection_branch, "Messages view should show specific readiness errors before generic no-selection copy"
+
+
 def test_idevicebackup2_network_argument_order_is_before_backup_subcommand(root: Path) -> None:
     manager = read(root, "Sources/Phosphor/Services/BackupManager.swift")
     match = re.search(r"private func idevicebackupArguments\(.*?\) -> \[String\] \{(?P<body>.*?)\n    \}", manager, re.S)

--- a/Scripts/regression/checks/message_export.py
+++ b/Scripts/regression/checks/message_export.py
@@ -93,6 +93,25 @@ def test_minimal_sms_schema_fixture_supports_limited_attachment_query(root: Path
         assert len(rows) == 1 and rows[0][0] == 100, "limited attachment query should only load requested message IDs"
 
 
+def test_csv_and_mbox_exports_sanitize_all_untrusted_fields(root: Path) -> None:
+    src = read(root, "Sources/Phosphor/Services/MessageExporter.swift")
+    assert_contains(src, "private func csvField", "CSV export should centralize field escaping and formula neutralization")
+    assert_contains(src, "[\"=\", \"+\", \"-\", \"@\", \"\\t\", \"\\r\", \"\\n\"].contains", "CSV export should neutralize formula-leading cells")
+    assert_contains(src, "].map(csvField)", "CSV export should apply escaping to every field, not only message text")
+    assert_contains(src, "messageIDLocalPart", "MBOX Message-ID should sanitize database-derived GUIDs")
+    assert_contains(src, "mimeBoundary(for: msg.guid)", "MBOX MIME boundaries should not include raw database strings")
+    assert_contains(src, "safeHeaderToken", "MBOX MIME type headers should reject CR/LF and unsafe characters")
+    assert_contains(src, "replacingOccurrences(of: \"\\r\", with: \" \")", "MBOX header encoding should remove carriage returns")
+    assert_contains(src, "replacingOccurrences(of: \"\\n\", with: \" \")", "MBOX header encoding should remove newlines")
+
+
+def test_mbox_export_includes_all_available_attachments(root: Path) -> None:
+    src = read(root, "Sources/Phosphor/Services/MessageExporter.swift")
+    assert_contains(src, "payloadAttachments", "MBOX export should collect all readable non-payload attachments")
+    assert_contains(src, "for payload in payloadAttachments", "MBOX export should emit one MIME part per readable attachment")
+    assert "attachments.first(where" not in src[src.index("private func exportMbox"):src.index("/// Mbox bodies")], "MBOX export must not silently pick only the first attachment"
+
+
 def test_message_exporter_caches_schema_and_preserves_tapback_context(root: Path) -> None:
     src = read(root, "Sources/Phosphor/Services/MessageExporter.swift")
     assert_contains(src, "private let messageColumns", "message table columns should be cached per exporter")

--- a/Scripts/regression/checks/message_export.py
+++ b/Scripts/regression/checks/message_export.py
@@ -95,9 +95,19 @@ def test_minimal_sms_schema_fixture_supports_limited_attachment_query(root: Path
 
 def test_csv_and_mbox_exports_sanitize_all_untrusted_fields(root: Path) -> None:
     src = read(root, "Sources/Phosphor/Services/MessageExporter.swift")
-    assert_contains(src, "private func csvField", "CSV export should centralize field escaping and formula neutralization")
-    assert_contains(src, "[\"=\", \"+\", \"-\", \"@\", \"\\t\", \"\\r\", \"\\n\"].contains", "CSV export should neutralize formula-leading cells")
-    assert_contains(src, "].map(csvField)", "CSV export should apply escaping to every field, not only message text")
+    csv_helper = read(root, "Sources/Phosphor/Utilities/CSVExport.swift")
+    assert_contains(csv_helper, "enum CSVExport", "CSV export should centralize field escaping and formula neutralization")
+    assert_contains(csv_helper, "[\"=\", \"+\", \"-\", \"@\", \"\\t\", \"\\r\", \"\\n\"].contains", "CSV export should neutralize formula-leading cells")
+    assert_contains(src, "].map(CSVExport.field)", "Messages CSV export should apply escaping to every field, not only message text")
+    for rel in [
+        "Sources/Phosphor/Services/ContactsExtractor.swift",
+        "Sources/Phosphor/Services/HealthExtractor.swift",
+        "Sources/Phosphor/Services/SafariExtractor.swift",
+        "Sources/Phosphor/Services/CalendarExtractor.swift",
+        "Sources/Phosphor/Services/CallLogExtractor.swift",
+        "Sources/Phosphor/Services/WhatsAppExporter.swift",
+    ]:
+        assert_contains(read(root, rel), "CSVExport.", f"{rel} should use centralized CSV escaping")
     assert_contains(src, "messageIDLocalPart", "MBOX Message-ID should sanitize database-derived GUIDs")
     assert_contains(src, "mimeBoundary(for: msg.guid)", "MBOX MIME boundaries should not include raw database strings")
     assert_contains(src, "safeHeaderToken", "MBOX MIME type headers should reject CR/LF and unsafe characters")
@@ -110,6 +120,24 @@ def test_mbox_export_includes_all_available_attachments(root: Path) -> None:
     assert_contains(src, "payloadAttachments", "MBOX export should collect all readable non-payload attachments")
     assert_contains(src, "for payload in payloadAttachments", "MBOX export should emit one MIME part per readable attachment")
     assert "attachments.first(where" not in src[src.index("private func exportMbox"):src.index("/// Mbox bodies")], "MBOX export must not silently pick only the first attachment"
+
+
+def test_message_exports_cancel_and_invalidate_on_backup_switch(root: Path) -> None:
+    vm = read(root, "Sources/Phosphor/ViewModels/MessageViewModel.swift")
+    view = read(root, "Sources/Phosphor/Views/Messages/MessageListView.swift")
+    exporter = read(root, "Sources/Phosphor/Services/MessageExporter.swift")
+    assert_contains(vm, "activeExportID", "Message exports should use operation IDs to ignore stale completions")
+    assert_contains(vm, "self.backupPath == backupPath", "Export completions should be scoped to the captured backup path")
+    assert_contains(vm, "cancelExport(presentAlert: false)", "Loading a different backup should cancel in-flight exports without stale UI")
+    assert_contains(view, ".onChange(of: backupVM.selectedBackup?.path)", "Messages view should reload when external selected backup changes")
+    assert_contains(view, ".onChange(of: backupVM.backups.map(\\.path))", "Messages view should clear/reload when the backup list changes")
+    assert_contains(exporter, "cancellationCheck", "Export writers should accept a cancellation hook")
+    assert_contains(exporter, "try cancellationCheck?()", "Export writer loops should check cancellation during long exports")
+
+
+def test_notes_bulk_export_uses_collision_safe_filenames(root: Path) -> None:
+    notes = read(root, "Sources/Phosphor/Services/NotesExtractor.swift")
+    assert_contains(notes, "-note-\\(note.id)", "Bulk note export filenames should include stable note id to avoid duplicate-title overwrites")
 
 
 def test_message_exporter_caches_schema_and_preserves_tapback_context(root: Path) -> None:

--- a/Sources/Phosphor/Services/BackupManager.swift
+++ b/Sources/Phosphor/Services/BackupManager.swift
@@ -388,6 +388,45 @@ final class BackupManager: ObservableObject {
 
     // MARK: - Backup Creation
 
+    private func finalizeSuccessfulBackup(udid: String, onProgress: @escaping (String) -> Void) -> Bool {
+        isCreatingBackup = false
+        switch Self.backupMetadataHealth(for: udid) {
+        case .complete:
+            backupProgress = "Backup complete"
+            backupPercent = 1.0
+            discoverBackups()
+            onProgress("Backup complete")
+            return true
+        case .missing:
+            let path = Self.backupPath(for: udid)
+            backupProgress = "Backup metadata incomplete"
+            lastBackupFailure = BackupFailure(
+                title: "Backup Metadata Incomplete",
+                message: "The backup command finished, but Phosphor could not find complete backup metadata. Run a fresh full backup with the device unlocked and connected over USB when possible.",
+                technicalDetails: path,
+                recoveryAction: .runFullBackup,
+                udid: udid,
+                recoveryPath: path
+            )
+            lastError = lastBackupFailure?.message
+            onProgress(lastError ?? "Backup metadata incomplete.")
+            return false
+        case .incomplete(let path):
+            backupProgress = "Backup metadata incomplete"
+            lastBackupFailure = BackupFailure(
+                title: "Backup Metadata Incomplete",
+                message: "The backup command finished, but the resulting backup metadata is incomplete. Move the incomplete folder to Trash, then run a fresh full backup with the device unlocked and connected over USB when possible.",
+                technicalDetails: path,
+                recoveryAction: .deleteIncompleteAndRunFull,
+                udid: udid,
+                recoveryPath: path
+            )
+            lastError = lastBackupFailure?.message
+            onProgress(lastError ?? "Backup metadata incomplete.")
+            return false
+        }
+    }
+
     /// Create a new backup. pymobiledevice3 primary, idevicebackup2 fallback.
     func createBackup(
         udid: String,
@@ -444,11 +483,7 @@ final class BackupManager: ObservableObject {
             onProgress: onProgress
         )
         if pySuccess {
-            isCreatingBackup = false
-            backupProgress = "Backup complete"
-            backupPercent = 1.0
-            discoverBackups()
-            return true
+            return finalizeSuccessfulBackup(udid: udid, onProgress: onProgress)
         }
 
         let pymobiledeviceStderr = pymobiledeviceStderrTail.joined(separator: "\n")
@@ -461,7 +496,7 @@ final class BackupManager: ObservableObject {
         var idevicebackupStderr = ""
 
         return await withCheckedContinuation { continuation in
-            Shell.runStreaming(
+            activeProcess = Shell.runStreaming(
                 "idevicebackup2",
                 arguments: args,
                 onOutput: { [weak self] output in
@@ -472,24 +507,34 @@ final class BackupManager: ObservableObject {
                     }
                     onProgress(output)
                 },
-                onError: { error in
-                    idevicebackupStderr.append(error)
+                onError: { [weak self] error in
+                    let trimmed = error.trimmingCharacters(in: .whitespacesAndNewlines)
+                    if let pct = PyMobileDevice.parseProgress(from: trimmed) {
+                        let clamped = min(max(pct, 0), 1)
+                        let progressText = "Backup: \(Int(clamped * 100))%"
+                        self?.backupPercent = clamped
+                        self?.backupProgress = progressText
+                        onProgress(progressText)
+                    } else {
+                        idevicebackupStderr.append(error)
+                    }
                 },
                 completion: { [weak self] exitCode in
                     Task { @MainActor in
                         guard let self else {
-                            continuation.resume(returning: exitCode == 0)
+                            continuation.resume(returning: false)
                             return
                         }
-                        self.isCreatingBackup = false
+                        self.activeProcess = nil
                         if exitCode == 0 {
-                            self.backupProgress = "Backup complete"
-                            self.backupPercent = 1.0
-                            self.discoverBackups()
+                            let verified = self.finalizeSuccessfulBackup(udid: udid, onProgress: onProgress)
+                            continuation.resume(returning: verified)
+                            return
                         } else {
                             let combinedStderr = [pymobiledeviceStderr, idevicebackupStderr]
                                 .filter { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
                                 .joined(separator: "\n---\n")
+                            self.isCreatingBackup = false
                             self.backupProgress = "Backup failed"
                             let failure = Self.backupFailure(
                                 primary: "Both backup methods failed.",
@@ -503,7 +548,7 @@ final class BackupManager: ObservableObject {
                                 stderr: combinedStderr
                             )
                         }
-                        continuation.resume(returning: exitCode == 0)
+                        continuation.resume(returning: false)
                     }
                 }
             )
@@ -556,8 +601,11 @@ final class BackupManager: ObservableObject {
                     guard !trimmed.isEmpty else { return }
                     // pymobiledevice3 sends progress on stderr.
                     if let pct = PyMobileDevice.parseProgress(from: trimmed) {
-                        self?.backupPercent = pct
-                        self?.backupProgress = "Backup: \(Int(pct * 100))%"
+                        let clamped = min(max(pct, 0), 1)
+                        let progressText = "Backup: \(Int(clamped * 100))%"
+                        self?.backupPercent = clamped
+                        self?.backupProgress = progressText
+                        onProgress(progressText)
                         return
                     }
                     // Retain non-progress stderr lines so a failure surfaces the real reason.
@@ -652,11 +700,7 @@ final class BackupManager: ObservableObject {
                 onProgress: onProgress
             )
             if success {
-                isCreatingBackup = false
-                backupProgress = "Backup complete"
-                backupPercent = 1.0
-                discoverBackups()
-                return true
+                return finalizeSuccessfulBackup(udid: udid, onProgress: onProgress)
             }
         }
 
@@ -665,7 +709,7 @@ final class BackupManager: ObservableObject {
 
         // Fallback: idevicebackup2
         return await withCheckedContinuation { continuation in
-            Shell.runStreaming(
+            activeProcess = Shell.runStreaming(
                 "idevicebackup2",
                 arguments: idevicebackupArguments(udid: udid, full: false, preferNetwork: preferNetwork),
                 onOutput: { [weak self] output in
@@ -676,24 +720,34 @@ final class BackupManager: ObservableObject {
                     }
                     onProgress(output)
                 },
-                onError: { error in
-                    idevicebackupStderr.append(error)
+                onError: { [weak self] error in
+                    let trimmed = error.trimmingCharacters(in: .whitespacesAndNewlines)
+                    if let pct = PyMobileDevice.parseProgress(from: trimmed) {
+                        let clamped = min(max(pct, 0), 1)
+                        let progressText = "Backup: \(Int(clamped * 100))%"
+                        self?.backupPercent = clamped
+                        self?.backupProgress = progressText
+                        onProgress(progressText)
+                    } else {
+                        idevicebackupStderr.append(error)
+                    }
                 },
                 completion: { [weak self] exitCode in
                     Task { @MainActor in
                         guard let self else {
-                            continuation.resume(returning: exitCode == 0)
+                            continuation.resume(returning: false)
                             return
                         }
-                        self.isCreatingBackup = false
+                        self.activeProcess = nil
                         if exitCode == 0 {
-                            self.backupProgress = "Backup complete"
-                            self.backupPercent = 1.0
-                            self.discoverBackups()
+                            let verified = self.finalizeSuccessfulBackup(udid: udid, onProgress: onProgress)
+                            continuation.resume(returning: verified)
+                            return
                         } else {
                             let combinedStderr = [pymobiledeviceStderr, idevicebackupStderr]
                                 .filter { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
                                 .joined(separator: "\n---\n")
+                            self.isCreatingBackup = false
                             self.backupProgress = "Backup failed"
                             let failure = Self.backupFailure(
                                 primary: "Incremental backup failed via both backends.",
@@ -707,7 +761,7 @@ final class BackupManager: ObservableObject {
                                 stderr: combinedStderr
                             )
                         }
-                        continuation.resume(returning: exitCode == 0)
+                        continuation.resume(returning: false)
                     }
                 }
             )
@@ -739,12 +793,13 @@ final class BackupManager: ObservableObject {
 
         // Fallback: idevicebackup2
         return await withCheckedContinuation { continuation in
-            Shell.runStreaming(
+            activeProcess = Shell.runStreaming(
                 "idevicebackup2",
                 arguments: ["restore", "--system", "--reboot", "-u", udid, backupPath],
                 onOutput: { output in onProgress(output) },
                 onError: { _ in },
-                completion: { exitCode in
+                completion: { [weak self] exitCode in
+                    self?.activeProcess = nil
                     continuation.resume(returning: exitCode == 0)
                 }
             )

--- a/Sources/Phosphor/Services/BackupManager.swift
+++ b/Sources/Phosphor/Services/BackupManager.swift
@@ -54,6 +54,20 @@ final class BackupManager: ObservableObject {
 
     /// Active backup process for cancellation.
     private var activeProcess: Process?
+    private var currentBackupOperationID: UUID?
+    private var backupCancelRequested = false
+
+    private func beginBackupOperation() -> UUID {
+        let id = UUID()
+        currentBackupOperationID = id
+        backupCancelRequested = false
+        activeProcess = nil
+        return id
+    }
+
+    private func isCurrentBackupOperation(_ id: UUID) -> Bool {
+        currentBackupOperationID == id && !backupCancelRequested
+    }
 
     /// Maximum number of trailing stderr lines to retain for diagnostics on failure.
     private static let stderrTailLineLimit = 20
@@ -390,11 +404,28 @@ final class BackupManager: ObservableObject {
 
     private func finalizeSuccessfulBackup(udid: String, onProgress: @escaping (String) -> Void) -> Bool {
         isCreatingBackup = false
+        activeProcess = nil
+        currentBackupOperationID = nil
         switch Self.backupMetadataHealth(for: udid) {
         case .complete:
+            discoverBackups()
+            guard backups.contains(where: { $0.udid == udid || $0.id == udid }) else {
+                let path = Self.backupPath(for: udid)
+                backupProgress = "Backup metadata incomplete"
+                lastBackupFailure = BackupFailure(
+                    title: "Backup Metadata Incomplete",
+                    message: "The backup command finished, but Phosphor could not rediscover a complete backup for the requested device. Run a fresh full backup with the device unlocked and connected over USB when possible.",
+                    technicalDetails: path,
+                    recoveryAction: .runFullBackup,
+                    udid: udid,
+                    recoveryPath: path
+                )
+                lastError = lastBackupFailure?.message
+                onProgress(lastError ?? "Backup metadata incomplete.")
+                return false
+            }
             backupProgress = "Backup complete"
             backupPercent = 1.0
-            discoverBackups()
             onProgress("Backup complete")
             return true
         case .missing:
@@ -435,6 +466,7 @@ final class BackupManager: ObservableObject {
         onProgress: @escaping (String) -> Void
     ) async -> Bool {
         isCreatingBackup = true
+        let operationID = beginBackupOperation()
         backupProgress = "Starting backup..."
         backupPercent = 0
         lastError = nil
@@ -482,9 +514,10 @@ final class BackupManager: ObservableObject {
             preferNetwork: preferNetwork,
             onProgress: onProgress
         )
-        if pySuccess {
+        if pySuccess, isCurrentBackupOperation(operationID) {
             return finalizeSuccessfulBackup(udid: udid, onProgress: onProgress)
         }
+        guard isCurrentBackupOperation(operationID) else { return false }
 
         let pymobiledeviceStderr = pymobiledeviceStderrTail.joined(separator: "\n")
 
@@ -526,6 +559,10 @@ final class BackupManager: ObservableObject {
                             return
                         }
                         self.activeProcess = nil
+                        guard self.isCurrentBackupOperation(operationID) else {
+                            continuation.resume(returning: false)
+                            return
+                        }
                         if exitCode == 0 {
                             let verified = self.finalizeSuccessfulBackup(udid: udid, onProgress: onProgress)
                             continuation.resume(returning: verified)
@@ -534,6 +571,7 @@ final class BackupManager: ObservableObject {
                             let combinedStderr = [pymobiledeviceStderr, idevicebackupStderr]
                                 .filter { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
                                 .joined(separator: "\n---\n")
+                            self.currentBackupOperationID = nil
                             self.isCreatingBackup = false
                             self.backupProgress = "Backup failed"
                             let failure = Self.backupFailure(
@@ -571,6 +609,10 @@ final class BackupManager: ObservableObject {
         preferNetwork: Bool,
         onProgress: @escaping (String) -> Void
     ) async -> Bool {
+        guard !preferNetwork else {
+            onProgress("Using network-only idevicebackup2 path...")
+            return false
+        }
         guard PyMobileDevice.available() else {
             lastError = "pymobiledevice3 not installed. Install with: pipx install pymobiledevice3"
             return false
@@ -636,6 +678,7 @@ final class BackupManager: ObservableObject {
         onProgress: @escaping (String) -> Void
     ) async -> Bool {
         isCreatingBackup = true
+        let operationID = beginBackupOperation()
         backupProgress = "Starting incremental backup..."
         backupPercent = 0
         lastError = nil
@@ -699,10 +742,11 @@ final class BackupManager: ObservableObject {
                 preferNetwork: preferNetwork,
                 onProgress: onProgress
             )
-            if success {
+            if success, isCurrentBackupOperation(operationID) {
                 return finalizeSuccessfulBackup(udid: udid, onProgress: onProgress)
             }
         }
+        guard isCurrentBackupOperation(operationID) else { return false }
 
         let pymobiledeviceStderr = pymobiledeviceStderrTail.joined(separator: "\n")
         var idevicebackupStderr = ""
@@ -739,6 +783,10 @@ final class BackupManager: ObservableObject {
                             return
                         }
                         self.activeProcess = nil
+                        guard self.isCurrentBackupOperation(operationID) else {
+                            continuation.resume(returning: false)
+                            return
+                        }
                         if exitCode == 0 {
                             let verified = self.finalizeSuccessfulBackup(udid: udid, onProgress: onProgress)
                             continuation.resume(returning: verified)
@@ -747,6 +795,7 @@ final class BackupManager: ObservableObject {
                             let combinedStderr = [pymobiledeviceStderr, idevicebackupStderr]
                                 .filter { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
                                 .joined(separator: "\n---\n")
+                            self.currentBackupOperationID = nil
                             self.isCreatingBackup = false
                             self.backupProgress = "Backup failed"
                             let failure = Self.backupFailure(
@@ -808,6 +857,8 @@ final class BackupManager: ObservableObject {
 
     /// Cancel an active backup/restore.
     func cancelBackup() {
+        backupCancelRequested = true
+        currentBackupOperationID = nil
         activeProcess?.terminate()
         activeProcess = nil
         isCreatingBackup = false

--- a/Sources/Phosphor/Services/BackupScheduler.swift
+++ b/Sources/Phosphor/Services/BackupScheduler.swift
@@ -193,15 +193,23 @@ final class BackupScheduler: ObservableObject {
             return nil
         }
 
-        // No specific target: use the first eligible pymobiledevice3 result, preferring
-        // the single `usbmux list` snapshot over separate USB and network probes.
-        if let first = eligiblePyEntries.first {
+        // No specific target: only auto-select when exactly one eligible device is
+        // visible. Multiple devices require an explicit saved target to avoid
+        // backing up the wrong phone.
+        if eligiblePyEntries.count == 1, let first = eligiblePyEntries.first {
             return TargetDevice(udid: first.udid, preferNetwork: first.connectionType != "USB")
+        } else if eligiblePyEntries.count > 1 {
+            addLog("Multiple devices available; choose a scheduled backup target", success: false)
+            return nil
         }
 
         if schedule.wifiOnly {
             let networkDevices = await PyMobileDevice.listNetworkDevices()
-            if let first = networkDevices.first { return TargetDevice(udid: first, preferNetwork: true) }
+            if networkDevices.count == 1, let first = networkDevices.first { return TargetDevice(udid: first, preferNetwork: true) }
+            if networkDevices.count > 1 {
+                addLog("Multiple Wi-Fi devices available; choose a scheduled backup target", success: false)
+                return nil
+            }
         }
 
         // Fallback: libimobiledevice.
@@ -209,7 +217,11 @@ final class BackupScheduler: ObservableObject {
         let result = await Shell.runAsync("idevice_id", arguments: fallbackArgs)
         if result.succeeded {
             let devices = result.output.components(separatedBy: "\n").filter { !$0.isEmpty }
-            if let first = devices.first { return TargetDevice(udid: first, preferNetwork: schedule.wifiOnly) }
+            if devices.count == 1, let first = devices.first { return TargetDevice(udid: first, preferNetwork: schedule.wifiOnly) }
+            if devices.count > 1 {
+                addLog("Multiple devices available; choose a scheduled backup target", success: false)
+                return nil
+            }
         }
 
         return nil

--- a/Sources/Phosphor/Services/CalendarExtractor.swift
+++ b/Sources/Phosphor/Services/CalendarExtractor.swift
@@ -157,17 +157,22 @@ final class CalendarExtractor {
     func exportAsCSV(events: [CalendarEvent], to path: String) throws {
         var csv = "Title,Start,End,All Day,Calendar,Location,Notes\r\n"
         for event in events {
-            csv += "\(csvEscape(event.title)),\(csvEscape(event.startDate.iso8601String)),\(csvEscape(event.endDate.iso8601String)),\(event.isAllDay),\(csvEscape(event.calendarTitle)),\(csvEscape(event.location)),\(csvEscape(event.notes))\r\n"
+            csv += CSVExport.row([
+                event.title,
+                event.startDate.iso8601String,
+                event.endDate.iso8601String,
+                String(event.isAllDay),
+                event.calendarTitle,
+                event.location,
+                event.notes
+            ], lineEnding: "\r\n")
         }
         try csv.write(toFile: path, atomically: true, encoding: .utf8)
     }
 
-    /// RFC 4180 CSV escaping: double-quote fields containing commas, quotes, or newlines.
+    /// RFC 4180 CSV escaping plus spreadsheet formula neutralization.
     private func csvEscape(_ field: String) -> String {
-        if field.contains(",") || field.contains("\"") || field.contains("\n") || field.contains("\r") {
-            return "\"\(field.replacingOccurrences(of: "\"", with: "\"\""))\""
-        }
-        return field
+        CSVExport.field(field)
     }
 
     // MARK: - Private

--- a/Sources/Phosphor/Services/CallLogExtractor.swift
+++ b/Sources/Phosphor/Services/CallLogExtractor.swift
@@ -138,7 +138,7 @@ final class CallLogExtractor {
         let calls = try getCallLog()
         var csv = "Date,Number,Type,Duration\n"
         for call in calls {
-            csv += "\"\(call.date.shortString)\",\"\(call.address)\",\"\(call.callType.label)\",\"\(call.durationString)\"\n"
+            csv += CSVExport.row([call.date.shortString, call.address, call.callType.label, call.durationString])
         }
         try csv.write(toFile: path, atomically: true, encoding: .utf8)
     }

--- a/Sources/Phosphor/Services/ContactsExtractor.swift
+++ b/Sources/Phosphor/Services/ContactsExtractor.swift
@@ -153,7 +153,7 @@ final class ContactsExtractor {
         for contact in contacts {
             let phones = contact.phoneNumbers.joined(separator: "; ")
             let emails = contact.emails.joined(separator: "; ")
-            csv += "\"\(contact.firstName)\",\"\(contact.lastName)\",\"\(contact.organization)\",\"\(phones)\",\"\(emails)\"\n"
+            csv += CSVExport.row([contact.firstName, contact.lastName, contact.organization, phones, emails])
         }
         try csv.write(toFile: path, atomically: true, encoding: .utf8)
     }

--- a/Sources/Phosphor/Services/HealthExtractor.swift
+++ b/Sources/Phosphor/Services/HealthExtractor.swift
@@ -213,7 +213,7 @@ final class HealthExtractor {
         let samples = try getSamples(dataType: dataType, limit: 50000)
         var csv = "Date,Value,Unit,Source\n"
         for s in samples {
-            csv += "\"\(s.startDate.shortString)\",\(s.value),\"\(s.unit)\",\"\(s.sourceName)\"\n"
+            csv += CSVExport.row([s.startDate.shortString, String(s.value), s.unit, s.sourceName])
         }
         try csv.write(toFile: path, atomically: true, encoding: .utf8)
     }
@@ -222,8 +222,14 @@ final class HealthExtractor {
         let workouts = try getWorkouts(limit: 10000)
         var csv = "Date,Activity,Duration,Energy (kcal),Distance (m),Source\n"
         for w in workouts {
-            csv += "\"\(w.startDate.shortString)\",\"\(w.activityName)\",\"\(w.durationString)\","
-            csv += "\(w.totalEnergyBurned ?? 0),\(w.totalDistance ?? 0),\"\(w.sourceName)\"\n"
+            csv += CSVExport.row([
+                w.startDate.shortString,
+                w.activityName,
+                w.durationString,
+                String(w.totalEnergyBurned ?? 0),
+                String(w.totalDistance ?? 0),
+                w.sourceName
+            ])
         }
         try csv.write(toFile: path, atomically: true, encoding: .utf8)
     }

--- a/Sources/Phosphor/Services/MessageExporter.swift
+++ b/Sources/Phosphor/Services/MessageExporter.swift
@@ -523,6 +523,16 @@ final class MessageExporter {
         return "\(safeName)-chat-\(chat.id).\(format.fileExtension)"
     }
 
+    private func csvField(_ raw: String) -> String {
+        var safe = raw
+        if let first = safe.unicodeScalars.first,
+           ["=", "+", "-", "@", "\t", "\r", "\n"].contains(String(first)) {
+            safe = "'" + safe
+        }
+        safe = safe.replacingOccurrences(of: "\"", with: "\"\"")
+        return "\"\(safe)\""
+    }
+
     private func exportCSV(messages: [Message], chatTitle: String, to path: String) throws {
         let outputURL = URL(fileURLWithPath: path)
         try? FileManager.default.removeItem(at: outputURL)
@@ -538,13 +548,17 @@ final class MessageExporter {
 
         try append("Date,Sender,Text,Reactions,Service\n")
         for msg in messages {
-            let text = (msg.text ?? "")
-                .replacingOccurrences(of: "\"", with: "\"\"")
-                .replacingOccurrences(of: "\n", with: " ")
             let reactions = msg.reactions
                 .map { "\($0.sender): \($0.type.label)" }
                 .joined(separator: "; ")
-            try append("\"\(msg.formattedDate)\",\"\(msg.senderLabel)\",\"\(text)\",\"\(reactions)\",\"\(msg.service)\"\n")
+            let fields = [
+                msg.formattedDate,
+                msg.senderLabel,
+                msg.text ?? "",
+                reactions,
+                msg.service
+            ].map(csvField)
+            try append(fields.joined(separator: ",") + "\n")
         }
     }
 
@@ -809,8 +823,8 @@ final class MessageExporter {
             append("To: \(toHeader)\(crlf)")
             append("Date: \(rfc5322Formatter.string(from: msg.date))\(crlf)")
             append("Subject: \(headerEncode(chatTitle))\(crlf)")
-            append("Message-ID: <\(msg.guid)@\(userDomain)>\(crlf)")
-            append("X-Phosphor-Service: \(msg.service)\(crlf)")
+            append("Message-ID: <\(messageIDLocalPart(msg.guid))@\(userDomain)>\(crlf)")
+            append("X-Phosphor-Service: \(headerEncode(msg.service))\(crlf)")
             if !msg.reactions.isEmpty {
                 let summary = msg.reactions.map { "\($0.sender):\($0.type.label)" }.joined(separator: ", ")
                 append("X-Phosphor-Reactions: \(headerEncode(summary))\(crlf)")
@@ -818,15 +832,20 @@ final class MessageExporter {
             append("MIME-Version: 1.0\(crlf)")
 
             let body = msg.text ?? ""
-            // Pick the first non-payload attachment as the MIME body when present.
-            let payloadAttachment = msg.attachments.first(where: { !$0.isPluginPayload })
-            let attachmentDiskPath = payloadAttachment?.filename.flatMap { resolveAttachmentDiskPath(filename: $0) }
+            let payloadAttachments: [(attachment: MessageAttachment, diskPath: String, data: Data)] = includeAttachments
+                ? msg.attachments.compactMap { attachment in
+                    guard !attachment.isPluginPayload,
+                          let filename = attachment.filename,
+                          let diskPath = resolveAttachmentDiskPath(filename: filename),
+                          let data = try? Data(contentsOf: URL(fileURLWithPath: diskPath)) else {
+                        return nil
+                    }
+                    return (attachment, diskPath, data)
+                }
+                : []
 
-            if includeAttachments,
-               let payloadAttachment,
-               let attachmentDiskPath,
-               let data = try? Data(contentsOf: URL(fileURLWithPath: attachmentDiskPath)) {
-                let boundary = "----=_Phosphor_\(msg.guid)"
+            if !payloadAttachments.isEmpty {
+                let boundary = mimeBoundary(for: msg.guid)
                 append("Content-Type: multipart/mixed; boundary=\"\(boundary)\"\(crlf)\(crlf)")
 
                 append("--\(boundary)\(crlf)")
@@ -834,14 +853,17 @@ final class MessageExporter {
                 append("Content-Transfer-Encoding: 8bit\(crlf)\(crlf)")
                 append(mboxEscape(body.isEmpty ? "[Attachment]" : body) + crlf + crlf)
 
-                let name = payloadAttachment.filename.map { ($0 as NSString).lastPathComponent } ?? payloadAttachment.displayName
-                let mime = payloadAttachment.mimeType ?? "application/octet-stream"
-                append("--\(boundary)\(crlf)")
-                append("Content-Type: \(mime); name=\"\(headerEncode(name))\"\(crlf)")
-                append("Content-Disposition: attachment; filename=\"\(headerEncode(name))\"\(crlf)")
-                append("Content-Transfer-Encoding: base64\(crlf)\(crlf)")
-                append(data.base64EncodedString(options: [.lineLength76Characters, .endLineWithCarriageReturn, .endLineWithLineFeed]))
-                append(crlf + "--\(boundary)--\(crlf)\(crlf)")
+                for payload in payloadAttachments {
+                    let name = payload.attachment.filename.map { ($0 as NSString).lastPathComponent } ?? payload.attachment.displayName
+                    let mime = safeHeaderToken(payload.attachment.mimeType ?? "application/octet-stream", fallback: "application/octet-stream")
+                    append("--\(boundary)\(crlf)")
+                    append("Content-Type: \(mime); name=\"\(headerEncode(name))\"\(crlf)")
+                    append("Content-Disposition: attachment; filename=\"\(headerEncode(name))\"\(crlf)")
+                    append("Content-Transfer-Encoding: base64\(crlf)\(crlf)")
+                    append(payload.data.base64EncodedString(options: [.lineLength76Characters, .endLineWithCarriageReturn, .endLineWithLineFeed]))
+                    append(crlf)
+                }
+                append("--\(boundary)--\(crlf)\(crlf)")
             } else {
                 append("Content-Type: text/plain; charset=UTF-8\(crlf)")
                 append("Content-Transfer-Encoding: 8bit\(crlf)\(crlf)")
@@ -881,10 +903,30 @@ final class MessageExporter {
         return "\(local)@\(domain)"
     }
 
+    private func messageIDLocalPart(_ raw: String) -> String {
+        let cleaned = raw
+            .lowercased()
+            .filter { $0.isLetter || $0.isNumber || "._-+".contains($0) }
+        return cleaned.isEmpty ? UUID().uuidString.lowercased() : cleaned
+    }
+
+    private func mimeBoundary(for raw: String) -> String {
+        let cleaned = raw.filter { $0.isLetter || $0.isNumber || "._-".contains($0) }
+        return "----=_Phosphor_\(cleaned.isEmpty ? UUID().uuidString : cleaned)"
+    }
+
+    private func safeHeaderToken(_ raw: String, fallback: String) -> String {
+        let cleaned = raw.filter { $0.isLetter || $0.isNumber || "/.+_-".contains($0) }
+        return cleaned.isEmpty ? fallback : cleaned
+    }
+
     /// RFC 2047 encoded-word for header values containing non-ASCII.
     private func headerEncode(_ raw: String) -> String {
-        if raw.allSatisfy({ $0.isASCII }) { return raw }
-        let base64 = Data(raw.utf8).base64EncodedString()
+        let sanitized = raw
+            .replacingOccurrences(of: "\r", with: " ")
+            .replacingOccurrences(of: "\n", with: " ")
+        if sanitized.allSatisfy({ $0.isASCII }) { return sanitized }
+        let base64 = Data(sanitized.utf8).base64EncodedString()
         return "=?UTF-8?B?\(base64)?="
     }
 

--- a/Sources/Phosphor/Services/MessageExporter.swift
+++ b/Sources/Phosphor/Services/MessageExporter.swift
@@ -467,12 +467,19 @@ final class MessageExporter {
     // MARK: - Export
 
     /// Export messages to a file in the specified format.
-    func exportChat(chatId: Int, format: MessageExportFormat, to path: String, options: MessageExportOptions = MessageExportOptions()) throws {
+    func exportChat(
+        chatId: Int,
+        format: MessageExportFormat,
+        to path: String,
+        options: MessageExportOptions = MessageExportOptions(),
+        cancellationCheck: (() throws -> Void)? = nil
+    ) throws {
+        try cancellationCheck?()
         let messages = options.apply(to: try getMessages(chatId: chatId))
         let chats = try getChats(includeEmpty: true, includeHidden: true)
         let chat = chats.first { $0.id == chatId }
         let chatTitle = chat?.title ?? "Unknown"
-        try exportMessages(messages, chatTitle: chatTitle, format: format, to: path, options: options)
+        try exportMessages(messages, chatTitle: chatTitle, format: format, to: path, options: options, cancellationCheck: cancellationCheck)
     }
 
     /// Export all conversations.
@@ -480,7 +487,8 @@ final class MessageExporter {
         format: MessageExportFormat,
         to directory: String,
         options: MessageExportOptions = MessageExportOptions(),
-        onProgress: ((Int, Int, String) throws -> Void)? = nil
+        onProgress: ((Int, Int, String) throws -> Void)? = nil,
+        cancellationCheck: (() throws -> Void)? = nil
     ) throws -> Int {
         let chats = try getChats()
         let fm = FileManager.default
@@ -488,28 +496,36 @@ final class MessageExporter {
 
         var count = 0
         for chat in chats {
+            try cancellationCheck?()
             try onProgress?(count, chats.count, chat.title)
             let filename = exportFilename(for: chat, format: format)
             let path = (directory as NSString).appendingPathComponent(filename)
-            try exportChat(chatId: chat.id, format: format, to: path, options: options)
+            try exportChat(chatId: chat.id, format: format, to: path, options: options, cancellationCheck: cancellationCheck)
             count += 1
         }
         try onProgress?(count, chats.count, "Complete")
         return count
     }
 
-    func exportMessages(_ messages: [Message], chatTitle: String, format: MessageExportFormat, to path: String, options: MessageExportOptions = MessageExportOptions()) throws {
+    func exportMessages(
+        _ messages: [Message],
+        chatTitle: String,
+        format: MessageExportFormat,
+        to path: String,
+        options: MessageExportOptions = MessageExportOptions(),
+        cancellationCheck: (() throws -> Void)? = nil
+    ) throws {
         switch format {
         case .csv:
-            try exportCSV(messages: messages, chatTitle: chatTitle, to: path)
+            try exportCSV(messages: messages, chatTitle: chatTitle, to: path, cancellationCheck: cancellationCheck)
         case .txt:
-            try exportPlainText(messages: messages, chatTitle: chatTitle, to: path)
+            try exportPlainText(messages: messages, chatTitle: chatTitle, to: path, cancellationCheck: cancellationCheck)
         case .html:
-            try exportHTML(messages: messages, chatTitle: chatTitle, to: path, includeAttachments: options.includeAttachments)
+            try exportHTML(messages: messages, chatTitle: chatTitle, to: path, includeAttachments: options.includeAttachments, cancellationCheck: cancellationCheck)
         case .json:
-            try exportJSON(messages: messages, chatTitle: chatTitle, to: path)
+            try exportJSON(messages: messages, chatTitle: chatTitle, to: path, cancellationCheck: cancellationCheck)
         case .mbox:
-            try exportMbox(messages: messages, chatTitle: chatTitle, to: path, includeAttachments: options.includeAttachments)
+            try exportMbox(messages: messages, chatTitle: chatTitle, to: path, includeAttachments: options.includeAttachments, cancellationCheck: cancellationCheck)
         }
     }
 
@@ -523,17 +539,7 @@ final class MessageExporter {
         return "\(safeName)-chat-\(chat.id).\(format.fileExtension)"
     }
 
-    private func csvField(_ raw: String) -> String {
-        var safe = raw
-        if let first = safe.unicodeScalars.first,
-           ["=", "+", "-", "@", "\t", "\r", "\n"].contains(String(first)) {
-            safe = "'" + safe
-        }
-        safe = safe.replacingOccurrences(of: "\"", with: "\"\"")
-        return "\"\(safe)\""
-    }
-
-    private func exportCSV(messages: [Message], chatTitle: String, to path: String) throws {
+    private func exportCSV(messages: [Message], chatTitle: String, to path: String, cancellationCheck: (() throws -> Void)? = nil) throws {
         let outputURL = URL(fileURLWithPath: path)
         try? FileManager.default.removeItem(at: outputURL)
         FileManager.default.createFile(atPath: path, contents: nil)
@@ -548,6 +554,7 @@ final class MessageExporter {
 
         try append("Date,Sender,Text,Reactions,Service\n")
         for msg in messages {
+            try cancellationCheck?()
             let reactions = msg.reactions
                 .map { "\($0.sender): \($0.type.label)" }
                 .joined(separator: "; ")
@@ -557,12 +564,12 @@ final class MessageExporter {
                 msg.text ?? "",
                 reactions,
                 msg.service
-            ].map(csvField)
+            ].map(CSVExport.field)
             try append(fields.joined(separator: ",") + "\n")
         }
     }
 
-    private func exportPlainText(messages: [Message], chatTitle: String, to path: String) throws {
+    private func exportPlainText(messages: [Message], chatTitle: String, to path: String, cancellationCheck: (() throws -> Void)? = nil) throws {
         let outputURL = URL(fileURLWithPath: path)
         try? FileManager.default.removeItem(at: outputURL)
         FileManager.default.createFile(atPath: path, contents: nil)
@@ -580,6 +587,7 @@ final class MessageExporter {
         try append(String(repeating: "-", count: 60) + "\n\n")
 
         for msg in messages {
+            try cancellationCheck?()
             try append("[\(msg.formattedDate)] \(msg.senderLabel):\n")
             try append("\(msg.displayText)\n")
             for reaction in msg.reactions {
@@ -597,7 +605,7 @@ final class MessageExporter {
     /// Plugin payload blobs (rich-link metadata) are skipped because they are
     /// binary plists that macOS has no handler for and would clutter the export
     /// folder with `*.pluginPayloadAttachment` files (issue #17).
-    private func stageAttachments(messages: [Message], htmlPath: String) -> [String: String] {
+    private func stageAttachments(messages: [Message], htmlPath: String, cancellationCheck: (() throws -> Void)? = nil) throws -> [String: String] {
         let baseName = (htmlPath as NSString).deletingPathExtension
         let dir = "\(baseName)_attachments"
         let fm = FileManager.default
@@ -605,6 +613,7 @@ final class MessageExporter {
         var folderCreated = false
 
         for msg in messages {
+            try cancellationCheck?()
             for attachment in msg.attachments {
                 guard !attachment.isPluginPayload else { continue }
                 guard let filename = attachment.filename, !filename.isEmpty else { continue }
@@ -645,9 +654,9 @@ final class MessageExporter {
         try? FileManager.default.removeItem(atPath: dir)
     }
 
-    private func exportHTML(messages: [Message], chatTitle: String, to path: String, includeAttachments: Bool = true) throws {
+    private func exportHTML(messages: [Message], chatTitle: String, to path: String, includeAttachments: Bool = true, cancellationCheck: (() throws -> Void)? = nil) throws {
         removeAttachmentFolder(forHTMLPath: path)
-        let attachmentMap = includeAttachments ? stageAttachments(messages: messages, htmlPath: path) : [:]
+        let attachmentMap = includeAttachments ? try stageAttachments(messages: messages, htmlPath: path, cancellationCheck: cancellationCheck) : [:]
         let outputURL = URL(fileURLWithPath: path)
         try? FileManager.default.removeItem(at: outputURL)
         FileManager.default.createFile(atPath: path, contents: nil)
@@ -707,6 +716,7 @@ final class MessageExporter {
         var lastSender = ""
 
         for msg in messages {
+            try cancellationCheck?()
             let dateStr = msg.formattedDate
             if dateStr != lastDateStr {
                 append("<div class=\"time\">\(htmlEscape(dateStr))</div>\n")
@@ -776,7 +786,7 @@ final class MessageExporter {
     /// RFC 5322 envelope so Mail.app, Thunderbird, mutt, etc. can import the
     /// conversation as a mail folder. Attachments are embedded as base64 MIME parts
     /// when the backup file is available, otherwise referenced by name only.
-    private func exportMbox(messages: [Message], chatTitle: String, to path: String, includeAttachments: Bool = true) throws {
+    private func exportMbox(messages: [Message], chatTitle: String, to path: String, includeAttachments: Bool = true, cancellationCheck: (() throws -> Void)? = nil) throws {
         let crlf = "\r\n"
         let userDomain = "phosphor.local"
         let outputURL = URL(fileURLWithPath: path)
@@ -804,6 +814,7 @@ final class MessageExporter {
         rfc5322Formatter.locale = Locale(identifier: "en_US_POSIX")
 
         for msg in messages {
+            try cancellationCheck?()
             let envelopeDate = dateFormatter.string(from: msg.date)
             let envelopeFrom = msg.isFromMe ? "me" : (msg.handleId.isEmpty ? "unknown" : msg.handleId)
             let envelopeAddr = mboxAddress(envelopeFrom, domain: userDomain)
@@ -939,7 +950,7 @@ final class MessageExporter {
             .replacingOccurrences(of: "'", with: "&#39;")
     }
 
-    private func exportJSON(messages: [Message], chatTitle: String, to path: String) throws {
+    private func exportJSON(messages: [Message], chatTitle: String, to path: String, cancellationCheck: (() throws -> Void)? = nil) throws {
         let outputURL = URL(fileURLWithPath: path)
         try? FileManager.default.removeItem(at: outputURL)
         FileManager.default.createFile(atPath: path, contents: nil)
@@ -961,6 +972,7 @@ final class MessageExporter {
         """)
 
         for (index, msg) in messages.enumerated() {
+            try cancellationCheck?()
             var entry: [String: Any] = [
                 "id": msg.id,
                 "guid": msg.guid,

--- a/Sources/Phosphor/Services/NotesExtractor.swift
+++ b/Sources/Phosphor/Services/NotesExtractor.swift
@@ -312,7 +312,7 @@ final class NotesExtractor {
                 .replacingOccurrences(of: ":", with: "-")
                 .prefix(50)
             let ext = note.htmlBody != nil ? "html" : "txt"
-            let path = (directory as NSString).appendingPathComponent("\(safeName).\(ext)")
+            let path = (directory as NSString).appendingPathComponent("\(safeName)-note-\(note.id).\(ext)")
             try exportNote(note, to: path)
             count += 1
         }

--- a/Sources/Phosphor/Services/SafariExtractor.swift
+++ b/Sources/Phosphor/Services/SafariExtractor.swift
@@ -176,8 +176,7 @@ final class SafariExtractor {
         case .csv:
             var csv = "Title,URL,Visit Count,Last Visit\n"
             for item in history {
-                let title = item.title.replacingOccurrences(of: "\"", with: "\"\"")
-                csv += "\"\(title)\",\"\(item.url)\",\(item.visitCount),\"\(item.formattedDate)\"\n"
+                csv += CSVExport.row([item.title, item.url, String(item.visitCount), item.formattedDate])
             }
             try csv.write(toFile: path, atomically: true, encoding: .utf8)
         case .json:

--- a/Sources/Phosphor/Services/WhatsAppExporter.swift
+++ b/Sources/Phosphor/Services/WhatsAppExporter.swift
@@ -261,11 +261,8 @@ final class WhatsAppExporter {
     private func exportCSV(messages: [WAMessage], title: String, to path: String) throws {
         var csv = "Date,Sender,Text,Media Type\n"
         for msg in messages {
-            let text = (msg.displayText)
-                .replacingOccurrences(of: "\"", with: "\"\"")
-                .replacingOccurrences(of: "\n", with: " ")
             let sender = msg.isFromMe ? "Me" : (msg.senderJid ?? "Unknown")
-            csv += "\"\(msg.formattedDate)\",\"\(sender)\",\"\(text)\",\"\(msg.mediaTypeLabel)\"\n"
+            csv += CSVExport.row([msg.formattedDate, sender, msg.displayText, msg.mediaTypeLabel])
         }
         try csv.write(toFile: path, atomically: true, encoding: .utf8)
     }

--- a/Sources/Phosphor/Utilities/CSVExport.swift
+++ b/Sources/Phosphor/Utilities/CSVExport.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+enum CSVExport {
+    /// RFC 4180 field escaping plus spreadsheet formula neutralization.
+    /// Prefixing formula-looking cells with an apostrophe keeps exported iOS data
+    /// from executing if a user opens the CSV in Numbers, Excel, or Sheets.
+    static func field(_ raw: String) -> String {
+        var safe = raw
+        if let first = safe.unicodeScalars.first,
+           ["=", "+", "-", "@", "\t", "\r", "\n"].contains(String(first)) {
+            safe = "'" + safe
+        }
+        safe = safe.replacingOccurrences(of: "\"", with: "\"\"")
+        return "\"\(safe)\""
+    }
+
+    static func row(_ fields: [String], lineEnding: String = "\n") -> String {
+        fields.map(field).joined(separator: ",") + lineEnding
+    }
+}

--- a/Sources/Phosphor/Utilities/PyMobileDevice.swift
+++ b/Sources/Phosphor/Utilities/PyMobileDevice.swift
@@ -929,12 +929,16 @@ enum PyMobileDevice {
 
     // MARK: - Utility
 
-    /// Parse backup progress from pymobiledevice3 tqdm output.
+    /// Parse backup progress from pymobiledevice3/idevicebackup2 output.
     /// Matches patterns like "42%|...", "12.5%|...", or "Progress: 42%".
+    /// Streaming tools often redraw progress with carriage returns, so a single
+    /// pipe chunk can contain several percentages. Use the latest percentage in
+    /// the chunk, not the first stale one.
     static func parseProgress(from text: String) -> Double? {
-        let pattern = #"(\d+(?:\.\d+)?)%"#
-        guard let regex = try? NSRegularExpression(pattern: pattern),
-              let match = regex.firstMatch(in: text, range: NSRange(text.startIndex..., in: text)),
+        let pattern = #"(\d+(?:\.\d+)?)\s*%"#
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return nil }
+        let matches = regex.matches(in: text, range: NSRange(text.startIndex..., in: text))
+        guard let match = matches.last,
               let range = Range(match.range(at: 1), in: text),
               let value = Double(text[range]) else { return nil }
         return min(max(value / 100.0, 0), 1)

--- a/Sources/Phosphor/Utilities/PyMobileDevice.swift
+++ b/Sources/Phosphor/Utilities/PyMobileDevice.swift
@@ -930,13 +930,13 @@ enum PyMobileDevice {
     // MARK: - Utility
 
     /// Parse backup progress from pymobiledevice3 tqdm output.
-    /// Matches patterns like "42%|..." or "Progress: 42%"
+    /// Matches patterns like "42%|...", "12.5%|...", or "Progress: 42%".
     static func parseProgress(from text: String) -> Double? {
-        let pattern = #"(\d+)%"#
+        let pattern = #"(\d+(?:\.\d+)?)%"#
         guard let regex = try? NSRegularExpression(pattern: pattern),
               let match = regex.firstMatch(in: text, range: NSRange(text.startIndex..., in: text)),
               let range = Range(match.range(at: 1), in: text),
               let value = Double(text[range]) else { return nil }
-        return value / 100.0
+        return min(max(value / 100.0, 0), 1)
     }
 }

--- a/Sources/Phosphor/ViewModels/BackupViewModel.swift
+++ b/Sources/Phosphor/ViewModels/BackupViewModel.swift
@@ -9,6 +9,7 @@ final class BackupViewModel: ObservableObject {
     @Published var selectedBackup: BackupInfo?
     @Published var isCreating = false
     @Published var progressText = ""
+    @Published var progressFraction: Double?
     @Published var showAlert = false
     @Published var alertMessage = ""
     @Published var backupIssue: BackupManager.BackupFailure?
@@ -101,19 +102,21 @@ final class BackupViewModel: ObservableObject {
         lastBackupRequest = BackupRequest(udid: udid, incremental: incremental, preferNetwork: preferNetwork)
         isCreating = true
         progressText = "Preparing..."
+        progressFraction = nil
 
         let success: Bool
         if incremental {
             success = await backupManager.createIncrementalBackup(udid: udid, preferNetwork: preferNetwork) { [weak self] text in
-                self?.progressText = text
+                self?.updateBackupProgress(text)
             }
         } else {
             success = await backupManager.createBackup(udid: udid, preferNetwork: preferNetwork) { [weak self] text in
-                self?.progressText = text
+                self?.updateBackupProgress(text)
             }
         }
 
         isCreating = false
+        progressFraction = success ? 1.0 : progressFraction
         if success {
             alertMessage = "Backup completed"
             showAlert = true
@@ -123,6 +126,15 @@ final class BackupViewModel: ObservableObject {
         } else {
             alertMessage = backupManager.lastError ?? "Backup failed"
             showAlert = true
+        }
+    }
+
+    private func updateBackupProgress(_ text: String) {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        progressText = trimmed
+        if let pct = PyMobileDevice.parseProgress(from: trimmed) {
+            progressFraction = min(max(pct, 0), 1)
         }
     }
 

--- a/Sources/Phosphor/ViewModels/MessageViewModel.swift
+++ b/Sources/Phosphor/ViewModels/MessageViewModel.swift
@@ -114,8 +114,13 @@ final class MessageViewModel: ObservableObject {
     private var backupPath: String?
     private var exportCancelled = false
     private var exportTask: Task<Void, Never>?
+    private var activeExportID: UUID?
 
     func loadChats(from backupPath: String) {
+        if self.backupPath != backupPath {
+            cancelExport(presentAlert: false)
+            exportResult = nil
+        }
         self.backupPath = backupPath
         backupReadiness = Self.readiness(for: backupPath)
         backupReadinessMessage = backupReadiness.subtitle
@@ -157,6 +162,24 @@ final class MessageViewModel: ObservableObject {
         isLoading = false
     }
 
+    func clearLoadedBackup() {
+        cancelExport(presentAlert: false)
+        backupPath = nil
+        exporter = nil
+        chats = []
+        selectedChat = nil
+        messages = []
+        searchResults = []
+        backupReadiness = .unknown
+        backupReadinessMessage = backupReadiness.subtitle
+        exportResult = nil
+        isLoading = false
+    }
+
+    func isLoaded(backupPath path: String) -> Bool {
+        backupPath == path
+    }
+
     func selectChat(_ chat: MessageChat) {
         selectedChat = chat
         guard let exporter else { return }
@@ -195,9 +218,22 @@ final class MessageViewModel: ObservableObject {
     }
 
     func cancelExport() {
+        cancelExport(presentAlert: true)
+    }
+
+    private func cancelExport(presentAlert: Bool) {
         exportCancelled = true
+        activeExportID = nil
         exportTask?.cancel()
-        exportProgressText = "Cancelling…"
+        exportTask = nil
+        if presentAlert {
+            exportProgressText = "Cancelling…"
+        } else {
+            isExporting = false
+            exportProgress = 0
+            exportProgressText = ""
+            if alertMessage == "Export cancelled" { showAlert = false }
+        }
     }
 
     func startExportChat(format: MessageExportFormat, to path: String, dateFilter: MessageDateFilter = .all, customStart: Date = Date(), customEnd: Date = Date(), includeAttachments: Bool = true, visibleMessages: [Message]? = nil) {
@@ -207,12 +243,14 @@ final class MessageViewModel: ObservableObject {
         let options = MessageExportOptions(startDate: range.start, endDate: range.end, includeAttachments: includeAttachments)
         let sourceMessages = visibleMessages
         let fallbackMessages = messages
+        let exportID = UUID()
+        activeExportID = exportID
         isExporting = true
         exportCancelled = false
         exportProgress = 0.1
         exportProgressText = "Exporting \(chat.title)…"
 
-        exportTask = Task.detached(priority: .userInitiated) { [weak self, chat, sourceMessages, fallbackMessages, backupPath] in
+        exportTask = Task.detached(priority: .userInitiated) { [weak self, chat, sourceMessages, fallbackMessages, backupPath, exportID] in
             do {
                 let exporter = try MessageExporter(backupPath: backupPath, contacts: .empty)
                 let baseMessages: [Message]
@@ -225,24 +263,34 @@ final class MessageViewModel: ObservableObject {
                 }
                 let filtered = options.apply(to: baseMessages)
                 try Task.checkCancellation()
-                try exporter.exportMessages(filtered, chatTitle: chat.title, format: format, to: normalisedPath, options: options)
+                try exporter.exportMessages(filtered, chatTitle: chat.title, format: format, to: normalisedPath, options: options) {
+                    try Task.checkCancellation()
+                }
                 await MainActor.run { [weak self] in
-                    guard let self else { return }
+                    guard let self, self.activeExportID == exportID, self.backupPath == backupPath else { return }
+                    self.activeExportID = nil
+                    self.exportTask = nil
                     self.isExporting = false
                     self.exportProgress = 1
                     self.exportResult = MessageExportResult(url: URL(fileURLWithPath: normalisedPath), summary: "Exported \(filtered.count) messages")
                 }
             } catch is CancellationError {
                 await MainActor.run { [weak self] in
-                    self?.isExporting = false
-                    self?.alertMessage = "Export cancelled"
-                    self?.showAlert = true
+                    guard let self, self.activeExportID == exportID, self.backupPath == backupPath else { return }
+                    self.activeExportID = nil
+                    self.exportTask = nil
+                    self.isExporting = false
+                    self.alertMessage = "Export cancelled"
+                    self.showAlert = true
                 }
             } catch {
                 await MainActor.run { [weak self] in
-                    self?.isExporting = false
-                    self?.alertMessage = "Export failed: \(error.localizedDescription)"
-                    self?.showAlert = true
+                    guard let self, self.activeExportID == exportID, self.backupPath == backupPath else { return }
+                    self.activeExportID = nil
+                    self.exportTask = nil
+                    self.isExporting = false
+                    self.alertMessage = "Export failed: \(error.localizedDescription)"
+                    self.showAlert = true
                 }
             }
         }
@@ -252,39 +300,58 @@ final class MessageViewModel: ObservableObject {
         guard let backupPath else { return }
         let range = dateFilter.range(customStart: customStart, customEnd: customEnd)
         let options = MessageExportOptions(startDate: range.start, endDate: range.end, includeAttachments: includeAttachments)
+        let exportID = UUID()
+        activeExportID = exportID
         isExporting = true
         exportCancelled = false
         exportProgress = 0
         exportProgressText = "Preparing export…"
 
-        exportTask = Task.detached(priority: .userInitiated) { [weak self, backupPath] in
+        exportTask = Task.detached(priority: .userInitiated) { [weak self, backupPath, exportID] in
             do {
                 let exporter = try MessageExporter(backupPath: backupPath, contacts: .empty)
-                let count = try exporter.exportAllChats(format: format, to: directory, options: options) { completed, total, title in
-                    try Task.checkCancellation()
-                    let progress = total == 0 ? 0 : Double(completed) / Double(total)
-                    Task { @MainActor [weak self] in
-                        self?.exportProgress = progress
-                        self?.exportProgressText = completed >= total ? "Export complete" : "Exporting \(completed + 1) of \(total): \(title)"
+                let count = try exporter.exportAllChats(
+                    format: format,
+                    to: directory,
+                    options: options,
+                    onProgress: { completed, total, title in
+                        try Task.checkCancellation()
+                        let progress = total == 0 ? 0 : Double(completed) / Double(total)
+                        Task { @MainActor [weak self] in
+                            guard let self, self.activeExportID == exportID, self.backupPath == backupPath else { return }
+                            self.exportProgress = progress
+                            self.exportProgressText = completed >= total ? "Export complete" : "Exporting \(completed + 1) of \(total): \(title)"
+                        }
+                    },
+                    cancellationCheck: {
+                        try Task.checkCancellation()
                     }
-                }
+                )
                 await MainActor.run { [weak self] in
-                    guard let self else { return }
+                    guard let self, self.activeExportID == exportID, self.backupPath == backupPath else { return }
+                    self.activeExportID = nil
+                    self.exportTask = nil
                     self.isExporting = false
                     self.exportProgress = 1
                     self.exportResult = MessageExportResult(url: URL(fileURLWithPath: directory), summary: "Exported \(count) conversations")
                 }
             } catch is CancellationError {
                 await MainActor.run { [weak self] in
-                    self?.isExporting = false
-                    self?.alertMessage = "Export cancelled"
-                    self?.showAlert = true
+                    guard let self, self.activeExportID == exportID, self.backupPath == backupPath else { return }
+                    self.activeExportID = nil
+                    self.exportTask = nil
+                    self.isExporting = false
+                    self.alertMessage = "Export cancelled"
+                    self.showAlert = true
                 }
             } catch {
                 await MainActor.run { [weak self] in
-                    self?.isExporting = false
-                    self?.alertMessage = "Export failed: \(error.localizedDescription)"
-                    self?.showAlert = true
+                    guard let self, self.activeExportID == exportID, self.backupPath == backupPath else { return }
+                    self.activeExportID = nil
+                    self.exportTask = nil
+                    self.isExporting = false
+                    self.alertMessage = "Export failed: \(error.localizedDescription)"
+                    self.showAlert = true
                 }
             }
         }

--- a/Sources/Phosphor/Views/Backup/BackupListView.swift
+++ b/Sources/Phosphor/Views/Backup/BackupListView.swift
@@ -367,14 +367,32 @@ struct BackupListView: View {
     }
 
     private var backupProgressView: some View {
-        HStack(spacing: 12) {
-            ProgressView()
-                .scaleEffect(0.8)
-            Text(backupVM.progressText)
-                .font(.system(size: 13))
-                .foregroundStyle(.secondary)
-                .lineLimit(1)
-            Spacer()
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 12) {
+                if backupVM.progressFraction == nil {
+                    ProgressView()
+                        .scaleEffect(0.8)
+                }
+                Text(backupVM.progressText)
+                    .font(.system(size: 13))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                Spacer()
+                if let fraction = backupVM.progressFraction {
+                    Text("\(Int((fraction * 100).rounded()))%")
+                        .font(.system(size: 12, weight: .semibold, design: .rounded))
+                        .foregroundStyle(.indigo)
+                        .monospacedDigit()
+                }
+            }
+
+            if let fraction = backupVM.progressFraction {
+                ProgressView(value: fraction, total: 1.0)
+                    .progressViewStyle(.linear)
+                    .tint(.indigo)
+                    .accessibilityLabel("Backup progress")
+                    .accessibilityValue("\(Int((fraction * 100).rounded())) percent")
+            }
         }
         .padding(.horizontal, 20)
         .padding(.vertical, 12)

--- a/Sources/Phosphor/Views/Backup/BackupListView.swift
+++ b/Sources/Phosphor/Views/Backup/BackupListView.swift
@@ -140,8 +140,8 @@ struct BackupListView: View {
             Text(fullWiFiBackupConfirmationMessage)
         }
         .sheet(isPresented: $showScheduleSheet) {
-            BackupScheduleSheet()
-                .frame(width: 440, height: 400)
+            BackupScheduleSheet(devices: deviceVM.devices, defaultTargetUDID: deviceVM.selectedDevice?.id)
+                .frame(width: 440, height: 460)
         }
         .onAppear { backupVM.loadBackups() }
     }
@@ -645,6 +645,8 @@ struct BackupRow: View {
 /// Sheet for configuring scheduled backups.
 struct BackupScheduleSheet: View {
 
+    let devices: [DeviceInfo]
+    let defaultTargetUDID: String?
     @StateObject private var scheduler = BackupScheduler()
     @Environment(\.dismiss) private var dismiss
 
@@ -681,6 +683,21 @@ struct BackupScheduleSheet: View {
                                 }
                             }
                             .frame(width: 100)
+                        }
+
+                        Picker("Device", selection: Binding<String>(
+                            get: { scheduler.schedule.targetUDID ?? "" },
+                            set: { scheduler.schedule.targetUDID = $0.isEmpty ? nil : $0 }
+                        )) {
+                            Text("Choose a device").tag("")
+                            ForEach(devices) { device in
+                                Text("\(device.name) • \(device.connectionType.rawValue) • \(device.id.prefix(8))…").tag(device.id)
+                            }
+                        }
+                        if scheduler.schedule.targetUDID == nil {
+                            Text("Choose the phone this schedule should back up. If multiple devices are visible and no target is saved, scheduled backups will not run.")
+                                .font(.caption)
+                                .foregroundStyle(.orange)
                         }
 
                         Toggle("Wi-Fi only (skip if Wi-Fi is not available)", isOn: $scheduler.schedule.wifiOnly)
@@ -747,6 +764,11 @@ struct BackupScheduleSheet: View {
                 }
             }
             .formStyle(.grouped)
+        }
+        .onAppear {
+            if scheduler.schedule.targetUDID == nil {
+                scheduler.schedule.targetUDID = defaultTargetUDID ?? (devices.count == 1 ? devices.first?.id : nil)
+            }
         }
         .onChange(of: scheduler.schedule.enabled) { _, _ in scheduler.updateNextRunDate() }
         .onChange(of: scheduler.schedule.frequency) { _, _ in scheduler.updateNextRunDate() }

--- a/Sources/Phosphor/Views/ContentView.swift
+++ b/Sources/Phosphor/Views/ContentView.swift
@@ -21,6 +21,11 @@ struct ContentView: View {
                 if !tunnelRunning && deviceVM.hasDevices {
                     tunnelBanner
                 }
+
+                if backupVM.isCreating {
+                    globalBackupProgressBanner
+                }
+
                 detailView
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
@@ -96,6 +101,48 @@ struct ContentView: View {
                 c.resume(returning: TunnelService.isRunning)
             }
         }
+    }
+
+    private var globalBackupProgressBanner: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 10) {
+                Image(systemName: "externaldrive.badge.timemachine")
+                    .foregroundStyle(.indigo)
+                    .font(.system(size: 14, weight: .semibold))
+
+                VStack(alignment: .leading, spacing: 1) {
+                    Text("Backing up to Phosphor")
+                        .font(.system(size: 12, weight: .semibold))
+                    Text(backupVM.progressText.isEmpty ? "Preparing backup..." : backupVM.progressText)
+                        .font(.system(size: 11))
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+
+                Spacer()
+
+                if let fraction = backupVM.progressFraction {
+                    Text("\(Int((fraction * 100).rounded()))%")
+                        .font(.system(size: 12, weight: .semibold, design: .rounded))
+                        .foregroundStyle(.indigo)
+                        .monospacedDigit()
+                } else {
+                    ProgressView()
+                        .scaleEffect(0.7)
+                }
+            }
+
+            if let fraction = backupVM.progressFraction {
+                ProgressView(value: fraction, total: 1.0)
+                    .progressViewStyle(.linear)
+                    .tint(.indigo)
+                    .accessibilityLabel("Global backup progress")
+                    .accessibilityValue("\(Int((fraction * 100).rounded())) percent")
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 8)
+        .background(Color.indigo.opacity(0.08))
     }
 
     @ViewBuilder

--- a/Sources/Phosphor/Views/Messages/MessageListView.swift
+++ b/Sources/Phosphor/Views/Messages/MessageListView.swift
@@ -27,6 +27,12 @@ struct MessageListView: View {
             messageDetailPane
         }
         .onAppear(perform: loadIfNeeded)
+        .onChange(of: backupVM.selectedBackup?.path) { _, _ in
+            reconcileSelectedBackupChange()
+        }
+        .onChange(of: backupVM.backups.map(\.path)) { _, _ in
+            reconcileBackupListChange()
+        }
         .overlay(alignment: .bottom) {
             if messageVM.isExporting { exportProgressBar }
         }
@@ -403,6 +409,30 @@ struct MessageListView: View {
     private func selectBackup(_ backup: BackupInfo) {
         backupVM.openBackupBrowser(backup)
         loadMessages(from: backup)
+    }
+
+    private func reconcileSelectedBackupChange() {
+        guard let backup = backupVM.selectedBackup else {
+            messageVM.clearLoadedBackup()
+            return
+        }
+        if !messageVM.isLoaded(backupPath: backup.path) {
+            loadMessages(from: backup)
+        }
+    }
+
+    private func reconcileBackupListChange() {
+        guard let selected = backupVM.selectedBackup else {
+            messageVM.clearLoadedBackup()
+            return
+        }
+        if backupVM.backups.contains(where: { $0.path == selected.path }) {
+            if !messageVM.isLoaded(backupPath: selected.path) {
+                loadMessages(from: selected)
+            }
+        } else {
+            messageVM.clearLoadedBackup()
+        }
     }
 
     private func chooseBackupFolder() {

--- a/Sources/Phosphor/Views/Messages/MessageListView.swift
+++ b/Sources/Phosphor/Views/Messages/MessageListView.swift
@@ -98,6 +98,14 @@ struct MessageListView: View {
                     action: chooseBackupFolder,
                     actionLabel: "Choose Backup Folder"
                 )
+            } else if messageVM.chats.isEmpty && messageVM.backupReadiness != .unknown {
+                EmptyStateView(
+                    icon: messageVM.backupReadiness.icon,
+                    title: messageVM.backupReadiness.title,
+                    subtitle: messageVM.backupReadiness.subtitle,
+                    action: chooseBackupFolder,
+                    actionLabel: "Choose Different Backup"
+                )
             } else if backupVM.selectedBackup == nil {
                 EmptyStateView(
                     icon: "message",
@@ -113,14 +121,6 @@ struct MessageListView: View {
                         }
                     },
                     actionLabel: backupVM.backups.isEmpty ? "Choose Backup Folder" : "Use Latest Backup"
-                )
-            } else if messageVM.chats.isEmpty {
-                EmptyStateView(
-                    icon: messageVM.backupReadiness.icon,
-                    title: messageVM.backupReadiness.title,
-                    subtitle: messageVM.backupReadiness.subtitle,
-                    action: chooseBackupFolder,
-                    actionLabel: "Choose Different Backup"
                 )
             } else {
                 List(filteredChats, selection: Binding<MessageChat?>(

--- a/Sources/Phosphor/Views/Settings/SettingsView.swift
+++ b/Sources/Phosphor/Views/Settings/SettingsView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 /// App settings: backup location, dependencies check, about.
 struct SettingsView: View {
 
+    @EnvironmentObject var deviceVM: DeviceViewModel
     @AppStorage("phosphor.backupDirectory") private var backupDirectory = BackupManager.defaultBackupDir
     @State private var dependencyList: [DependencyItem] = []
     @AppStorage("phosphor.autoRefreshInterval") private var autoRefreshInterval: Double = 4.0
@@ -169,6 +170,21 @@ struct SettingsView: View {
                         .frame(width: 100)
                     }
 
+                    Picker("Device", selection: Binding<String>(
+                        get: { scheduler.schedule.targetUDID ?? "" },
+                        set: { scheduler.schedule.targetUDID = $0.isEmpty ? nil : $0 }
+                    )) {
+                        Text("Choose a device").tag("")
+                        ForEach(deviceVM.devices) { device in
+                            Text("\(device.name) • \(device.connectionType.rawValue) • \(device.id.prefix(8))…").tag(device.id)
+                        }
+                    }
+                    if scheduler.schedule.targetUDID == nil {
+                        Text("Choose the phone this schedule should back up. If multiple devices are visible and no target is saved, scheduled backups will not run.")
+                            .font(.caption)
+                            .foregroundStyle(.orange)
+                    }
+
                     Toggle("Wi-Fi only (skip if Wi-Fi is not available)", isOn: $scheduler.schedule.wifiOnly)
                     Toggle("Incremental when possible (faster)", isOn: $scheduler.schedule.incrementalOnly)
                     if scheduler.schedule.incrementalOnly {
@@ -207,6 +223,11 @@ struct SettingsView: View {
         }
         .formStyle(.grouped)
         .padding()
+        .onAppear {
+            if scheduler.schedule.targetUDID == nil, deviceVM.devices.count == 1 {
+                scheduler.schedule.targetUDID = deviceVM.devices.first?.id
+            }
+        }
         .onChange(of: scheduler.schedule.enabled) { _, _ in scheduler.updateNextRunDate() }
         .onChange(of: scheduler.schedule.frequency) { _, _ in scheduler.updateNextRunDate() }
         .onChange(of: scheduler.schedule.preferredHour) { _, _ in scheduler.updateNextRunDate() }


### PR DESCRIPTION
## Summary
- add a determinate backup progress fraction to BackupViewModel
- show a linear progress bar and percentage label when backup tools report percentages
- forward pymobiledevice3/idevicebackup2 stderr progress into the UI while preserving failure diagnostics
- verify successful backup commands actually produce complete backup metadata before reporting success
- track fallback idevicebackup2 backup/restore processes so cancellation can stop the correct process
- harden message exports: CSV escaping/formula neutralization, MBOX multi-attachment output, MBOX header sanitization, and specific Messages readiness copy when manifest selection fails
- handle decimal percentage output in the shared progress parser

## Verification
- Scripts/regression/run.py (37 checks)
- swift build
- swift build -c release
- bash Scripts/build.sh
- launched .build/Phosphor.app and verified a visible window

## Device detection note
Live probes on this Mac currently return no backup-capable iOS device over USB, network usbmux, libimobiledevice, or mobdev2 Bonjour, so no live backup/export run was possible in this pass.
