### PR TITLE
fix: prevent cancelled clone continuation restore

### DIFF
--- a/Scripts/regression/checks/clone_cancellation.py
+++ b/Scripts/regression/checks/clone_cancellation.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+def read(root: Path, rel: str) -> str:
+    return (root / rel).read_text()
+
+
+def test_clone_cancellation_after_backup_never_reaches_restore(root: Path) -> None:
+    """A late cancel is still authoritative before the destructive restore starts."""
+    service = read(root, "Sources/Phosphor/Services/DeviceCloneService.swift")
+    gate = root / "Sources/Phosphor/Utilities/CloneCancellationGate.swift"
+
+    assert gate.exists(), "clone continuation cancellation needs a production-owned gate"
+    assert "private var cancellationGate = CloneCancellationGate()" in service, (
+        "DeviceCloneService must own cancellation separately from BackupViewModel job state"
+    )
+    assert "func cancelClone()" in service, "clone cancellation must be requestable by the clone flow"
+    view = read(root, "Sources/Phosphor/Views/Clone/DeviceCloneView.swift")
+    assert "private func cancelClone()" in view, "the clone view must route cancellation through the clone-local gate"
+    assert "cloneService.cancelClone()" in view, "the UI cancel action must request continuation cancellation"
+    assert "backupVM.cancelBackup(udid: sourceUDID)" in view, "the UI cancel action must also stop the active source backup"
+    assert "Button(\"Cancel\", role: .destructive)" in view, "an active clone needs a reachable cancel action"
+    assert "defer { cancellationGate.reset() }" in service, (
+        "every clone terminal path must reset its cancellation request"
+    )
+
+    backup_await = service.index("await backupViewModel.createBackup")
+    continuation_cancel_guard = service.index("guard !cancellationGate.isCancellationRequested else")
+    restore = service.index("await backupManager.restoreBackup")
+    assert backup_await < continuation_cancel_guard < restore, (
+        "a cancellation arriving after backup completion must stop clone continuation before restore"
+    )
+
+    probe = r'''
+import Foundation
+
+@main
+struct CloneCancellationProbe {
+    static func main() {
+        var gate = CloneCancellationGate()
+        var sourceBackupFinished = false
+        var restoreStarted = false
+
+        func continueClone() {
+            guard sourceBackupFinished else { fatalError("probe must model completed source backup") }
+            guard !gate.isCancellationRequested else { return }
+            restoreStarted = true
+        }
+
+        sourceBackupFinished = true
+        // Simulates Cancel arriving after the backup subprocess completes but before
+        // the clone task resumes its restore continuation.
+        gate.requestCancellation()
+        continueClone()
+        precondition(!restoreStarted, "late clone cancellation must prevent destination restore")
+
+        gate.reset()
+        precondition(!gate.isCancellationRequested, "terminal cleanup must not poison the next clone")
+        continueClone()
+        precondition(restoreStarted, "a reset gate must allow a later clone continuation")
+        print("PASS")
+    }
+}
+'''
+
+    with tempfile.TemporaryDirectory(prefix="phosphor-clone-cancel-") as temp_dir:
+        temp = Path(temp_dir)
+        probe_path = temp / "Probe.swift"
+        binary_path = temp / "clone-cancel-probe"
+        probe_path.write_text(probe)
+        result = subprocess.run(
+            ["swiftc", str(gate), str(probe_path), "-o", str(binary_path)],
+            cwd=root,
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        assert result.returncode == 0, result.stderr
+        result = subprocess.run([str(binary_path)], capture_output=True, text=True, timeout=10)
+        assert result.returncode == 0, result.stderr
+        assert result.stdout.strip() == "PASS"

--- a/Sources/Phosphor/Services/DeviceCloneService.swift
+++ b/Sources/Phosphor/Services/DeviceCloneService.swift
@@ -11,6 +11,7 @@ final class DeviceCloneService: ObservableObject {
         case preparing = "Preparing restore..."
         case restoring = "Restoring to destination device..."
         case complete = "Clone complete"
+        case cancelled = "Clone cancelled"
         case failed = "Clone failed"
     }
 
@@ -28,6 +29,7 @@ final class DeviceCloneService: ObservableObject {
     }
 
     private let backupManager = BackupManager()
+    private var cancellationGate = CloneCancellationGate()
 
     /// Get all currently connected devices.
     func getConnectedDevices() async -> [(udid: String, name: String)] {
@@ -65,6 +67,9 @@ final class DeviceCloneService: ObservableObject {
         backupViewModel: BackupViewModel,
         encrypted: Bool = false
     ) async -> Bool {
+        cancellationGate.reset()
+        defer { cancellationGate.reset() }
+
         guard sourceUDID != destinationUDID else {
             lastError = "Source and destination must be different devices"
             phase = .failed
@@ -93,6 +98,16 @@ final class DeviceCloneService: ObservableObject {
         guard backupSuccess else {
             lastError = sourceActivity?.errorMessage ?? "Backup of source device failed"
             phase = .failed
+            isRunning = false
+            return false
+        }
+
+        // BackupViewModel may finish its source subprocess before this clone
+        // continuation resumes. A clone-local request remains authoritative here:
+        // never begin the destructive destination restore after cancellation.
+        guard !cancellationGate.isCancellationRequested else {
+            lastError = nil
+            phase = .cancelled
             isRunning = false
             return false
         }
@@ -140,6 +155,13 @@ final class DeviceCloneService: ObservableObject {
 
         isRunning = false
         return restoreSuccess
+    }
+
+    /// Request cancellation of clone continuation. The source backup may already
+    /// have completed when this arrives, so `clone` checks this again before restore.
+    func cancelClone() {
+        guard isRunning else { return }
+        cancellationGate.requestCancellation()
     }
 
     private func backupFingerprint(for backup: BackupInfo) -> BackupFingerprint {

--- a/Sources/Phosphor/Utilities/CloneCancellationGate.swift
+++ b/Sources/Phosphor/Utilities/CloneCancellationGate.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+/// Clone-local cancellation state. This remains independent of BackupViewModel's
+/// source-backup job so a late cancellation can still stop clone continuation.
+struct CloneCancellationGate {
+    private(set) var isCancellationRequested = false
+
+    mutating func requestCancellation() {
+        isCancellationRequested = true
+    }
+
+    mutating func reset() {
+        isCancellationRequested = false
+    }
+}

--- a/Sources/Phosphor/Views/Clone/DeviceCloneView.swift
+++ b/Sources/Phosphor/Views/Clone/DeviceCloneView.swift
@@ -248,6 +248,13 @@ struct DeviceCloneView: View {
                 .font(.system(size: 11))
                 .foregroundStyle(.orange)
 
+            if cloneService.phase == .backingUp {
+                Button("Cancel", role: .destructive) {
+                    cancelClone()
+                }
+                .buttonStyle(.bordered)
+            }
+
             Spacer()
         }
         .frame(maxWidth: .infinity)
@@ -324,6 +331,13 @@ struct DeviceCloneView: View {
         Task {
             availableDevices = await cloneService.getConnectedDevices()
             isScanning = false
+        }
+    }
+
+    private func cancelClone() {
+        cloneService.cancelClone()
+        if let sourceUDID {
+            backupVM.cancelBackup(udid: sourceUDID)
         }
     }
 


### PR DESCRIPTION
## Summary
- Rebuilds the clone-cancellation fix on current `main` without restoring the obsolete scheduler/UI implementation.
- A Cancel action is available only while the source backup is running. It cancels that source backup by UDID and records clone-local cancellation.
- A late cancel after source backup completion cannot continue into destructive destination restore.
- No unconfirmed restore-cancellation path is added.

## Verification
- `python3 Scripts/regression/run.py` (140 checks)
- `swift build`
- Independent review: no blockers.

The remaining global status UI is intentionally deferred to a separate current-main follow-up rather than mixing it with this safety repair.