### PR TITLE
fix: preserve restore source and target

### DIFF
--- a/Scripts/regression/checks/shell_safety.py
+++ b/Scripts/regression/checks/shell_safety.py
@@ -100,6 +100,29 @@ def test_backup_streaming_callers_are_timeout_bounded_and_cancelable(root: Path)
     assert "Shell.terminate(syslogProcess)" in diagnostics, "stopSyslog should escalate termination for stuck syslog children"
 
 
+def test_restore_captures_target_and_uses_backup_parent_with_source_udid(root: Path) -> None:
+    time_machine = read(root, "Sources/Phosphor/Views/Backup/BackupTimeMachineView.swift")
+    assert "struct RestoreRequest" in time_machine, "restore confirmation should capture one backup and target device"
+    assert "@State private var pendingRestore: RestoreRequest?" in time_machine, "restore alert should be driven by one item-scoped request"
+    assert "pendingRestore = RestoreRequest(backup: backup, targetUDID: target.id" in time_machine, "restore target must be captured when the button is clicked"
+    assert "performRestore(request)" in time_machine, "confirmation must execute the captured request"
+    assert "showRestoreConfirm" not in time_machine, "one Boolean shared by every backup card can confirm the wrong snapshot"
+
+    backup = read(root, "Sources/Phosphor/Services/BackupManager.swift")
+    assert "func restoreBackup(\n        backup: BackupInfo,\n        targetUDID: String" in backup, "restore service should accept typed source-backup metadata and an explicit target"
+    assert "deletingLastPathComponent" in swift_block_after(backup, "func restoreBackup("), "restore backends need the directory containing the source-UDID folder"
+    assert "sourceUDID: backup.udid" in swift_block_after(backup, "func restoreBackup("), "cross-device restores must identify the source backup UDID"
+    assert '["-u", targetUDID, "-s", backup.udid, "restore", "--system", backupRoot]' in backup, "idevicebackup2 options must precede restore and include source/target UDIDs"
+
+    py = read(root, "Sources/Phosphor/Utilities/PyMobileDevice.swift")
+    restore = swift_block_after(py, "static func restore(")
+    assert "sourceUDID: String?" in restore, "pymobiledevice restore should accept a source backup UDID"
+    assert 'args += ["--source", sourceUDID]' in restore, "pymobiledevice restore should pass --source for cross-device safety"
+
+    clone = read(root, "Sources/Phosphor/Services/DeviceCloneService.swift")
+    assert "backup: latestBackup" in clone and "targetUDID: destinationUDID" in clone, "clone restore must keep source backup and destination device distinct"
+
+
 def test_cancellation_token_model_prevents_cancelled_primary_from_starting_fallback(root: Path) -> None:
     del root
     active_operation_id: str | None = None

--- a/Sources/Phosphor/Services/BackupManager.swift
+++ b/Sources/Phosphor/Services/BackupManager.swift
@@ -835,17 +835,19 @@ final class BackupManager: ObservableObject {
 
     /// Restore a backup to a device. pymobiledevice3 primary, idevicebackup2 fallback.
     func restoreBackup(
-        backupPath: String,
-        udid: String,
+        backup: BackupInfo,
+        targetUDID: String,
         onProgress: @escaping (String) -> Void
     ) async -> Bool {
         let operationID = beginCancellableOperation()
+        let backupRoot = (backup.path as NSString).deletingLastPathComponent
         // Primary: pymobiledevice3
         if PyMobileDevice.available() {
             return await withCheckedContinuation { continuation in
                 activeProcess = PyMobileDevice.restore(
-                    directory: backupPath,
-                    udid: udid,
+                    directory: backupRoot,
+                    udid: targetUDID,
+                    sourceUDID: backup.udid,
                     timeout: Self.streamingRestoreTimeout,
                     onOutput: { output in onProgress(output) },
                     completion: { [weak self] exitCode in
@@ -871,7 +873,7 @@ final class BackupManager: ObservableObject {
         return await withCheckedContinuation { continuation in
             activeProcess = Shell.runStreaming(
                 "idevicebackup2",
-                arguments: ["restore", "--system", "--reboot", "-u", udid, backupPath],
+                arguments: ["-u", targetUDID, "-s", backup.udid, "restore", "--system", backupRoot],
                 timeout: Self.streamingRestoreTimeout,
                 onOutput: { output in onProgress(output) },
                 onError: { _ in },

--- a/Sources/Phosphor/Services/DeviceCloneService.swift
+++ b/Sources/Phosphor/Services/DeviceCloneService.swift
@@ -102,8 +102,8 @@ final class DeviceCloneService: ObservableObject {
         progress = "Restoring to destination device..."
 
         let restoreSuccess = await backupManager.restoreBackup(
-            backupPath: latestBackup.path,
-            udid: destinationUDID
+            backup: latestBackup,
+            targetUDID: destinationUDID
         ) { [weak self] text in
             self?.progress = text
             if let pct = PyMobileDevice.parseProgress(from: text) {

--- a/Sources/Phosphor/Utilities/PyMobileDevice.swift
+++ b/Sources/Phosphor/Utilities/PyMobileDevice.swift
@@ -751,6 +751,7 @@ enum PyMobileDevice {
     static func restore(
         directory: String,
         udid: String? = nil,
+        sourceUDID: String? = nil,
         system: Bool = true,
         reboot: Bool = true,
         timeout: TimeInterval? = 6 * 60 * 60,
@@ -761,6 +762,7 @@ enum PyMobileDevice {
         if system { args.append("--system") }
         if reboot { args.append("--reboot") }
         if let udid { args += ["--udid", udid] }
+        if let sourceUDID { args += ["--source", sourceUDID] }
         args.append(directory)
 
         return runStreaming(args, timeout: timeout, onOutput: onOutput, completion: completion)

--- a/Sources/Phosphor/Views/Backup/BackupTimeMachineView.swift
+++ b/Sources/Phosphor/Views/Backup/BackupTimeMachineView.swift
@@ -10,10 +10,16 @@ struct BackupTimeMachineView: View {
     var onBrowseBackup: () -> Void = {}
     @State private var selectedIndex: Int = 0
     @State private var isAnimating = false
-    @State private var showRestoreConfirm = false
+    @State private var pendingRestore: RestoreRequest?
     @State private var restoreProgress: String?
     @State private var isRestoring = false
     @State private var starPositions: [StarParticle] = generateStars(count: 120)
+
+    private struct RestoreRequest {
+        let backup: BackupInfo
+        let targetUDID: String
+        let targetName: String
+    }
 
     struct StarParticle: Identifiable {
         let id = UUID()
@@ -71,6 +77,25 @@ struct BackupTimeMachineView: View {
                 restoreOverlay(progress)
             }
         }
+        .alert(
+            "Restore Backup?",
+            isPresented: restoreConfirmationPresented,
+            presenting: pendingRestore
+        ) { request in
+            Button("Cancel", role: .cancel) {}
+            Button("Restore", role: .destructive) {
+                performRestore(request)
+            }
+        } message: { request in
+            Text("Restore \(request.targetName) from \(request.backup.dateString)? The device will restart, and this cannot be undone.")
+        }
+    }
+
+    private var restoreConfirmationPresented: Binding<Bool> {
+        Binding(
+            get: { pendingRestore != nil },
+            set: { if !$0 { pendingRestore = nil } }
+        )
     }
 
     // MARK: - Star Field
@@ -165,7 +190,8 @@ struct BackupTimeMachineView: View {
                 if offset == 0 {
                     HStack(spacing: 8) {
                         Button("Restore This Backup") {
-                            showRestoreConfirm = true
+                            guard let target = deviceVM.selectedDevice else { return }
+                            pendingRestore = RestoreRequest(backup: backup, targetUDID: target.id, targetName: target.name)
                         }
                         .buttonStyle(.borderedProminent)
                         .tint(.brandAccent)
@@ -212,14 +238,6 @@ struct BackupTimeMachineView: View {
         .opacity(cardOpacity)
         .zIndex(zIndex)
         .animation(.spring(response: 0.4, dampingFraction: 0.8), value: selectedIndex)
-        .alert("Restore Backup?", isPresented: $showRestoreConfirm) {
-            Button("Cancel", role: .cancel) {}
-            Button("Restore", role: .destructive) {
-                performRestore(backup)
-            }
-        } message: {
-            Text("This will restore your device to the state from \(backup.dateString). The device will restart. This cannot be undone.")
-        }
     }
 
     // MARK: - Timeline Bar
@@ -346,15 +364,14 @@ struct BackupTimeMachineView: View {
 
     // MARK: - Actions
 
-    private func performRestore(_ backup: BackupInfo) {
-        guard let udid = deviceVM.selectedDevice?.id else { return }
+    private func performRestore(_ request: RestoreRequest) {
         isRestoring = true
         restoreProgress = "Preparing restore..."
 
         Task {
             let success = await backupVM.backupManager.restoreBackup(
-                backupPath: backup.path,
-                udid: udid
+                backup: request.backup,
+                targetUDID: request.targetUDID
             ) { [self] text in
                 restoreProgress = text
             }


### PR DESCRIPTION
## Summary
- capture the exact backup and target device before showing destructive restore confirmation
- pass the backup parent directory plus explicit source and target UDIDs to both restore backends
- correct clone restore arguments and idevicebackup2 option order

## Why
The previous flow could confirm one snapshot and later restore another card or a newly selected device. It also passed the individual UDID folder where both backends require its parent, and omitted the source UDID for cross-device restore.

## Verification
- 55 regression checks pass
- debug and release Swift builds pass
- packaged app bundle builds successfully
- independent blocker review: no blockers
