### PR TITLE
fix: preserve timeout failure results

### DIFF
--- a/Scripts/regression/checks/shell_safety.py
+++ b/Scripts/regression/checks/shell_safety.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 from pathlib import Path
+import subprocess
+import tempfile
 
 
 def read(root: Path, rel: str) -> str:
@@ -47,6 +49,79 @@ def test_shell_run_async_cancels_timeout_watchdog_on_finish(root: Path) -> None:
     assert "attachWatchdog" in body, "runAsync should hand its timeout watchdog to the state so it can be cancelled early"
     assert "pendingWatchdog?.cancel()" in src, "finish should cancel the watchdog so pipe fds are freed the moment the command completes"
     assert "timedOut ? -1 : process.terminationStatus" in body, "runAsync must not read terminationStatus on the timed-out path (process may still be running)"
+
+
+def test_shell_timeouts_cannot_be_reported_as_success(root: Path) -> None:
+    probe = r'''
+import Foundation
+
+actor ErrorStore {
+    private var values: [String] = []
+    func append(_ value: String) { values.append(value) }
+    func snapshot() -> [String] { values }
+}
+
+@main
+struct TimeoutProbe {
+    static func main() async {
+        let command = "trap 'exit 0' TERM; while :; do sleep 1; done"
+
+        let asyncStart = Date()
+        let asyncResult = await Shell.runAsync(
+            "/bin/sh",
+            arguments: ["-c", command],
+            timeout: 0.2
+        )
+        let asyncElapsed = Date().timeIntervalSince(asyncStart)
+
+        let errors = ErrorStore()
+        let streamStart = Date()
+        let streamCode: Int32 = await withCheckedContinuation { continuation in
+            _ = Shell.runStreaming(
+                "/bin/sh",
+                arguments: ["-c", command],
+                timeout: 0.2,
+                onOutput: { _ in },
+                onError: { error in Task { await errors.append(error) } },
+                completion: { continuation.resume(returning: $0) }
+            )
+        }
+        let streamElapsed = Date().timeIntervalSince(streamStart)
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        let streamErrors = await errors.snapshot()
+
+        let asyncError = asyncResult.stderr.replacingOccurrences(of: "\n", with: " ")
+        print("ASYNC|\(asyncResult.exitCode)|\(asyncElapsed)|\(asyncError)")
+        print("STREAM|\(streamCode)|\(streamElapsed)|\(streamErrors.joined(separator: " "))")
+    }
+}
+'''
+    stub = "enum PyMobileDevice { static func available() -> Bool { false } }\n"
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp = Path(temp_dir)
+        shell_copy = temp / "Shell.swift"
+        shell_copy.write_text(read(root, "Sources/Phosphor/Utilities/Shell.swift"))
+        (temp / "PyMobileDeviceStub.swift").write_text(stub)
+        (temp / "Probe.swift").write_text(probe)
+        executable = temp / "timeout-probe"
+        compile_result = subprocess.run(
+            ["swiftc", "-parse-as-library", str(shell_copy), str(temp / "PyMobileDeviceStub.swift"), str(temp / "Probe.swift"), "-o", str(executable)],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        assert compile_result.returncode == 0, compile_result.stderr
+        result = subprocess.run([str(executable)], capture_output=True, text=True, timeout=10)
+
+    assert result.returncode == 0, result.stderr
+    records = {line.split("|", 1)[0]: line.split("|", 3)[1:] for line in result.stdout.splitlines() if "|" in line}
+    assert records["ASYNC"][0] == "-2", f"runAsync timeout was reported as exit {records['ASYNC'][0]}"
+    assert records["STREAM"][0] == "-2", f"runStreaming timeout was reported as exit {records['STREAM'][0]}"
+    assert "timed out" in records["ASYNC"][2].lower(), f"runAsync timeout should include a diagnostic: {result.stdout!r}"
+    assert "timed out" in records["STREAM"][2].lower(), "runStreaming timeout should include a diagnostic"
+    assert 0.1 <= float(records["ASYNC"][1]) < 1.5, "runAsync should complete near its timeout"
+    assert 0.1 <= float(records["STREAM"][1]) < 1.5, "runStreaming should complete near its timeout"
 
 
 def test_shell_run_streaming_has_bounded_timeout_and_force_kill(root: Path) -> None:

--- a/Sources/Phosphor/Utilities/Shell.swift
+++ b/Sources/Phosphor/Utilities/Shell.swift
@@ -18,6 +18,7 @@ enum Shell {
         private var stdoutData = Data()
         private var stderrData = Data()
         private var didFinish = false
+        private var timedOut = false
         private var watchdog: Task<Void, Never>?
 
         /// Hand the timeout watchdog to the state so it can be cancelled the moment the
@@ -43,6 +44,24 @@ enum Shell {
             lock.unlock()
         }
 
+        func markTimedOut() -> Bool {
+            lock.lock()
+            guard !didFinish else {
+                lock.unlock()
+                return false
+            }
+            timedOut = true
+            lock.unlock()
+            return true
+        }
+
+        func hasTimedOut() -> Bool {
+            lock.lock()
+            let value = timedOut
+            lock.unlock()
+            return value
+        }
+
         func hasFinished() -> Bool {
             lock.lock()
             let value = didFinish
@@ -50,18 +69,19 @@ enum Shell {
             return value
         }
 
-        func finish(timedOut: Bool, timeout: TimeInterval, exitCode: Int32) -> Result? {
+        func finish(timeout: TimeInterval, exitCode: Int32) -> Result? {
             lock.lock()
             guard !didFinish else {
                 lock.unlock()
                 return nil
             }
             didFinish = true
+            let didTimeOut = timedOut
             let pendingWatchdog = watchdog
             watchdog = nil
             let stdout = stdoutData
             var stderr = String(data: stderrData, encoding: .utf8) ?? ""
-            if timedOut {
+            if didTimeOut {
                 let timeoutMessage = "Command timed out after \(Int(timeout))s"
                 stderr = stderr.isEmpty ? timeoutMessage : stderr + "\n" + timeoutMessage
             }
@@ -71,7 +91,7 @@ enum Shell {
             pendingWatchdog?.cancel()
 
             return Result(
-                exitCode: timedOut ? -2 : exitCode,
+                exitCode: didTimeOut ? -2 : exitCode,
                 stdout: String(data: stdout, encoding: .utf8) ?? "",
                 stderr: stderr
             )
@@ -81,6 +101,7 @@ enum Shell {
     private final class StreamingCommandState: @unchecked Sendable {
         private let lock = NSLock()
         private var didFinish = false
+        private var timedOut = false
         private var timeoutTask: Task<Void, Never>?
 
         func hasFinished() -> Bool {
@@ -88,6 +109,17 @@ enum Shell {
             let value = didFinish
             lock.unlock()
             return value
+        }
+
+        func markTimedOut() -> Bool {
+            lock.lock()
+            guard !didFinish else {
+                lock.unlock()
+                return false
+            }
+            timedOut = true
+            lock.unlock()
+            return true
         }
 
         func setTimeoutTask(_ task: Task<Void, Never>) {
@@ -101,18 +133,19 @@ enum Shell {
             lock.unlock()
         }
 
-        func finish() -> Bool {
+        func finish(exitCode: Int32) -> Int32? {
             lock.lock()
             guard !didFinish else {
                 lock.unlock()
-                return false
+                return nil
             }
             didFinish = true
+            let result = timedOut ? -2 : exitCode
             let task = timeoutTask
             timeoutTask = nil
             lock.unlock()
             task?.cancel()
-            return true
+            return result
         }
     }
 
@@ -225,7 +258,7 @@ enum Shell {
             for (key, value) in extraEnvironment { environment[key] = value }
             process.environment = environment
 
-            @Sendable func finish(timedOut: Bool) {
+            @Sendable func finish() {
                 stdoutPipe.fileHandleForReading.readabilityHandler = nil
                 stderrPipe.fileHandleForReading.readabilityHandler = nil
                 state.append(stdoutPipe.fileHandleForReading.availableData, toStdout: true)
@@ -234,8 +267,8 @@ enum Shell {
                 // On the timed-out path the process may not be reaped yet; reading
                 // terminationStatus while it is still running throws. state.finish
                 // ignores the exit code for timeouts, so pass a placeholder there.
+                let timedOut = state.hasTimedOut()
                 guard let result = state.finish(
-                    timedOut: timedOut,
                     timeout: timeout,
                     exitCode: timedOut ? -1 : process.terminationStatus
                 ) else {
@@ -255,7 +288,7 @@ enum Shell {
             }
 
             process.terminationHandler = { _ in
-                finish(timedOut: false)
+                finish()
             }
 
             do {
@@ -275,7 +308,7 @@ enum Shell {
             let watchdogTask = Task {
                 let nanoseconds = UInt64(max(timeout, 0) * 1_000_000_000)
                 try? await Task.sleep(nanoseconds: nanoseconds)
-                guard !Task.isCancelled, !state.hasFinished() else { return }
+                guard !Task.isCancelled, state.markTimedOut() else { return }
 
                 process.terminate()
                 try? await Task.sleep(nanoseconds: 2_000_000_000)
@@ -287,7 +320,7 @@ enum Shell {
 
                 Darwin.kill(process.processIdentifier, SIGKILL)
                 try? await Task.sleep(nanoseconds: 1_000_000_000)
-                finish(timedOut: true)
+                finish()
             }
             state.attachWatchdog(watchdogTask)
         }
@@ -320,13 +353,13 @@ enum Shell {
         process.standardError = stderrPipe
         process.environment = environment ?? environmentWithToolPaths()
 
-        @Sendable func finish(exitCode: Int32, timedOut: Bool = false) {
-            guard state.finish() else { return }
+        @Sendable func finish(exitCode: Int32) {
+            guard let resolvedExitCode = state.finish(exitCode: exitCode) else { return }
             stdoutPipe.fileHandleForReading.readabilityHandler = nil
             stderrPipe.fileHandleForReading.readabilityHandler = nil
             process.terminationHandler = nil
 
-            DispatchQueue.main.async { completion(exitCode) }
+            DispatchQueue.main.async { completion(resolvedExitCode) }
         }
 
         stdoutPipe.fileHandleForReading.readabilityHandler = { handle in
@@ -362,7 +395,7 @@ enum Shell {
             let timeoutTask = Task {
                 let nanoseconds = UInt64(max(timeout, 0) * 1_000_000_000)
                 try? await Task.sleep(nanoseconds: nanoseconds)
-                guard !Task.isCancelled, !state.hasFinished() else { return }
+                guard !Task.isCancelled, state.markTimedOut() else { return }
 
                 let message = "Command timed out after \(Int(timeout))s"
                 DispatchQueue.main.async { onError(message) }
@@ -377,7 +410,7 @@ enum Shell {
                 Darwin.kill(process.processIdentifier, SIGKILL)
                 try? await Task.sleep(nanoseconds: 1_000_000_000)
                 guard !Task.isCancelled else { return }
-                finish(exitCode: -2, timedOut: true)
+                finish(exitCode: -2)
             }
             state.setTimeoutTask(timeoutTask)
         }


### PR DESCRIPTION
## Summary
- atomically claim timeout ownership before signaling subprocesses
- map both async and streaming timeout completions to exit code -2
- add a behavioral regression using TERM-trapping children that exit 0

## Why
The termination handler could previously win the race after the watchdog sent SIGTERM. A child trapping TERM and exiting 0 was then reported as successful even though it had timed out, allowing backup/restore and other callers to surface false success.

## Verification
- behavioral timeout regression passes 5 consecutive runs
- 55 regression checks pass
- debug and release Swift builds pass
- packaged app bundle builds successfully
- independent concurrency review: no blockers
