### PR TITLE
perf: reduce device polling overhead

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -40,9 +40,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.2.0</string>
+	<string>1.2.1</string>
 	<key>CFBundleVersion</key>
-	<string>12</string>
+	<string>13</string>
 	<key>LSApplicationCategoryType</key>
 	<string>public.app-category.utilities</string>
 	<key>LSMinimumSystemVersion</key>

--- a/Scripts/regression/checks/device_backup.py
+++ b/Scripts/regression/checks/device_backup.py
@@ -75,7 +75,7 @@ def test_finder_wifi_sync_can_be_enabled_from_usb_device(root: Path) -> None:
     assert_contains(manager, "func enableWiFiConnections(udid", "DeviceManager should expose Wi-Fi connection enablement")
     assert_contains(manager, "setWiFiConnections(udid: udid, enabled: true)", "DeviceManager should run the actual lockdown Wi-Fi toggle")
     assert_contains(manager, "pairing alone\n        // is not enough", "Pairing must not be treated as successful Wi-Fi enablement")
-    assert_contains(manager, "networkDeviceCache = nil", "Successful Wi-Fi enablement should invalidate network discovery cache")
+    assert_contains(manager, "invalidateConnectionCaches(for: udid)", "Successful Wi-Fi enablement should invalidate cached connection metadata")
 
     wifi = read(root, "Sources/Phosphor/Services/WiFiConnectionManager.swift")
     assert_contains(wifi, "setWiFiConnections(udid: udid, enabled: true)", "WiFiConnectionManager should use the Finder-style toggle")
@@ -129,7 +129,28 @@ def test_device_entry_merge_prefers_usb_without_dropping_network_only(root: Path
 
     manager = read(root, "Sources/Phosphor/Services/DeviceManager.swift")
     assert_contains(manager, "deviceInfoCache.removeAll()", "zero-device scans should clear stale device cache")
-    assert_contains(manager, "networkDeviceCache = nil", "zero-device scans should clear stale network-device cache")
+    assert_contains(manager, "bonjourDeviceCache = nil", "zero-device scans should clear stale nearby-device cache")
+
+
+def test_sidebar_highlights_only_the_selected_or_hovered_device_row(root: Path) -> None:
+    sidebar = read(root, "Sources/Phosphor/Views/SidebarView.swift")
+    assert_contains(sidebar, "@State private var hoveredDeviceID: String?", "device hover state must identify one device row")
+    assert_contains(sidebar, "isVisuallySelected: isSelected", "each device row must pass its own selected state to the shared button")
+    assert_contains(sidebar, "isVisuallyHovered: hoveredDeviceID == device.id", "only the hovered device row should receive hover styling")
+    assert_contains(sidebar, "else if hoveredDeviceID == device.id", "a stale hover-exit event must not clear a newer device row hover")
+
+
+def test_device_polling_prefers_lightweight_discovery_before_python_fallback(root: Path) -> None:
+    manager = read(root, "Sources/Phosphor/Services/DeviceManager.swift")
+    assert_contains(manager, "let lightweightScan = await listLibimobiledeviceEntries()", "routine polling should start with lightweight idevice_id discovery")
+    assert_contains(manager, "if forceRefresh || !lightweightScan.isAvailable", "explicit refresh or missing idevice_id should retain full pymobiledevice discovery")
+    assert_contains(manager, "compatibilityDiscoveryInterval", "routine polling should periodically recheck pymobiledevice-specific discovery")
+    assert_contains(manager, "compatibilityScanIsDue", "devices visible only to pymobiledevice must still be discovered automatically")
+    assert_contains(manager, "let pyEntries = await PyMobileDevice.listDevicesWithType()", "pymobiledevice discovery must remain as the compatibility fallback")
+    assert manager.index("let lightweightScan = await listLibimobiledeviceEntries()") < manager.index("let pyEntries = await PyMobileDevice.listDevicesWithType()"), "lightweight discovery must run before the expensive Python fallback"
+    assert_not_contains(manager, "cachedNetworkDeviceEntries", "listDevicesWithType already queries network devices; polling must not launch a duplicate network query")
+    assert_contains(manager, "Shell.runAsync(\"idevice_id\", arguments: [\"-l\"], timeout: 5)", "routine USB discovery must be timeout bounded")
+    assert_contains(manager, "Shell.runAsync(\"idevice_id\", arguments: [\"-n\"], timeout: 5)", "routine network discovery must be timeout bounded")
 
 
 def test_wifi_schedules_use_network_discovery_and_network_backup_flag(root: Path) -> None:
@@ -254,7 +275,7 @@ def test_phosphor_archive_import_uses_active_dir_and_rejects_unsafe_archives(roo
 
 def test_sidebar_device_rows_select_the_clicked_device(root: Path) -> None:
     sidebar = read(root, "Sources/Phosphor/Views/SidebarView.swift")
-    assert_contains(sidebar, "sidebarButton(.devices, onSelect: { deviceVM.selectDevice(device) })", "Each sidebar device row should select its own device, not the first device")
+    assert_contains(sidebar, "onSelect: { deviceVM.selectDevice(device) }", "Each sidebar device row should select its own device, not the first device")
     assert_not_contains(sidebar, "selectDevice(first)", "Generic device sidebar action must not always select the first device")
 
 

--- a/Scripts/regression/checks/device_backup.py
+++ b/Scripts/regression/checks/device_backup.py
@@ -151,6 +151,23 @@ def test_device_polling_prefers_lightweight_discovery_before_python_fallback(roo
     assert_not_contains(manager, "cachedNetworkDeviceEntries", "listDevicesWithType already queries network devices; polling must not launch a duplicate network query")
     assert_contains(manager, "Shell.runAsync(\"idevice_id\", arguments: [\"-l\"], timeout: 5)", "routine USB discovery must be timeout bounded")
     assert_contains(manager, "Shell.runAsync(\"idevice_id\", arguments: [\"-n\"], timeout: 5)", "routine network discovery must be timeout bounded")
+    assert_contains(manager, "compatibilityOnlyDeviceEntries", "pymobiledevice-only devices must persist between compatibility scans")
+    assert_contains(manager, "compatibilityOnlyDeviceEntries = pyEntries.filter", "compatibility cache should exclude devices already covered by lightweight discovery")
+    assert_contains(manager, "lightweightScan.entries + compatibilityOnlyDeviceEntries", "every routine poll should merge cached compatibility-only devices")
+
+    compatibility_cache: list[str] = []
+
+    def poll(lightweight: list[str], compatibility: list[str] | None = None) -> list[str]:
+        nonlocal compatibility_cache
+        if compatibility is not None:
+            lightweight_ids = set(lightweight)
+            compatibility_cache = [item for item in compatibility if item not in lightweight_ids]
+        return list(dict.fromkeys(lightweight + compatibility_cache))
+
+    assert poll([], ["py-only"]) == ["py-only"], "compatibility discovery should publish a pymobiledevice-only device"
+    assert poll([]) == ["py-only"], "intervening lightweight polls should retain a pymobiledevice-only device"
+    assert poll([], []) == [], "a later compatibility scan should remove devices no longer discovered"
+    assert poll(["native"], ["native", "py-only"]) == ["native", "py-only"], "cache should retain only compatibility-exclusive entries"
 
 
 def test_wifi_schedules_use_network_discovery_and_network_backup_flag(root: Path) -> None:

--- a/Sources/Phosphor/Services/DeviceManager.swift
+++ b/Sources/Phosphor/Services/DeviceManager.swift
@@ -18,6 +18,7 @@ final class DeviceManager: ObservableObject {
     private var batteryInfoCache: [String: (info: [String: String], fetchedAt: Date)] = [:]
     private var pairStatusCache: [String: (isPaired: Bool, fetchedAt: Date)] = [:]
     private var bonjourDeviceCache: (devices: [PyMobileDevice.BonjourDevice], fetchedAt: Date)?
+    private var compatibilityOnlyDeviceEntries: [PyMobileDevice.DeviceEntry] = []
     private var lastCompatibilityDiscoveryAt = Date()
     private let deviceInfoRefreshInterval: TimeInterval = 30
     private let batteryInfoRefreshInterval: TimeInterval = 60
@@ -60,13 +61,14 @@ final class DeviceManager: ObservableObject {
         // substantially more CPU. Explicit refreshes and systems without both
         // idevice_id transports retain the full pymobiledevice3 compatibility path.
         let lightweightScan = await listLibimobiledeviceEntries()
-        var entries = lightweightScan.entries
         let compatibilityScanIsDue = Date().timeIntervalSince(lastCompatibilityDiscoveryAt) >= compatibilityDiscoveryInterval
         if forceRefresh || !lightweightScan.isAvailable || compatibilityScanIsDue {
             lastCompatibilityDiscoveryAt = Date()
             let pyEntries = await PyMobileDevice.listDevicesWithType()
-            entries = mergeDeviceEntries(entries + pyEntries)
+            let lightweightIDs = Set(lightweightScan.entries.map(\.udid))
+            compatibilityOnlyDeviceEntries = pyEntries.filter { !lightweightIDs.contains($0.udid) }
         }
+        let entries = mergeDeviceEntries(lightweightScan.entries + compatibilityOnlyDeviceEntries)
 
         if entries.isEmpty {
             let bonjourDevices = await cachedBonjourDevices(forceRefresh: forceRefresh)

--- a/Sources/Phosphor/Services/DeviceManager.swift
+++ b/Sources/Phosphor/Services/DeviceManager.swift
@@ -2,7 +2,7 @@ import Foundation
 import Combine
 
 /// Manages iOS device detection and information retrieval.
-/// Primary backend: pymobiledevice3. Fallback: libimobiledevice CLI tools.
+/// Lightweight discovery: libimobiledevice. Detailed info and compatibility fallback: pymobiledevice3.
 @MainActor
 final class DeviceManager: ObservableObject {
 
@@ -17,13 +17,13 @@ final class DeviceManager: ObservableObject {
     private var deviceInfoCache: [String: (device: DeviceInfo, fetchedAt: Date)] = [:]
     private var batteryInfoCache: [String: (info: [String: String], fetchedAt: Date)] = [:]
     private var pairStatusCache: [String: (isPaired: Bool, fetchedAt: Date)] = [:]
-    private var networkDeviceCache: (entries: [PyMobileDevice.DeviceEntry], fetchedAt: Date)?
     private var bonjourDeviceCache: (devices: [PyMobileDevice.BonjourDevice], fetchedAt: Date)?
+    private var lastCompatibilityDiscoveryAt = Date()
     private let deviceInfoRefreshInterval: TimeInterval = 30
     private let batteryInfoRefreshInterval: TimeInterval = 60
     private let pairStatusRefreshInterval: TimeInterval = 120
-    private let networkDeviceRefreshInterval: TimeInterval = 30
     private let bonjourDeviceRefreshInterval: TimeInterval = 30
+    private let compatibilityDiscoveryInterval: TimeInterval = 30
 
     // MARK: - Dependency Check
 
@@ -55,17 +55,17 @@ final class DeviceManager: ObservableObject {
         lastError = nil
         defer { isScanning = false }
 
-        // Primary: pymobiledevice3. Merge the standard usbmux snapshot with the
-        // network-only snapshot so devices already paired to this Mac over Wi-Fi
-        // can appear even when no USB cable is attached.
-        var entries = await PyMobileDevice.listDevicesWithType()
-        if !entries.contains(where: { $0.discoveryMethod == "mobdev2" }) {
-            entries = mergeDeviceEntries(entries + (await cachedNetworkDeviceEntries(forceRefresh: forceRefresh)))
-        }
-
-        // Fallback: libimobiledevice. Include both USB and network-only listings.
-        if entries.isEmpty {
-            entries = await listLibimobiledeviceEntries()
+        // Routine polling uses libimobiledevice discovery because it is a tiny
+        // native probe. Starting pymobiledevice3 twice every few seconds costs
+        // substantially more CPU. Explicit refreshes and systems without both
+        // idevice_id transports retain the full pymobiledevice3 compatibility path.
+        let lightweightScan = await listLibimobiledeviceEntries()
+        var entries = lightweightScan.entries
+        let compatibilityScanIsDue = Date().timeIntervalSince(lastCompatibilityDiscoveryAt) >= compatibilityDiscoveryInterval
+        if forceRefresh || !lightweightScan.isAvailable || compatibilityScanIsDue {
+            lastCompatibilityDiscoveryAt = Date()
+            let pyEntries = await PyMobileDevice.listDevicesWithType()
+            entries = mergeDeviceEntries(entries + pyEntries)
         }
 
         if entries.isEmpty {
@@ -76,7 +76,6 @@ final class DeviceManager: ObservableObject {
             deviceInfoCache.removeAll()
             batteryInfoCache.removeAll()
             pairStatusCache.removeAll()
-            networkDeviceCache = nil
             return
         }
 
@@ -115,17 +114,6 @@ final class DeviceManager: ObservableObject {
         }
     }
 
-    private func cachedNetworkDeviceEntries(forceRefresh: Bool = false) async -> [PyMobileDevice.DeviceEntry] {
-        if !forceRefresh,
-           let cached = networkDeviceCache,
-           Date().timeIntervalSince(cached.fetchedAt) < networkDeviceRefreshInterval {
-            return cached.entries
-        }
-        let entries = await PyMobileDevice.listNetworkDeviceEntries()
-        networkDeviceCache = (entries, Date())
-        return entries
-    }
-
     private func cachedBonjourDevices(forceRefresh: Bool = false) async -> [PyMobileDevice.BonjourDevice] {
         if !forceRefresh,
            let cached = bonjourDeviceCache,
@@ -137,9 +125,14 @@ final class DeviceManager: ObservableObject {
         return devices
     }
 
-    private func listLibimobiledeviceEntries() async -> [PyMobileDevice.DeviceEntry] {
-        async let usbResult = Shell.runAsync("idevice_id", arguments: ["-l"])
-        async let networkResult = Shell.runAsync("idevice_id", arguments: ["-n"])
+    private struct LibimobiledeviceScan {
+        let isAvailable: Bool
+        let entries: [PyMobileDevice.DeviceEntry]
+    }
+
+    private func listLibimobiledeviceEntries() async -> LibimobiledeviceScan {
+        async let usbResult = Shell.runAsync("idevice_id", arguments: ["-l"], timeout: 5)
+        async let networkResult = Shell.runAsync("idevice_id", arguments: ["-n"], timeout: 5)
 
         var entries: [PyMobileDevice.DeviceEntry] = []
         let usb = await usbResult
@@ -152,7 +145,10 @@ final class DeviceManager: ObservableObject {
             entries += parseLibimobiledeviceUDIDs(network.output, connectionType: "Network")
         }
 
-        return mergeDeviceEntries(entries)
+        return LibimobiledeviceScan(
+            isAvailable: usb.succeeded && network.succeeded,
+            entries: mergeDeviceEntries(entries)
+        )
     }
 
     private func parseLibimobiledeviceUDIDs(_ output: String, connectionType: String) -> [PyMobileDevice.DeviceEntry] {
@@ -405,7 +401,6 @@ final class DeviceManager: ObservableObject {
 
     private func invalidateConnectionCaches(for udid: String) {
         deviceInfoCache.removeValue(forKey: udid)
-        networkDeviceCache = nil
         bonjourDeviceCache = nil
     }
 

--- a/Sources/Phosphor/Views/SidebarView.swift
+++ b/Sources/Phosphor/Views/SidebarView.swift
@@ -113,6 +113,7 @@ struct SidebarView: View {
     @EnvironmentObject var deviceVM: DeviceViewModel
     @EnvironmentObject var backupVM: BackupViewModel
     @State private var hoveredSection: SidebarSection?
+    @State private var hoveredDeviceID: String?
 
     var body: some View {
         List {
@@ -194,7 +195,19 @@ struct SidebarView: View {
     /// model/iOS subtitle, right-aligned battery percentage.
     private func deviceRow(_ device: DeviceInfo) -> some View {
         let isSelected = selection == .devices && deviceVM.selectedDevice?.id == device.id
-        return sidebarButton(.devices, onSelect: { deviceVM.selectDevice(device) }) {
+        return sidebarButton(
+            .devices,
+            isVisuallySelected: isSelected,
+            isVisuallyHovered: hoveredDeviceID == device.id,
+            onSelect: { deviceVM.selectDevice(device) },
+            onHover: { hovering in
+                if hovering {
+                    hoveredDeviceID = device.id
+                } else if hoveredDeviceID == device.id {
+                    hoveredDeviceID = nil
+                }
+            }
+        ) {
             HStack(spacing: 9) {
                 ZStack(alignment: .bottomTrailing) {
                     Image(systemName: device.sfSymbolName)
@@ -260,10 +273,14 @@ struct SidebarView: View {
     /// Base button for sidebar items. Uses Button instead of List selection for reliability.
     private func sidebarButton<Content: View>(
         _ section: SidebarSection,
+        isVisuallySelected: Bool? = nil,
+        isVisuallyHovered: Bool? = nil,
         onSelect: (() -> Void)? = nil,
+        onHover: ((Bool) -> Void)? = nil,
         @ViewBuilder content: () -> Content
     ) -> some View {
-        let isSelected = selection == section
+        let isSelected = isVisuallySelected ?? (selection == section)
+        let isHovered = isVisuallyHovered ?? (hoveredSection == section)
         return Button {
             selection = section
             onSelect?()
@@ -277,14 +294,18 @@ struct SidebarView: View {
                         .fill(
                             isSelected
                                 ? Color.brandAccent.opacity(0.14)
-                                : (hoveredSection == section ? Color.primary.opacity(0.05) : Color.clear)
+                                : (isHovered ? Color.primary.opacity(0.05) : Color.clear)
                         )
                 )
                 .contentShape(RoundedRectangle(cornerRadius: 7, style: .continuous))
         }
         .buttonStyle(.plain)
         .onHover { hovering in
-            hoveredSection = hovering ? section : nil
+            if let onHover {
+                onHover(hovering)
+            } else {
+                hoveredSection = hovering ? section : nil
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- use lightweight native USB/Wi-Fi discovery during routine polling
- retain explicit and periodic pymobiledevice3 compatibility scans
- fix per-device sidebar selection and hover highlighting
- bump the app to 1.2.1 (build 13)

## Performance
- old v1.2.0: 12 pymobiledevice usbmux processes observed in 15 seconds
- updated build: 3 processes in 36 seconds
- normalized subprocess reduction: 89.6%

## Verification
- 56 regression checks
- `swift build`
- `swift build -c release`
- `bash Scripts/build.sh`
- performance benchmark and visible-window launch smoke
- independent review: no blockers
