### PR TITLE
fix: contain app data extraction paths

### DIFF
--- a/Scripts/regression/checks/security_hardening.py
+++ b/Scripts/regression/checks/security_hardening.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 from pathlib import Path
+import subprocess
+import tempfile
 
 
 def read(root: Path, rel: str) -> str:
@@ -37,6 +39,111 @@ def test_backup_password_is_not_passed_on_the_command_line(root: Path) -> None:
     # The old argv-based idevicebackup2 encryption invocations must be gone.
     assert '"encryption", "on", password' not in backup, "password must not be an idevicebackup2 argv value"
     assert '"encryption", "off", password' not in backup, "password must not be an idevicebackup2 argv value"
+
+
+def test_app_extraction_rejects_traversal_and_symlink_components(root: Path) -> None:
+    utility_path = root / "Sources/Phosphor/Utilities/SafeExtractionPath.swift"
+    assert utility_path.exists(), "app extraction needs a shared safe destination resolver"
+
+    app_manager = read(root, "Sources/Phosphor/Services/AppManager.swift")
+    assert "SafeExtractionPath.prepareExtractionRoot" in app_manager, "AppManager must validate the untrusted bundle ID beneath the selected directory"
+    assert "SafeExtractionPath.prepareDestination" in app_manager, "app extraction must validate every manifest relative path before writing"
+    assert "appendingPathComponent(entry.relativePath)" not in app_manager, "untrusted manifest paths must not be appended directly"
+    assert "lastError = nil" in app_manager[app_manager.index("func extractAppData("):], "app extraction should clear stale errors before validating paths"
+
+    app_view = read(root, "Sources/Phosphor/Views/Apps/AppManagerView.swift")
+    assert "appendingPathComponent(app.id)" not in app_view, "the view must not turn an untrusted bundle ID into the trusted extraction root"
+    assert "to: url.path" in app_view, "AppManager needs the selected directory so it can enforce the boundary itself"
+
+    app_view_model = read(root, "Sources/Phosphor/ViewModels/AppViewModel.swift")
+    assert 'appManager.lastError ?? "No files extracted"' in app_view_model, "unsafe-path failures should be shown instead of a generic empty result"
+
+    probe = r'''
+import Foundation
+
+@main
+struct SafePathProbe {
+    static func main() throws {
+        let fm = FileManager.default
+        let root = URL(fileURLWithPath: CommandLine.arguments[1], isDirectory: true)
+        let outside = URL(fileURLWithPath: CommandLine.arguments[2], isDirectory: true)
+        try fm.createDirectory(at: root, withIntermediateDirectories: true)
+        try fm.createDirectory(at: outside, withIntermediateDirectories: true)
+        try fm.createSymbolicLink(at: root.appendingPathComponent("symlinked-app"), withDestinationURL: outside)
+
+        let extractionRoot = try SafeExtractionPath.prepareExtractionRoot(
+            selectedDirectory: root,
+            component: "com.example.app",
+            fileManager: fm
+        )
+        try fm.createSymbolicLink(at: extractionRoot.appendingPathComponent("linked"), withDestinationURL: outside)
+
+        let safe = try SafeExtractionPath.prepareDestination(
+            root: extractionRoot,
+            relativePath: "Documents/file.txt",
+            fileManager: fm
+        )
+        guard safe.path == extractionRoot.appendingPathComponent("Documents/file.txt").path else {
+            throw NSError(domain: "Probe", code: 1)
+        }
+
+        for component in ["", ".", "..", "../outside", "nested/app", "/tmp/absolute", "symlinked-app"] {
+            do {
+                _ = try SafeExtractionPath.prepareExtractionRoot(
+                    selectedDirectory: root,
+                    component: component,
+                    fileManager: fm
+                )
+                print("ALLOWED_ROOT|\(component)")
+                throw NSError(domain: "Probe", code: 2)
+            } catch SafeExtractionPath.PathError.unsafePath {
+                continue
+            }
+        }
+
+        let unsafe = [
+            "",
+            "/tmp/absolute.txt",
+            "../victim.txt",
+            "Documents/../../victim.txt",
+            "Documents/./file.txt",
+            "linked/victim.txt"
+        ]
+        for path in unsafe {
+            do {
+                _ = try SafeExtractionPath.prepareDestination(root: extractionRoot, relativePath: path, fileManager: fm)
+                print("ALLOWED|\(path)")
+                throw NSError(domain: "Probe", code: 2)
+            } catch SafeExtractionPath.PathError.unsafePath {
+                continue
+            }
+        }
+        print("PASS")
+    }
+}
+'''
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp = Path(temp_dir)
+        probe_path = temp / "Probe.swift"
+        probe_path.write_text(probe)
+        executable = temp / "safe-path-probe"
+        compile_result = subprocess.run(
+            ["swiftc", "-parse-as-library", str(utility_path), str(probe_path), "-o", str(executable)],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        assert compile_result.returncode == 0, compile_result.stderr
+        result = subprocess.run(
+            [str(executable), str(temp / "root"), str(temp / "outside")],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "PASS", result.stdout
 
 
 def test_shell_runasync_supports_extra_environment(root: Path) -> None:

--- a/Sources/Phosphor/Services/AppManager.swift
+++ b/Sources/Phosphor/Services/AppManager.swift
@@ -183,23 +183,39 @@ final class AppManager: ObservableObject {
     func extractAppData(
         bundleId: String,
         from backupPath: String,
-        to destination: String
+        to selectedDirectory: String
     ) async -> Int {
+        lastError = nil
         do {
             let manifest = try BackupManifest(backupPath: backupPath)
             let files = try manifest.appFiles(bundleId: bundleId)
 
             let fm = FileManager.default
-            try fm.createDirectory(atPath: destination, withIntermediateDirectories: true)
+            let extractionRoot = try SafeExtractionPath.prepareExtractionRoot(
+                selectedDirectory: URL(fileURLWithPath: selectedDirectory, isDirectory: true),
+                component: bundleId,
+                fileManager: fm
+            )
+
+            let extractionPlan = try files.filter(\.isFile).map { entry in
+                let destinationURL = try SafeExtractionPath.prepareDestination(
+                    root: extractionRoot,
+                    relativePath: entry.relativePath,
+                    fileManager: fm
+                )
+                return (entry, destinationURL)
+            }
 
             var extracted = 0
-            for entry in files where entry.isFile {
-                let destPath = (destination as NSString).appendingPathComponent(entry.relativePath)
-                let destDir = (destPath as NSString).deletingLastPathComponent
-                try fm.createDirectory(atPath: destDir, withIntermediateDirectories: true)
-
+            for (entry, destinationURL) in extractionPlan {
                 do {
-                    try manifest.extractFile(entry, to: destPath)
+                    let verifiedDestination = try SafeExtractionPath.prepareDestination(
+                        root: extractionRoot,
+                        relativePath: entry.relativePath,
+                        fileManager: fm
+                    )
+                    guard verifiedDestination == destinationURL else { continue }
+                    try manifest.extractFile(entry, to: verifiedDestination.path)
                     extracted += 1
                 } catch {
                     continue

--- a/Sources/Phosphor/Utilities/SafeExtractionPath.swift
+++ b/Sources/Phosphor/Utilities/SafeExtractionPath.swift
@@ -1,0 +1,113 @@
+import Foundation
+
+/// Resolves untrusted backup-manifest paths beneath an extraction root without
+/// allowing traversal through absolute paths, `..`, or pre-existing symlinks.
+enum SafeExtractionPath {
+    enum PathError: LocalizedError {
+        case unsafePath
+
+        var errorDescription: String? {
+            "Backup entry contains an unsafe extraction path"
+        }
+    }
+
+    static func prepareExtractionRoot(
+        selectedDirectory: URL,
+        component: String,
+        fileManager: FileManager = .default
+    ) throws -> URL {
+        guard selectedDirectory.isFileURL,
+              !component.isEmpty,
+              component != ".",
+              component != "..",
+              !component.contains("/"),
+              !(component as NSString).isAbsolutePath else {
+            throw PathError.unsafePath
+        }
+
+        try fileManager.createDirectory(at: selectedDirectory, withIntermediateDirectories: true)
+        let lexicalBoundary = selectedDirectory.standardizedFileURL
+        let resolvedBoundary = lexicalBoundary.resolvingSymlinksInPath()
+        let candidate = lexicalBoundary.appendingPathComponent(component, isDirectory: true).standardizedFileURL
+        guard isContained(candidate, in: lexicalBoundary) else {
+            throw PathError.unsafePath
+        }
+
+        if let attributes = try? fileManager.attributesOfItem(atPath: candidate.path) {
+            guard attributes[.type] as? FileAttributeType == .typeDirectory else {
+                throw PathError.unsafePath
+            }
+        } else {
+            try fileManager.createDirectory(at: candidate, withIntermediateDirectories: false)
+        }
+
+        let resolvedCandidate = candidate.resolvingSymlinksInPath()
+        guard isContained(resolvedCandidate, in: resolvedBoundary) else {
+            throw PathError.unsafePath
+        }
+        return resolvedCandidate
+    }
+
+    static func prepareDestination(
+        root: URL,
+        relativePath: String,
+        fileManager: FileManager = .default
+    ) throws -> URL {
+        guard root.isFileURL,
+              !relativePath.isEmpty,
+              !(relativePath as NSString).isAbsolutePath else {
+            throw PathError.unsafePath
+        }
+
+        let components = relativePath
+            .split(separator: "/", omittingEmptySubsequences: false)
+            .map(String.init)
+        guard !components.isEmpty,
+              components.allSatisfy({ !$0.isEmpty && $0 != "." && $0 != ".." }) else {
+            throw PathError.unsafePath
+        }
+
+        try fileManager.createDirectory(at: root, withIntermediateDirectories: true)
+        let resolvedRoot = root.standardizedFileURL.resolvingSymlinksInPath()
+        var parent = resolvedRoot
+
+        for component in components.dropLast() {
+            let candidate = parent.appendingPathComponent(component, isDirectory: true).standardizedFileURL
+            guard isContained(candidate, in: resolvedRoot) else {
+                throw PathError.unsafePath
+            }
+
+            var isDirectory: ObjCBool = false
+            if fileManager.fileExists(atPath: candidate.path, isDirectory: &isDirectory) {
+                let attributes = try fileManager.attributesOfItem(atPath: candidate.path)
+                guard attributes[.type] as? FileAttributeType != .typeSymbolicLink,
+                      isDirectory.boolValue else {
+                    throw PathError.unsafePath
+                }
+            } else {
+                try fileManager.createDirectory(at: candidate, withIntermediateDirectories: false)
+            }
+            parent = candidate
+        }
+
+        let destination = parent.appendingPathComponent(components[components.count - 1]).standardizedFileURL
+        guard isContained(destination, in: resolvedRoot) else {
+            throw PathError.unsafePath
+        }
+
+        if fileManager.fileExists(atPath: destination.path) {
+            let attributes = try fileManager.attributesOfItem(atPath: destination.path)
+            guard attributes[.type] as? FileAttributeType != .typeSymbolicLink,
+                  attributes[.type] as? FileAttributeType != .typeDirectory else {
+                throw PathError.unsafePath
+            }
+        }
+
+        return destination
+    }
+
+    private static func isContained(_ candidate: URL, in root: URL) -> Bool {
+        let rootPath = root.path.hasSuffix("/") ? root.path : root.path + "/"
+        return candidate.path.hasPrefix(rootPath)
+    }
+}

--- a/Sources/Phosphor/ViewModels/AppViewModel.swift
+++ b/Sources/Phosphor/ViewModels/AppViewModel.swift
@@ -60,7 +60,7 @@ final class AppViewModel: ObservableObject {
 
     func extractAppData(bundleId: String, backupPath: String, to dest: String) async {
         let count = await appManager.extractAppData(bundleId: bundleId, from: backupPath, to: dest)
-        alertMessage = count > 0 ? "Extracted \(count) files" : "No files extracted"
+        alertMessage = count > 0 ? "Extracted \(count) files" : (appManager.lastError ?? "No files extracted")
         showAlert = true
     }
 }

--- a/Sources/Phosphor/Views/Apps/AppManagerView.swift
+++ b/Sources/Phosphor/Views/Apps/AppManagerView.swift
@@ -250,7 +250,6 @@ struct AppManagerView: View {
               let url = panel.url,
               let backup = backupVM.selectedBackup else { return }
 
-        let dest = (url.path as NSString).appendingPathComponent(app.id)
-        Task { await appVM.extractAppData(bundleId: app.id, backupPath: backup.path, to: dest) }
+        Task { await appVM.extractAppData(bundleId: app.id, backupPath: backup.path, to: url.path) }
     }
 }


### PR DESCRIPTION
## Summary
- validate backup bundle IDs as one safe extraction-root component
- reject absolute, traversal, malformed, and symlinked manifest destinations
- preflight every app-data entry before file copies and surface validation failures

## Why
A crafted backup could use `../` in its bundle ID or Manifest.db relative paths—or rely on an existing destination symlink—to write outside the directory selected by the user and overwrite unrelated files.

## Verification
- behavioral Swift probe covers bundle-ID traversal, absolute paths, extraction-root symlinks, relative traversal, and nested symlinks
- 55 regression checks pass
- debug and release Swift builds pass
- packaged app bundle builds successfully
- final independent security review: no blockers
