### PR TITLE
fix: bound memory during device output streaming (Diagnostics/backup logs)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -19,6 +19,11 @@ let package = Package(
             linkerSettings: [
                 .linkedLibrary("sqlite3")
             ]
+        ),
+        .testTarget(
+            name: "PhosphorTests",
+            dependencies: ["Phosphor"],
+            path: "Tests/PhosphorTests"
         )
     ]
 )

--- a/Sources/Phosphor/Services/DiagnosticsManager.swift
+++ b/Sources/Phosphor/Services/DiagnosticsManager.swift
@@ -11,6 +11,10 @@ final class DiagnosticsManager: ObservableObject {
     /// Active syslog process for proper termination.
     private var syslogProcess: Process?
 
+    /// Splits coalesced syslog text into clean, bounded lines (fixes multi-line chunks
+    /// counting as a single entry and reassembles UTF-8 scalars split across reads).
+    private var syslogBuffer = StreamingLineBuffer(capacity: 5000)
+
     struct BatteryDiagnostics {
         let currentCapacity: Int
         let isCharging: Bool
@@ -175,42 +179,42 @@ final class DiagnosticsManager: ObservableObject {
         guard !isStreamingSyslog else { return }
         isStreamingSyslog = true
         syslogLines = []
+        syslogBuffer = StreamingLineBuffer(capacity: 5000)
+
+        // Split coalesced syslog text into whole lines; keep only the most recent 5000.
+        let handleText: (String) -> Void = { [weak self] text in
+            guard let self else { return }
+            self.syslogBuffer.append(Data(text.utf8))
+            let newLines = self.syslogBuffer.drain()
+                .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+                .filter { !$0.isEmpty }
+            guard !newLines.isEmpty else { return }
+            self.syslogLines.append(contentsOf: newLines)
+            if self.syslogLines.count > 5000 {
+                self.syslogLines.removeFirst(self.syslogLines.count - 5000)
+            }
+        }
 
         // Primary: pymobiledevice3 syslog
         syslogProcess = PyMobileDevice.startSyslog(
             udid: udid,
-            onOutput: { [weak self] line in
-                guard let self else { return }
-                let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
-                guard !trimmed.isEmpty else { return }
-
-                if self.syslogLines.count > 5000 {
-                    self.syslogLines.removeFirst(500)
-                }
-                self.syslogLines.append(trimmed)
-            },
+            onOutput: handleText,
             completion: { [weak self] _ in
                 self?.isStreamingSyslog = false
                 self?.syslogProcess = nil
             }
         )
 
-        // Fallback if pymobiledevice3 failed
+        // Fallback if pymobiledevice3 failed. Retain the returned Process so stopSyslog()
+        // can actually terminate it (previously the fallback stream was unstoppable).
         if syslogProcess == nil {
-            Shell.runStreaming(
+            syslogProcess = Shell.runStreaming(
                 "idevicesyslog",
                 arguments: ["-u", udid],
-                onOutput: { [weak self] line in
-                    guard let self else { return }
-                    let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
-                    guard !trimmed.isEmpty else { return }
-                    if self.syslogLines.count > 5000 {
-                        self.syslogLines.removeFirst(500)
-                    }
-                    self.syslogLines.append(trimmed)
-                },
+                onOutput: handleText,
                 completion: { [weak self] _ in
                     self?.isStreamingSyslog = false
+                    self?.syslogProcess = nil
                 }
             )
         }

--- a/Sources/Phosphor/Utilities/CoalescingOutputBuffer.swift
+++ b/Sources/Phosphor/Utilities/CoalescingOutputBuffer.swift
@@ -1,0 +1,79 @@
+import Foundation
+
+/// Thread-safe, bounded, UTF-8-safe coalescing buffer for process output streaming.
+///
+/// A pipe `readabilityHandler` on a background queue feeds raw `Data` via `append(_:)`.
+/// A consumer periodically calls `drainText()` (on the main queue). Unlike a line buffer
+/// this preserves the raw text — including `\r`-based progress updates from idevicebackup2 /
+/// pymobiledevice3 — so it is safe for every `runStreaming` caller, not just `\n`-based syslog.
+///
+/// Two properties make it the fix for the diagnostics "47 GB" freeze when paired with a
+/// single-in-flight main-queue flush in the caller:
+///   * bounded — bytes past `maxBytes` are dropped from the front, so a fast producer can
+///     never grow the buffer without limit;
+///   * UTF-8-safe — a multi-byte scalar split across two pipe reads is held back until its
+///     bytes complete, instead of being decoded to replacement characters or dropped
+///     (the pre-existing `String(data:encoding:.utf8)` returned nil and lost the whole chunk).
+final class CoalescingOutputBuffer: @unchecked Sendable {
+    private let maxBytes: Int
+    private let lock = NSLock()
+    private var buffer = Data()
+
+    init(maxBytes: Int = 1_000_000) {
+        self.maxBytes = max(16, maxBytes)
+    }
+
+    var byteCount: Int {
+        lock.lock(); defer { lock.unlock() }
+        return buffer.count
+    }
+
+    func append(_ data: Data) {
+        guard !data.isEmpty else { return }
+        lock.lock(); defer { lock.unlock() }
+        buffer.append(data)
+        if buffer.count > maxBytes {
+            buffer = Data(buffer.suffix(maxBytes))
+        }
+    }
+
+    /// Decode and return the longest complete-UTF-8 prefix, retaining any trailing
+    /// partial scalar for the next read. Clears what it returns.
+    func drainText() -> String {
+        lock.lock(); defer { lock.unlock() }
+        guard !buffer.isEmpty else { return "" }
+        let cut = Self.safePrefixLength(buffer)
+        guard cut > 0 else { return "" }
+        let head = Data(buffer.prefix(cut))
+        buffer = Data(buffer.suffix(buffer.count - cut))
+        return String(decoding: head, as: UTF8.self)
+    }
+
+    /// Flush everything, including any trailing partial bytes (call on stream end).
+    func finishText() -> String {
+        lock.lock(); defer { lock.unlock() }
+        guard !buffer.isEmpty else { return "" }
+        let s = String(decoding: buffer, as: UTF8.self)
+        buffer.removeAll(keepingCapacity: false)
+        return s
+    }
+
+    /// Count of leading bytes that end on a complete UTF-8 scalar boundary.
+    static func safePrefixLength(_ d: Data) -> Int {
+        let bytes = [UInt8](d)
+        let n = bytes.count
+        if n == 0 { return 0 }
+        var i = n - 1
+        while i >= 0 && (bytes[i] & 0xC0) == 0x80 { i -= 1 }   // skip continuation bytes
+        if i < 0 { return n }                                  // all continuation → take all
+        let lead = bytes[i]
+        let expected: Int
+        if lead & 0x80 == 0 { expected = 1 }
+        else if lead & 0xE0 == 0xC0 { expected = 2 }
+        else if lead & 0xF0 == 0xE0 { expected = 3 }
+        else if lead & 0xF8 == 0xF0 { expected = 4 }
+        else { expected = 1 }                                  // invalid lead → treat as single
+        let have = n - i
+        return have >= expected ? n : i                        // hold back an incomplete last scalar
+    }
+}

--- a/Sources/Phosphor/Utilities/PyMobileDevice.swift
+++ b/Sources/Phosphor/Utilities/PyMobileDevice.swift
@@ -188,30 +188,71 @@ enum PyMobileDevice {
         process.environment = ProcessInfo.processInfo.environment
         process.environment?["PATH"] = extendedPath
 
+        // Coalesce high-rate output into a single in-flight main-queue flush. A chatty
+        // stream (e.g. verbose device syslog) previously enqueued one DispatchQueue.main.async
+        // block per chunk; when the producer outpaced the main thread that backlog grew without
+        // bound (each block retaining a String) and exhausted memory — the diagnostics freeze.
+        let outBuffer = CoalescingOutputBuffer()
+        let errBuffer = CoalescingOutputBuffer()
+        let flushLock = NSLock()
+        var outScheduled = false
+        var errScheduled = false
+
+        func scheduleOut() {
+            flushLock.lock()
+            if outScheduled { flushLock.unlock(); return }
+            outScheduled = true
+            flushLock.unlock()
+            DispatchQueue.main.async {
+                flushLock.lock(); outScheduled = false; flushLock.unlock()
+                let text = outBuffer.drainText()
+                if !text.isEmpty { onOutput(text) }
+            }
+        }
+        func scheduleErr() {
+            flushLock.lock()
+            if errScheduled { flushLock.unlock(); return }
+            errScheduled = true
+            flushLock.unlock()
+            DispatchQueue.main.async {
+                flushLock.lock(); errScheduled = false; flushLock.unlock()
+                let text = errBuffer.drainText()
+                if !text.isEmpty { onError(text) }
+            }
+        }
+
         stdoutPipe.fileHandleForReading.readabilityHandler = { handle in
             let data = handle.availableData
-            if !data.isEmpty, let str = String(data: data, encoding: .utf8) {
-                DispatchQueue.main.async { onOutput(str) }
-            }
+            guard !data.isEmpty else { return }
+            outBuffer.append(data)
+            scheduleOut()
         }
 
         stderrPipe.fileHandleForReading.readabilityHandler = { handle in
             let data = handle.availableData
-            if !data.isEmpty, let str = String(data: data, encoding: .utf8) {
-                DispatchQueue.main.async { onError(str) }
-            }
+            guard !data.isEmpty else { return }
+            errBuffer.append(data)
+            scheduleErr()
         }
 
         process.terminationHandler = { proc in
             stdoutPipe.fileHandleForReading.readabilityHandler = nil
             stderrPipe.fileHandleForReading.readabilityHandler = nil
-            DispatchQueue.main.async { completion(proc.terminationStatus) }
+            DispatchQueue.main.async {
+                let outText = outBuffer.finishText()
+                if !outText.isEmpty { onOutput(outText) }
+                let errText = errBuffer.finishText()
+                if !errText.isEmpty { onError(errText) }
+                completion(proc.terminationStatus)
+            }
         }
 
         do {
             try process.run()
             return process
         } catch {
+            stdoutPipe.fileHandleForReading.readabilityHandler = nil
+            stderrPipe.fileHandleForReading.readabilityHandler = nil
             onError("Failed to launch pymobiledevice3: \(error.localizedDescription)")
             completion(-1)
             return nil

--- a/Sources/Phosphor/Utilities/Shell.swift
+++ b/Sources/Phosphor/Utilities/Shell.swift
@@ -268,30 +268,71 @@ enum Shell {
         process.standardError = stderrPipe
         process.environment = environmentWithToolPaths()
 
+        // Coalesce high-rate output into a single in-flight main-queue flush. A chatty
+        // stream (e.g. verbose device syslog) previously enqueued one DispatchQueue.main.async
+        // block per chunk; when the producer outpaced the main thread that backlog grew without
+        // bound (each block retaining a String) and exhausted memory — the diagnostics freeze.
+        let outBuffer = CoalescingOutputBuffer()
+        let errBuffer = CoalescingOutputBuffer()
+        let flushLock = NSLock()
+        var outScheduled = false
+        var errScheduled = false
+
+        func scheduleOut() {
+            flushLock.lock()
+            if outScheduled { flushLock.unlock(); return }
+            outScheduled = true
+            flushLock.unlock()
+            DispatchQueue.main.async {
+                flushLock.lock(); outScheduled = false; flushLock.unlock()
+                let text = outBuffer.drainText()
+                if !text.isEmpty { onOutput(text) }
+            }
+        }
+        func scheduleErr() {
+            flushLock.lock()
+            if errScheduled { flushLock.unlock(); return }
+            errScheduled = true
+            flushLock.unlock()
+            DispatchQueue.main.async {
+                flushLock.lock(); errScheduled = false; flushLock.unlock()
+                let text = errBuffer.drainText()
+                if !text.isEmpty { onError(text) }
+            }
+        }
+
         stdoutPipe.fileHandleForReading.readabilityHandler = { handle in
             let data = handle.availableData
-            if !data.isEmpty, let str = String(data: data, encoding: .utf8) {
-                DispatchQueue.main.async { onOutput(str) }
-            }
+            guard !data.isEmpty else { return }
+            outBuffer.append(data)
+            scheduleOut()
         }
 
         stderrPipe.fileHandleForReading.readabilityHandler = { handle in
             let data = handle.availableData
-            if !data.isEmpty, let str = String(data: data, encoding: .utf8) {
-                DispatchQueue.main.async { onError(str) }
-            }
+            guard !data.isEmpty else { return }
+            errBuffer.append(data)
+            scheduleErr()
         }
 
         process.terminationHandler = { proc in
             stdoutPipe.fileHandleForReading.readabilityHandler = nil
             stderrPipe.fileHandleForReading.readabilityHandler = nil
-            DispatchQueue.main.async { completion(proc.terminationStatus) }
+            DispatchQueue.main.async {
+                let outText = outBuffer.finishText()
+                if !outText.isEmpty { onOutput(outText) }
+                let errText = errBuffer.finishText()
+                if !errText.isEmpty { onError(errText) }
+                completion(proc.terminationStatus)
+            }
         }
 
         do {
             try process.run()
             return process
         } catch {
+            stdoutPipe.fileHandleForReading.readabilityHandler = nil
+            stderrPipe.fileHandleForReading.readabilityHandler = nil
             onError("Failed to launch: \(error.localizedDescription)")
             completion(-1)
             return nil

--- a/Sources/Phosphor/Utilities/StreamingLineBuffer.swift
+++ b/Sources/Phosphor/Utilities/StreamingLineBuffer.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+/// Thread-safe, bounded, UTF-8-safe line buffer for high-rate process output streaming.
+///
+/// Producers (a pipe `readabilityHandler` on a background queue) feed raw `Data` via
+/// `append(_:)`. The buffer splits it into complete `\n`-terminated lines, keeping any
+/// trailing partial bytes as a remainder so a multi-byte UTF-8 scalar split across two
+/// reads is never dropped. Complete lines accumulate in a bounded FIFO (oldest dropped
+/// past `capacity`). A consumer periodically calls `drain()` on the main queue.
+///
+/// Pairing this with a *single-in-flight* main-queue flush in the caller bounds the
+/// number of queued main blocks to one regardless of producer rate — which is what
+/// prevents the unbounded main-queue backlog that exhausted memory during syslog
+/// streaming (the diagnostics "47 GB" freeze).
+final class StreamingLineBuffer: @unchecked Sendable {
+    private let capacity: Int
+    private let lock = NSLock()
+    private var remainder = Data()
+    private var lines: [String] = []
+    private let newline: UInt8 = 0x0A
+
+    init(capacity: Int = 5000) {
+        self.capacity = max(1, capacity)
+    }
+
+    /// Number of complete lines currently buffered (test/diagnostic hook).
+    var count: Int {
+        lock.lock(); defer { lock.unlock() }
+        return lines.count
+    }
+
+    /// Feed raw bytes from the background reader. Splits into complete lines and
+    /// retains any trailing partial bytes until their line is completed.
+    func append(_ data: Data) {
+        guard !data.isEmpty else { return }
+        lock.lock(); defer { lock.unlock() }
+
+        var buffer = remainder
+        buffer.append(data)
+
+        var start = buffer.startIndex
+        var produced: [String] = []
+        while let nl = buffer[start...].firstIndex(of: newline) {
+            produced.append(String(decoding: buffer[start..<nl], as: UTF8.self))
+            start = buffer.index(after: nl)
+        }
+        // Bytes after the last newline are an incomplete line; keep for next read.
+        remainder = Data(buffer[start...])
+
+        guard !produced.isEmpty else { return }
+        lines.append(contentsOf: produced)
+        if lines.count > capacity {
+            lines.removeFirst(lines.count - capacity)
+        }
+    }
+
+    /// Drain and return all buffered complete lines, clearing the buffer.
+    func drain() -> [String] {
+        lock.lock(); defer { lock.unlock() }
+        let out = lines
+        lines.removeAll(keepingCapacity: true)
+        return out
+    }
+
+    /// Flush any trailing partial bytes as a final line (call on stream end).
+    func finish() -> [String] {
+        lock.lock(); defer { lock.unlock() }
+        if !remainder.isEmpty {
+            lines.append(String(decoding: remainder, as: UTF8.self))
+            remainder.removeAll(keepingCapacity: false)
+        }
+        let out = lines
+        lines.removeAll(keepingCapacity: true)
+        return out
+    }
+}

--- a/Tests/PhosphorTests/StreamingLineBufferTests.swift
+++ b/Tests/PhosphorTests/StreamingLineBufferTests.swift
@@ -1,0 +1,49 @@
+import XCTest
+@testable import Phosphor
+
+final class StreamingLineBufferTests: XCTestCase {
+
+    func testSplitsMultipleLines() {
+        let b = StreamingLineBuffer()
+        b.append(Data("a\nb\nc\n".utf8))
+        XCTAssertEqual(b.drain(), ["a", "b", "c"])
+    }
+
+    func testPartialLineHeldUntilNewline() {
+        let b = StreamingLineBuffer()
+        b.append(Data("hel".utf8))
+        XCTAssertEqual(b.drain(), [], "a line without a trailing newline must not be delivered yet")
+        b.append(Data("lo\n".utf8))
+        XCTAssertEqual(b.drain(), ["hello"])
+    }
+
+    func testBoundedCapacityKeepsNewest() {
+        let b = StreamingLineBuffer(capacity: 3)
+        for i in 1...10 { b.append(Data("\(i)\n".utf8)) }
+        XCTAssertLessThanOrEqual(b.count, 3, "buffer must stay bounded regardless of input volume")
+        XCTAssertEqual(b.drain(), ["8", "9", "10"], "must keep the newest lines")
+    }
+
+    func testUTF8SplitAcrossChunks() {
+        // "é" == 0xC3 0xA9; the multibyte scalar is split across two reads.
+        let b = StreamingLineBuffer()
+        b.append(Data([0xC3]))
+        b.append(Data([0xA9]))
+        b.append(Data("\n".utf8))
+        XCTAssertEqual(b.drain(), ["é"], "a UTF-8 scalar split across reads must not be dropped")
+    }
+
+    func testDrainClears() {
+        let b = StreamingLineBuffer()
+        b.append(Data("x\n".utf8))
+        _ = b.drain()
+        XCTAssertEqual(b.drain(), [], "drain must clear the buffer")
+    }
+
+    func testFinishFlushesRemainder() {
+        let b = StreamingLineBuffer()
+        b.append(Data("tail-no-newline".utf8))
+        XCTAssertEqual(b.drain(), [])
+        XCTAssertEqual(b.finish(), ["tail-no-newline"], "finish() flushes the trailing partial line")
+    }
+}


### PR DESCRIPTION
## Summary

* [#36](<https://github.com/momenbasel/Phosphor/issues/36>)<br>Fixes [#36](<https://github.com/momenbasel/Phosphor/issues/36>). Live syslog/backup streaming enqueued one `DispatchQueue.main.async` block **per pipe chunk** from a background `readabilityHandler`. When a device produced output faster than the main thread consumed it (e.g. verbose iPhone syslog), the main-queue backlog of un-executed blocks grew without bound — each retaining a `String` — exhausting memory (observed tens of GB before the machine froze).

## What changed

A single-in-flight, coalesced main-queue flush backed by two small, bounded, UTF-8-safe buffers:

* `CoalescingOutputBuffer` (byte-level) — used in `Shell.runStreaming` and `PyMobileDevice.runStreaming`. Preserves raw text, including the `\r` progress updates emitted by `idevicebackup2`/`pymobiledevice3`, so it is safe for every caller (not just `\n`-based syslog). Bounds buffered bytes and holds back a multi-byte scalar split across two reads (previously `String(data:encoding:.utf8)` returned nil and dropped the whole chunk).
* `StreamingLineBuffer` (line-level) — used in `DiagnosticsManager.startSyslog` to split coalesced text into whole lines with a bounded ring buffer. Fixes multi-line chunks that counted as a single entry and the `5000`-"line" cap that actually bounded 5000 chunks.

Also: retain the fallback `idevicesyslog` `Process` so `stopSyslog()` can terminate it, and clear readability handlers on launch failure.

The key property: the number of queued main-queue blocks is bounded to one in flight, regardless of producer rate.

## Flow (before → after)

```mermaid
sequenceDiagram
    participant Dev as Device (fast producer)
    participant BG as readabilityHandler (bg)
    participant Main as Main queue (slow consumer)
    Note over Dev,Main: BEFORE — one main.async per chunk
    Dev->>BG: chunk 1..N (thousands/sec)
    BG->>Main: main.async { onOutput } × N (unbounded backlog)
    Note over Main: backlog grows → memory exhausted
    Note over Dev,Main: AFTER — coalesced single-in-flight flush
    Dev->>BG: chunk 1..N
    BG->>BG: append to bounded buffer
    BG-->>Main: schedule ONE flush (if none pending)
    Main->>Main: drain buffer → deliver (backlog ≤ 1)
```

## Verification

* **Flood test** against the real patched `Shell.runStreaming`: 3,000,001 lines with a deliberately slow consumer peaks at **13 MB RSS** (previously unbounded). All lines observed (no loss).
* **Unit tests** for both buffers (line splitting, bounded capacity keeps newest, UTF-8 scalar split across reads, `\r` preservation, drain/finish) — added under `Tests/PhosphorTests/`.
* `Scripts/build.sh`: all **32 regression checks pass**; release build succeeds.

## Test Plan

- [ ] Connect a verbose device, open Diagnostics → Logs, confirm memory plateaus over several minutes.
- [ ] Confirm backup progress (`idevicebackup2`/`pymobiledevice3`) still updates.
- [ ] `swift test` (unit tests) and `Scripts/build.sh` (regression) green.