### PR TITLE
Prevent overlapping backup and restore operations

### DIFF
--- a/Scripts/regression/checks/shell_safety.py
+++ b/Scripts/regression/checks/shell_safety.py
@@ -168,11 +168,11 @@ def test_backup_streaming_callers_are_timeout_bounded_and_cancelable(root: Path)
     assert "timeout: Self.streamingBackupTimeout" in backup, "backup subprocess streams must pass the backup timeout"
     assert "timeout: Self.streamingRestoreTimeout" in backup, "restore subprocess streams must pass the restore timeout"
     assert "activeProcess = Shell.runStreaming" in backup, "fallback streaming processes should be cancelable via activeProcess"
-    assert "beginCancellableOperation()" in backup, "backup/restore operations should use operation IDs rather than one shared cancellation boolean"
+    assert "beginCancellableOperation(udid:" in backup, "backup/restore operations should use operation IDs rather than one shared cancellation boolean"
     assert "cancelledOperationIDs.insert(activeOperationID)" in backup, "cancelBackup should mark the active operation canceled before killing the child"
     assert "operationWasCancelled(operationID)" in backup, "cancelled primary streams should not fall through into fallback backups"
     assert "lastOperationWasCancelled" in backup, "cancellation should be exposed separately from lastError/backup failures"
-    assert "if activeOperationID == id" in swift_block_after(backup, "private func markOperationCancelled"), "stale cancelled operations should not overwrite current operation UI state"
+    assert "if operationCoordinator.activeOperationID == id" in swift_block_after(backup, "private func markOperationCancelled"), "stale cancelled operations should not overwrite current operation UI state"
     assert "backupCancelled" not in backup, "backup/restore cancellation must not use one shared mutable boolean"
     assert "lastError = nil" in swift_block_after(backup, "func cancelBackup()"), "cancelBackup should not report user cancellation as an error"
     assert "Shell.terminate(activeProcess)" in backup, "cancelBackup should escalate termination for stuck subprocesses"
@@ -197,6 +197,89 @@ def test_backup_streaming_callers_are_timeout_bounded_and_cancelable(root: Path)
     assert "syslogStreamID = nil" in swift_block_after(diagnostics, "func stopSyslog()"), "stopSyslog should invalidate stream identity before termination completions fire"
     assert "syslogProcess = Shell.runStreaming" in diagnostics, "syslog fallback should be stoppable via syslogProcess"
     assert "Shell.terminate(syslogProcess)" in diagnostics, "stopSyslog should escalate termination for stuck syslog children"
+
+
+def test_backup_entry_points_reject_concurrent_device_operations(root: Path) -> None:
+    manager = read(root, "Sources/Phosphor/Services/BackupManager.swift")
+    coordinator_path = root / "Sources/Phosphor/Services/BackupOperationCoordinator.swift"
+    coordinator = coordinator_path.read_text()
+    assert "struct BackupOperationRegistry" in coordinator
+    assert "struct BackupOperationCoordinator" in coordinator
+    assert "private static var operationRegistry" in manager, "all BackupManager instances must share an active-device registry"
+    assert "private var operationCoordinator" in manager, "each BackupManager must retain its own active-operation identity"
+    begin_body = swift_block_after(manager, "private func beginCancellableOperation")
+    assert begin_body.index("lastOperationWasCancelled = false") < begin_body.index("operationCoordinator.begin"), "a blocked new operation must not inherit stale cancellation state"
+    assert "operationCoordinator.begin" in begin_body, "manual, scheduled, and clone operations must acquire shared device ownership"
+    finish_body = swift_block_after(manager, "private func finishOperation")
+    assert "operationCoordinator.finish" in finish_body, "device ownership must be identity-checked when an operation finishes"
+    cancel_body = swift_block_after(manager, "func cancelBackup()")
+    assert "operationCoordinator.finish" not in cancel_body, "cancellation must retain ownership until process completion"
+    assert manager.count("guard let operationID = beginCancellableOperation(udid: udid)") >= 2, "full and incremental backup entry points must acquire device ownership before starting"
+    assert "guard let operationID = beginCancellableOperation(udid: targetUDID)" in manager, "restore must acquire ownership for its target device before starting"
+
+    probe = r'''
+import Foundation
+
+@main
+struct OperationOwnershipProbe {
+    static func main() {
+        var registry = BackupOperationRegistry()
+        var firstManager = BackupOperationCoordinator()
+        var secondManager = BackupOperationCoordinator()
+        var thirdManager = BackupOperationCoordinator()
+
+        let firstID = UUID()
+        let secondID = UUID()
+        let otherDeviceID = UUID()
+        let overlappingID = UUID()
+
+        precondition(firstManager.begin(udid: "device-a", operationID: firstID, registry: &registry) == firstID)
+        precondition(firstManager.begin(udid: "device-b", operationID: overlappingID, registry: &registry) == nil)
+        precondition(firstManager.activeOperationID == firstID)
+        precondition(secondManager.begin(udid: "device-a", operationID: secondID, registry: &registry) == nil)
+        precondition(secondManager.begin(udid: "device-b", operationID: otherDeviceID, registry: &registry) == otherDeviceID)
+
+        // Cancelling the process does not finish ownership. The device stays blocked
+        // until the matching completion reaches finish(operationID:registry:).
+        precondition(thirdManager.begin(udid: "device-a", operationID: secondID, registry: &registry) == nil)
+        precondition(firstManager.finish(operationID: firstID, registry: &registry))
+        precondition(firstManager.begin(udid: "device-a", operationID: secondID, registry: &registry) == secondID)
+
+        // A stale completion on the same manager cannot release its newer operation.
+        precondition(!firstManager.finish(operationID: firstID, registry: &registry))
+        precondition(secondManager.begin(udid: "device-a", operationID: overlappingID, registry: &registry) == nil)
+        precondition(firstManager.finish(operationID: secondID, registry: &registry))
+        precondition(!firstManager.finish(operationID: secondID, registry: &registry))
+
+        precondition(secondManager.finish(operationID: otherDeviceID, registry: &registry))
+        precondition(thirdManager.begin(udid: "device-a", operationID: overlappingID, registry: &registry) == overlappingID)
+        print("PASS")
+    }
+}
+'''
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp = Path(temp_dir)
+        probe_path = temp / "Probe.swift"
+        binary_path = temp / "operation-ownership-probe"
+        probe_path.write_text(probe)
+        result = subprocess.run(
+            ["swiftc", "-parse-as-library", str(coordinator_path), str(probe_path), "-o", str(binary_path)],
+            cwd=root,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        assert result.returncode == 0, result.stderr
+        result = subprocess.run([str(binary_path)], capture_output=True, text=True, timeout=30)
+        assert result.returncode == 0, result.stderr
+        assert result.stdout.strip() == "PASS"
+
+    view_model = read(root, "Sources/Phosphor/ViewModels/BackupViewModel.swift")
+    create_body = swift_block_after(view_model, "func createBackup(udid: String")
+    assert "guard !isCreating else { return }" in create_body, "Cmd-B and other UI triggers must be rejected before a second task starts"
+
+    app = read(root, "Sources/Phosphor/App/PhosphorApp.swift")
+    assert ".disabled(deviceVM.selectedDevice == nil || backupVM.isCreating)" in app, "the Cmd-B menu item should be disabled while a backup is active"
 
 
 def test_restore_captures_target_and_uses_backup_parent_with_source_udid(root: Path) -> None:

--- a/Sources/Phosphor/App/PhosphorApp.swift
+++ b/Sources/Phosphor/App/PhosphorApp.swift
@@ -105,7 +105,7 @@ struct PhosphorApp: App {
                     }
                 }
                 .keyboardShortcut("b", modifiers: .command)
-                .disabled(deviceVM.selectedDevice == nil)
+                .disabled(deviceVM.selectedDevice == nil || backupVM.isCreating)
 
                 Button("Refresh Backups") {
                     backupVM.loadBackups()

--- a/Sources/Phosphor/Services/BackupManager.swift
+++ b/Sources/Phosphor/Services/BackupManager.swift
@@ -53,16 +53,30 @@ final class BackupManager: ObservableObject {
         case incomplete(path: String)
     }
 
-    /// Active backup process for cancellation.
+    /// Active backup process for cancellation. Device ownership is shared across
+    /// manager instances so manual, scheduled, clone, and restore paths cannot
+    /// write the same device backup concurrently.
+    private static var operationRegistry = BackupOperationRegistry()
     private var activeProcess: Process?
-    private var activeOperationID: UUID?
+    private var operationCoordinator = BackupOperationCoordinator()
     private var cancelledOperationIDs: Set<UUID> = []
 
-    private func beginCancellableOperation() -> UUID {
-        let id = UUID()
-        activeOperationID = id
+    private func beginCancellableOperation(udid: String) -> UUID? {
+        guard operationCoordinator.activeOperationID == nil else {
+            lastError = "Another backup or restore operation is already running."
+            return nil
+        }
+
         lastOperationWasCancelled = false
-        return id
+        lastBackupFailure = nil
+        guard let operationID = operationCoordinator.begin(
+            udid: udid,
+            registry: &Self.operationRegistry
+        ) else {
+            lastError = "Another backup or restore operation is already running for this device."
+            return nil
+        }
+        return operationID
     }
 
     private func operationWasCancelled(_ id: UUID) -> Bool {
@@ -70,8 +84,7 @@ final class BackupManager: ObservableObject {
     }
 
     private func finishOperation(_ id: UUID) {
-        if activeOperationID == id {
-            activeOperationID = nil
+        if operationCoordinator.finish(operationID: id, registry: &Self.operationRegistry) {
             activeProcess = nil
             isCreatingBackup = false
         }
@@ -79,7 +92,7 @@ final class BackupManager: ObservableObject {
     }
 
     private func markOperationCancelled(_ id: UUID, progress: String = "Cancelled") {
-        if activeOperationID == id {
+        if operationCoordinator.activeOperationID == id {
             lastOperationWasCancelled = true
             backupProgress = progress
             lastError = nil
@@ -481,8 +494,8 @@ final class BackupManager: ObservableObject {
         preferNetwork: Bool = false,
         onProgress: @escaping (String) -> Void
     ) async -> Bool {
+        guard let operationID = beginCancellableOperation(udid: udid) else { return false }
         isCreatingBackup = true
-        let operationID = beginCancellableOperation()
         backupProgress = "Starting backup..."
         backupPercent = 0
         lastError = nil
@@ -676,7 +689,7 @@ final class BackupManager: ObservableObject {
                             continuation.resume(returning: false)
                             return
                         }
-                        if self.activeOperationID == operationID {
+                        if self.operationCoordinator.activeOperationID == operationID {
                             self.activeProcess = nil
                         }
                         if self.operationWasCancelled(operationID) {
@@ -696,8 +709,8 @@ final class BackupManager: ObservableObject {
         preferNetwork: Bool = false,
         onProgress: @escaping (String) -> Void
     ) async -> Bool {
+        guard let operationID = beginCancellableOperation(udid: udid) else { return false }
         isCreatingBackup = true
-        let operationID = beginCancellableOperation()
         backupProgress = "Starting incremental backup..."
         backupPercent = 0
         lastError = nil
@@ -852,7 +865,7 @@ final class BackupManager: ObservableObject {
             return false
         }
 
-        let operationID = beginCancellableOperation()
+        guard let operationID = beginCancellableOperation(udid: targetUDID) else { return false }
         // Primary: pymobiledevice3
         if PyMobileDevice.available() {
             return await withCheckedContinuation { continuation in
@@ -913,7 +926,7 @@ final class BackupManager: ObservableObject {
 
     /// Cancel an active backup/restore.
     func cancelBackup() {
-        if let activeOperationID {
+        if let activeOperationID = operationCoordinator.activeOperationID {
             cancelledOperationIDs.insert(activeOperationID)
         }
         lastOperationWasCancelled = true

--- a/Sources/Phosphor/Services/BackupOperationCoordinator.swift
+++ b/Sources/Phosphor/Services/BackupOperationCoordinator.swift
@@ -1,0 +1,48 @@
+import Foundation
+
+struct BackupOperationRegistry {
+    private var operationByDevice: [String: UUID] = [:]
+
+    mutating func acquire(udid: String, operationID: UUID) -> Bool {
+        guard operationByDevice[udid] == nil else { return false }
+        operationByDevice[udid] = operationID
+        return true
+    }
+
+    mutating func release(udid: String, operationID: UUID) -> Bool {
+        guard operationByDevice[udid] == operationID else { return false }
+        operationByDevice.removeValue(forKey: udid)
+        return true
+    }
+}
+
+struct BackupOperationCoordinator {
+    private(set) var activeOperationID: UUID?
+    private var activeUDID: String?
+
+    mutating func begin(
+        udid: String,
+        operationID: UUID = UUID(),
+        registry: inout BackupOperationRegistry
+    ) -> UUID? {
+        guard activeOperationID == nil else { return nil }
+        guard registry.acquire(udid: udid, operationID: operationID) else { return nil }
+
+        activeOperationID = operationID
+        activeUDID = udid
+        return operationID
+    }
+
+    @discardableResult
+    mutating func finish(
+        operationID: UUID,
+        registry: inout BackupOperationRegistry
+    ) -> Bool {
+        guard activeOperationID == operationID, let activeUDID else { return false }
+        guard registry.release(udid: activeUDID, operationID: operationID) else { return false }
+
+        self.activeOperationID = nil
+        self.activeUDID = nil
+        return true
+    }
+}

--- a/Sources/Phosphor/ViewModels/BackupViewModel.swift
+++ b/Sources/Phosphor/ViewModels/BackupViewModel.swift
@@ -106,6 +106,7 @@ final class BackupViewModel: ObservableObject {
     }
 
     func createBackup(udid: String, incremental: Bool = false, preferNetwork: Bool = false) async {
+        guard !isCreating else { return }
         let operationID = UUID()
         backupOperationID = operationID
         lastBackupRequest = BackupRequest(udid: udid, incremental: incremental, preferNetwork: preferNetwork)


### PR DESCRIPTION
## Summary
- prevent one BackupManager from replacing an operation already tracked for cancellation
- coordinate device ownership across manual, scheduled, clone, restore, and Cmd-B entry points
- allow operations on different devices while rejecting concurrent writers for the same device
- retain ownership through cancellation until the matching process completion arrives
- protect newer operations from duplicate or stale completion callbacks

## Regression coverage
The behavioral ownership probe compiles the production coordinator and verifies:
- same-manager overlap rejection without replacing active state
- cross-manager same-device rejection
- different-device concurrency
- cancellation ownership retention
- matching completion release
- duplicate completion safety
- stale completion after same-manager reacquisition

## Verification
- `python3 Scripts/regression/run.py` — 65/65 passed
- `swift build`
- `swift build -c release`
- `bash Scripts/build.sh`
- final blockers-only review: no blockers