### PR TITLE
Add a secure built-in update checker

### DIFF
--- a/Scripts/regression/checks/app_update.py
+++ b/Scripts/regression/checks/app_update.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+import tempfile
+
+
+def read(root: Path, rel: str) -> str:
+    return (root / rel).read_text()
+
+
+def test_update_release_parsing_and_version_comparison_are_behavioral(root: Path) -> None:
+    service = root / "Sources/Phosphor/Services/UpdateService.swift"
+    assert service.exists(), "UpdateService.swift should provide the release-checking behavior"
+
+    probe = r'''
+import Foundation
+
+enum AppVersion {
+    static let current = "1.3.0"
+}
+
+@main
+struct UpdateProbe {
+    static func main() throws {
+        precondition(UpdateService.isVersion("1.3.1", newerThan: "1.3.0"))
+        precondition(UpdateService.isVersion("v2.0.0", newerThan: "1.99.99"))
+        precondition(UpdateService.isVersion("1.10.0", newerThan: "1.9.9"))
+        precondition(!UpdateService.isVersion("1.3.0", newerThan: "1.3.0"))
+        precondition(!UpdateService.isVersion("1.2.9", newerThan: "1.3.0"))
+        precondition(!UpdateService.isVersion("nightly", newerThan: "1.3.0"))
+
+        let payload = #"{"tag_name":"v1.4.0","name":"Phosphor 1.4.0","html_url":"https://github.com/momenbasel/Phosphor/releases/tag/v1.4.0","body":"Release notes","draft":false,"prerelease":false,"assets":[{"name":"Phosphor.dmg","browser_download_url":"https://github.com/momenbasel/Phosphor/releases/download/v1.4.0/Phosphor.dmg"}]}"#.data(using: .utf8)!
+        let release = try UpdateService.decodeRelease(from: payload)
+        precondition(release.version == "1.4.0")
+        precondition(release.downloadURL.absoluteString.hasSuffix("/Phosphor.dmg"))
+        precondition(release.releaseNotesURL.absoluteString.hasSuffix("/v1.4.0"))
+
+        let nullableMetadataPayload = #"{"tag_name":"v1.4.1","name":null,"html_url":"https://github.com/momenbasel/Phosphor/releases/tag/v1.4.1","body":null,"draft":false,"prerelease":false,"assets":[]}"#.data(using: .utf8)!
+        let nullableMetadataRelease = try UpdateService.decodeRelease(from: nullableMetadataPayload)
+        precondition(nullableMetadataRelease.version == "1.4.1")
+        precondition(nullableMetadataRelease.downloadURL == nullableMetadataRelease.releaseNotesURL)
+
+        let unsafeAssetPayload = #"{"tag_name":"v1.4.2","html_url":"https://github.com/momenbasel/Phosphor/releases/tag/v1.4.2","draft":false,"prerelease":false,"assets":[{"name":"Phosphor.dmg","browser_download_url":"x-phosphor-test://attacker/payload"}]}"#.data(using: .utf8)!
+        let unsafeAssetRelease = try UpdateService.decodeRelease(from: unsafeAssetPayload)
+        precondition(unsafeAssetRelease.downloadURL == unsafeAssetRelease.releaseNotesURL)
+
+        let unsafeNotesPayload = #"{"tag_name":"v1.4.3","html_url":"file:///etc/passwd","draft":false,"prerelease":false,"assets":[]}"#.data(using: .utf8)!
+        do {
+            _ = try UpdateService.decodeRelease(from: unsafeNotesPayload)
+            preconditionFailure("non-HTTPS release notes URL should be rejected")
+        } catch UpdateServiceError.invalidRelease {
+            // Expected.
+        }
+        print("PASS")
+    }
+}
+'''
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp = Path(temp_dir)
+        probe_path = temp / "Probe.swift"
+        probe_path.write_text(probe)
+        executable = temp / "update-probe"
+        compile_result = subprocess.run(
+            ["swiftc", "-parse-as-library", str(service), str(probe_path), "-o", str(executable)],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        assert compile_result.returncode == 0, compile_result.stderr
+        result = subprocess.run([str(executable)], capture_output=True, text=True, timeout=10)
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == "PASS"
+
+
+def test_update_checker_validates_github_response_and_uses_current_bundle_version(root: Path) -> None:
+    service = read(root, "Sources/Phosphor/Services/UpdateService.swift")
+    assert "https://api.github.com/repos/momenbasel/Phosphor/releases/latest" in service
+    assert 'request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")' in service
+    assert 'request.setValue("Phosphor/\\(currentVersion)", forHTTPHeaderField: "User-Agent")' in service
+    assert "200..<300" in service, "GitHub HTTP failures must not be decoded as successful releases"
+    assert "AppVersion.current" in service, "update checks should compare against the running bundle version"
+
+
+def test_update_checker_is_available_from_the_app_menu_and_about_settings(root: Path) -> None:
+    app = read(root, "Sources/Phosphor/App/PhosphorApp.swift")
+    settings = read(root, "Sources/Phosphor/Views/Settings/SettingsView.swift")
+    controller = read(root, "Sources/Phosphor/ViewModels/UpdateViewModel.swift")
+
+    assert 'CommandGroup(after: .appInfo)' in app
+    assert 'Button("Check for Updates…")' in app
+    assert ".disabled(updateController.isChecking)" in app
+    assert ".environmentObject(updateController)" in app
+    assert 'Button("Check for Updates")' in settings
+    assert "updateController.isChecking" in settings
+    assert 'alert.addButton(withTitle: "Download Update")' in controller
+    assert 'alert.addButton(withTitle: "Release Notes")' in controller
+    assert "NSWorkspace.shared.open(release.downloadURL)" in controller

--- a/Sources/Phosphor/App/PhosphorApp.swift
+++ b/Sources/Phosphor/App/PhosphorApp.swift
@@ -37,6 +37,7 @@ struct PhosphorApp: App {
     @StateObject private var deviceVM = DeviceViewModel()
     @StateObject private var backupVM = BackupViewModel()
     @StateObject private var scheduler = BackupScheduler()
+    @StateObject private var updateController = UpdateViewModel()
     @AppStorage("phosphor.hasCompletedOnboarding") private var hasCompletedOnboarding = false
 
     init() {
@@ -51,6 +52,7 @@ struct PhosphorApp: App {
             ContentView()
                 .environmentObject(deviceVM)
                 .environmentObject(backupVM)
+                .environmentObject(updateController)
                 .frame(minWidth: 960, minHeight: 640)
                 .onAppear {
                     Task {
@@ -70,6 +72,13 @@ struct PhosphorApp: App {
         .windowToolbarStyle(.unified(showsTitle: true))
         .defaultSize(width: 1100, height: 720)
         .commands {
+            CommandGroup(after: .appInfo) {
+                Button("Check for Updates…") {
+                    Task { await updateController.checkForUpdates() }
+                }
+                .disabled(updateController.isChecking)
+            }
+
             CommandMenu("Device") {
                 Button("Refresh Devices") {
                     Task { await deviceVM.refresh() }
@@ -116,6 +125,7 @@ struct PhosphorApp: App {
 
         Settings {
             SettingsView()
+                .environmentObject(updateController)
         }
     }
 

--- a/Sources/Phosphor/Services/UpdateService.swift
+++ b/Sources/Phosphor/Services/UpdateService.swift
@@ -1,0 +1,148 @@
+import Foundation
+
+struct UpdateRelease: Decodable, Sendable {
+    struct Asset: Decodable, Sendable {
+        let name: String
+        let browserDownloadURL: URL
+
+        enum CodingKeys: String, CodingKey {
+            case name
+            case browserDownloadURL = "browser_download_url"
+        }
+    }
+
+    let tagName: String
+    let releaseNotesURL: URL
+    let draft: Bool
+    let prerelease: Bool
+    let assets: [Asset]
+
+    enum CodingKeys: String, CodingKey {
+        case tagName = "tag_name"
+        case releaseNotesURL = "html_url"
+        case draft
+        case prerelease
+        case assets
+    }
+
+    var version: String {
+        UpdateService.normalizedVersion(tagName) ?? tagName
+    }
+
+    var downloadURL: URL {
+        assets.first {
+            $0.name.compare("Phosphor.dmg", options: [.caseInsensitive]) == .orderedSame
+                && UpdateService.isTrustedGitHubURL($0.browserDownloadURL)
+        }?.browserDownloadURL ?? releaseNotesURL
+    }
+}
+
+enum UpdateCheckResult: Sendable {
+    case updateAvailable(UpdateRelease)
+    case upToDate(UpdateRelease)
+}
+
+enum UpdateServiceError: LocalizedError {
+    case invalidResponse(statusCode: Int)
+    case invalidRelease
+    case invalidVersion(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidResponse(let statusCode):
+            return "GitHub returned HTTP \(statusCode)."
+        case .invalidRelease:
+            return "GitHub did not return a usable stable Phosphor release."
+        case .invalidVersion(let version):
+            return "Phosphor could not compare version \(version)."
+        }
+    }
+}
+
+struct UpdateService: Sendable {
+    static let latestReleaseURL = URL(
+        string: "https://api.github.com/repos/momenbasel/Phosphor/releases/latest"
+    )!
+
+    func checkForUpdates(currentVersion: String = AppVersion.current) async throws -> UpdateCheckResult {
+        guard Self.normalizedVersion(currentVersion) != nil else {
+            throw UpdateServiceError.invalidVersion(currentVersion)
+        }
+
+        var request = URLRequest(url: Self.latestReleaseURL)
+        request.timeoutInterval = 15
+        request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
+        request.setValue("Phosphor/\(currentVersion)", forHTTPHeaderField: "User-Agent")
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let httpResponse = response as? HTTPURLResponse,
+              (200..<300).contains(httpResponse.statusCode) else {
+            let statusCode = (response as? HTTPURLResponse)?.statusCode ?? 0
+            throw UpdateServiceError.invalidResponse(statusCode: statusCode)
+        }
+
+        let release = try Self.decodeRelease(from: data)
+        guard !release.draft, !release.prerelease,
+              Self.normalizedVersion(release.tagName) != nil else {
+            throw UpdateServiceError.invalidRelease
+        }
+
+        if Self.isVersion(release.tagName, newerThan: currentVersion) {
+            return .updateAvailable(release)
+        }
+        return .upToDate(release)
+    }
+
+    static func decodeRelease(from data: Data) throws -> UpdateRelease {
+        let release = try JSONDecoder().decode(UpdateRelease.self, from: data)
+        guard isTrustedGitHubURL(release.releaseNotesURL) else {
+            throw UpdateServiceError.invalidRelease
+        }
+        return release
+    }
+
+    static func isTrustedGitHubURL(_ url: URL) -> Bool {
+        url.scheme?.lowercased() == "https"
+            && url.host?.lowercased() == "github.com"
+            && url.user == nil
+            && url.password == nil
+    }
+
+    static func isVersion(_ candidate: String, newerThan current: String) -> Bool {
+        guard let candidateParts = versionComponents(candidate),
+              let currentParts = versionComponents(current) else {
+            return false
+        }
+
+        let componentCount = max(candidateParts.count, currentParts.count)
+        for index in 0..<componentCount {
+            let candidatePart = index < candidateParts.count ? candidateParts[index] : 0
+            let currentPart = index < currentParts.count ? currentParts[index] : 0
+            if candidatePart != currentPart {
+                return candidatePart > currentPart
+            }
+        }
+        return false
+    }
+
+    static func normalizedVersion(_ version: String) -> String? {
+        versionComponents(version)?.map(String.init).joined(separator: ".")
+    }
+
+    private static func versionComponents(_ version: String) -> [Int]? {
+        var normalized = version.trimmingCharacters(in: .whitespacesAndNewlines)
+        if normalized.first == "v" || normalized.first == "V" {
+            normalized.removeFirst()
+        }
+        guard !normalized.isEmpty,
+              !normalized.contains("-"),
+              !normalized.contains("+") else {
+            return nil
+        }
+
+        let parts = normalized.split(separator: ".", omittingEmptySubsequences: false)
+        guard !parts.isEmpty else { return nil }
+        let numbers = parts.compactMap { Int($0) }
+        return numbers.count == parts.count ? numbers : nil
+    }
+}

--- a/Sources/Phosphor/ViewModels/UpdateViewModel.swift
+++ b/Sources/Phosphor/ViewModels/UpdateViewModel.swift
@@ -1,0 +1,67 @@
+import AppKit
+import Combine
+
+@MainActor
+final class UpdateViewModel: ObservableObject {
+    @Published private(set) var isChecking = false
+
+    private let updateService: UpdateService
+
+    init(updateService: UpdateService = UpdateService()) {
+        self.updateService = updateService
+    }
+
+    func checkForUpdates() async {
+        guard !isChecking else { return }
+        isChecking = true
+        defer { isChecking = false }
+
+        do {
+            switch try await updateService.checkForUpdates() {
+            case .updateAvailable(let release):
+                presentAvailableUpdate(release)
+            case .upToDate(let release):
+                presentUpToDate(release)
+            }
+        } catch {
+            presentFailure(error)
+        }
+    }
+
+    private func presentAvailableUpdate(_ release: UpdateRelease) {
+        let alert = NSAlert()
+        alert.alertStyle = .informational
+        alert.messageText = "Phosphor \(release.version) Is Available"
+        alert.informativeText = "You are using Phosphor \(AppVersion.current). Download the latest release, then replace the existing app in Applications."
+        alert.addButton(withTitle: "Download Update")
+        alert.addButton(withTitle: "Release Notes")
+        alert.addButton(withTitle: "Later")
+
+        switch alert.runModal() {
+        case .alertFirstButtonReturn:
+            NSWorkspace.shared.open(release.downloadURL)
+        case .alertSecondButtonReturn:
+            NSWorkspace.shared.open(release.releaseNotesURL)
+        default:
+            break
+        }
+    }
+
+    private func presentUpToDate(_ release: UpdateRelease) {
+        let alert = NSAlert()
+        alert.alertStyle = .informational
+        alert.messageText = "Phosphor Is Up to Date"
+        alert.informativeText = "You are using the latest version of Phosphor (\(release.version))."
+        alert.addButton(withTitle: "OK")
+        alert.runModal()
+    }
+
+    private func presentFailure(_ error: Error) {
+        let alert = NSAlert()
+        alert.alertStyle = .warning
+        alert.messageText = "Couldn’t Check for Updates"
+        alert.informativeText = "Check your internet connection and try again.\n\n\(error.localizedDescription)"
+        alert.addButton(withTitle: "OK")
+        alert.runModal()
+    }
+}

--- a/Sources/Phosphor/Views/Settings/SettingsView.swift
+++ b/Sources/Phosphor/Views/Settings/SettingsView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 /// App settings: backup location, dependencies check, about.
 struct SettingsView: View {
 
+    @EnvironmentObject private var updateController: UpdateViewModel
     @AppStorage("phosphor.backupDirectory") private var backupDirectory = BackupManager.defaultBackupDir
     @State private var dependencyList: [DependencyItem] = []
     @State private var isCheckingDependencies = false
@@ -285,6 +286,21 @@ struct SettingsView: View {
             Text("Version \(AppVersion.current) (\(AppVersion.build))")
                 .font(.subheadline)
                 .foregroundStyle(.secondary)
+
+            HStack(spacing: 8) {
+                Button("Check for Updates") {
+                    Task { await updateController.checkForUpdates() }
+                }
+                .disabled(updateController.isChecking)
+
+                if updateController.isChecking {
+                    ProgressView()
+                        .controlSize(.small)
+                    Text("Checking…")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
 
             Text("Free and open-source iOS device manager for macOS.\nBattery diagnostics, screen capture, location tools, and more.")
                 .font(.system(size: 13))


### PR DESCRIPTION
## Summary
- add Check for Updates to the app menu and About settings
- compare the installed bundle version with the latest stable GitHub release
- offer trusted DMG download and release-note actions without replacing the app automatically
- reject non-HTTPS and non-GitHub URLs before opening remote content

## Verification
- `python3 Scripts/regression/run.py` — 67/67 passed
- `swift build`
- `swift build -c release`
- `bash Scripts/build.sh`
- live GitHub release probe returned v1.3.0 and the official DMG URL
- launched the built app and exercised the Check for Updates menu flow