### PR TITLE
feat: improve message exports and preserve attachments

### DIFF
--- a/Scripts/build.sh
+++ b/Scripts/build.sh
@@ -63,6 +63,9 @@ fi
 # Copy entitlements for reference
 cp "$PROJECT_DIR/Resources/Phosphor.entitlements" "$APP_BUNDLE/Contents/Resources/"
 
+# Include licenses for source incorporated into the release binary.
+cp "$PROJECT_DIR/THIRD_PARTY_NOTICES.md" "$APP_BUNDLE/Contents/Resources/"
+
 # Copy SPM resource bundle (localization strings)
 # dirname, not "$BINARY_PATH/..": the latter traverses '..' through the binary
 # file itself (ENOTDIR), so the -d test always failed and the localization

--- a/Scripts/regression/checks/backup_operation_lease.py
+++ b/Scripts/regression/checks/backup_operation_lease.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+def read(root: Path, rel: str) -> str:
+    return (root / rel).read_text()
+
+
+def assert_contains(text: str, needle: str, message: str) -> None:
+    assert needle in text, message
+
+
+def test_backup_operation_lease_blocks_scheduled_clone_and_rapid_menu_overlap(root: Path) -> None:
+    coordinator = read(root, "Sources/Phosphor/Services/BackupOperationCoordinator.swift")
+    manager = read(root, "Sources/Phosphor/Services/BackupManager.swift")
+    app = read(root, "Sources/Phosphor/App/PhosphorApp.swift")
+    scheduler = read(root, "Sources/Phosphor/Services/BackupScheduler.swift")
+    clone = read(root, "Sources/Phosphor/Services/DeviceCloneService.swift")
+
+    assert_contains(coordinator, "static let shared", "every backup owner must use one app-wide coordinator")
+    assert_contains(coordinator, "@Published private(set) var activeKind", "menu state must observe an active backup operation")
+    assert_contains(coordinator, "var isRunning: Bool", "the coordinator must expose whether a lease is active")
+    assert_contains(coordinator, "func acquire", "a backup must acquire a lease before starting")
+    assert_contains(coordinator, "func release", "every acquired backup lease must be released")
+
+    assert manager.count("BackupOperationCoordinator.shared.acquire") >= 2, (
+        "full and incremental BackupManager paths must acquire the shared lease"
+    )
+    assert manager.count("BackupOperationCoordinator.shared.release") >= 2, (
+        "full and incremental BackupManager paths must release the shared lease"
+    )
+    assert_contains(manager, "Another backup is already running", "a rejected overlap needs a user-facing reason")
+
+    assert_contains(scheduler, "manager.create", "scheduled backups must continue through the lease-owning BackupManager")
+    assert_contains(clone, "backupManager.createBackup", "clone source backups must continue through the lease-owning BackupManager")
+
+    assert_contains(app, "@StateObject private var backupOperations = BackupOperationCoordinator.shared", "Quick Actions must observe the shared lease")
+    assert_contains(app, "backupOperations.isRunning", "Quick Actions must disable while any owner holds the lease")
+    assert_contains(app, "!backupOperations.isRunning", "rapid duplicate activation must be rejected before dispatch")
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        probe = tmp_path / "BackupOperationLeaseProbe.swift"
+        executable = tmp_path / "backup-operation-lease-probe"
+        probe.write_text(
+            """
+import Foundation
+
+@main
+struct BackupOperationLeaseProbe {
+    static func main() async {
+        let passed = await MainActor.run {
+            let coordinator = BackupOperationCoordinator.shared
+            guard let first = coordinator.acquire(), coordinator.isRunning else { return false }
+            guard coordinator.acquire() == nil else { return false }
+            coordinator.release(first)
+            guard !coordinator.isRunning, let second = coordinator.acquire() else { return false }
+            coordinator.release(second)
+            return !coordinator.isRunning
+        }
+        guard passed else { fatalError("backup operation lease failed") }
+    }
+}
+"""
+        )
+        compile = subprocess.run(
+            [
+                "swiftc",
+                "-parse-as-library",
+                str(root / "Sources/Phosphor/Services/BackupOperationCoordinator.swift"),
+                str(probe),
+                "-o",
+                str(executable),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        assert compile.returncode == 0, compile.stderr
+        run = subprocess.run([str(executable)], capture_output=True, text=True, timeout=15)
+        assert run.returncode == 0, run.stderr

--- a/Scripts/regression/checks/menu_actions.py
+++ b/Scripts/regression/checks/menu_actions.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def read(root: Path, rel: str) -> str:
+    return (root / rel).read_text()
+
+
+def assert_contains(text: str, needle: str, message: str) -> None:
+    assert needle in text, message
+
+
+def test_menu_bar_has_safe_one_click_backup_and_navigation_actions(root: Path) -> None:
+    app = read(root, "Sources/Phosphor/App/PhosphorApp.swift")
+    content = read(root, "Sources/Phosphor/Views/ContentView.swift")
+
+    assert_contains(
+        app,
+        "@State private var selectedSection: SidebarSection? = .devices",
+        "menu commands need shared navigation state",
+    )
+    assert_contains(
+        app,
+        "ContentView(selectedSection: $selectedSection)",
+        "the root view must receive app-owned navigation for menu commands",
+    )
+    assert_contains(app, 'CommandMenu("Quick Actions")', "the menu bar needs a dedicated one-click action menu")
+    assert_contains(app, 'Button("Backup Now")', "the menu bar needs a clearly named immediate backup action")
+    assert_contains(app, "startBackupNow()", "Backup Now must share the guarded backup action")
+    assert_contains(app, "!backupVM.isCreating", "Backup Now must not start a concurrent backup")
+    assert_contains(app, 'Button("Open Backup Folder")', "the menu bar should reveal the active backup destination")
+    assert_contains(app, "NSWorkspace.shared.open", "opening the backup folder must use the standard Finder action")
+    assert_contains(app, "BackupManager.activeBackupDir", "opening the backup folder must use the configured destination")
+
+    for label, section in [
+        ("Show Backups", ".backups"),
+        ("Show Messages", ".messages"),
+        ("Show Photos", ".photos"),
+        ("Show Files", ".files"),
+    ]:
+        assert_contains(app, f'Button("{label}")', f"Quick Actions should include {label}")
+        assert_contains(app, f"selectedSection = {section}", f"{label} should navigate directly to {section}")
+
+    assert_contains(
+        content,
+        "@Binding var selectedSection: SidebarSection?",
+        "ContentView must observe the shared menu navigation selection",
+    )

--- a/Scripts/regression/checks/menu_actions.py
+++ b/Scripts/regression/checks/menu_actions.py
@@ -28,7 +28,7 @@ def test_menu_bar_has_safe_one_click_backup_and_navigation_actions(root: Path) -
     assert_contains(app, 'CommandMenu("Quick Actions")', "the menu bar needs a dedicated one-click action menu")
     assert_contains(app, 'Button("Backup Now")', "the menu bar needs a clearly named immediate backup action")
     assert_contains(app, "startBackupNow()", "Backup Now must share the guarded backup action")
-    assert_contains(app, "!backupVM.isCreating", "Backup Now must not start a concurrent backup")
+    assert_contains(app, "!backupOperations.isRunning", "Backup Now must not start a concurrent backup")
     assert_contains(app, 'Button("Open Backup Folder")', "the menu bar should reveal the active backup destination")
     assert_contains(app, "NSWorkspace.shared.open", "opening the backup folder must use the standard Finder action")
     assert_contains(app, "BackupManager.activeBackupDir", "opening the backup folder must use the configured destination")

--- a/Scripts/regression/checks/message_export.py
+++ b/Scripts/regression/checks/message_export.py
@@ -16,14 +16,101 @@ def assert_contains(text: str, needle: str, message: str) -> None:
     assert needle in text, message
 
 
-def test_streaming_exports_truncate_before_write(root: Path) -> None:
+def test_message_exports_publish_generation_sidecars_without_crash_mismatch(root: Path) -> None:
     src = read(root, "Sources/Phosphor/Services/MessageExporter.swift")
+    transaction = root / "Sources/Phosphor/Utilities/MessageExportTransaction.swift"
+    attachment_exporter = root / "Sources/Phosphor/Utilities/MessageAttachmentExporter.swift"
+    assert transaction.exists(), "single-conversation exports need a transactional staging helper"
+    assert_contains(src, "MessageExportTransaction.write", "exportMessages must stage the transcript and sidecar as one recoverable operation")
+    assert_contains(src, "stagedTranscriptURL.path", "format writers must receive a same-volume staging path")
     for func_name in ["exportCSV", "exportPlainText", "exportHTML", "exportMbox", "exportJSON"]:
         match = re.search(rf"private func {func_name}.*?(?=\n    private func|\n    ///|\Z)", src, re.S)
         assert match is not None, f"{func_name} not found"
-        body = match.group(0)
-        assert_contains(body, "removeItem(at: outputURL)", f"{func_name} must remove existing output before streaming")
-        assert_contains(body, "FileHandle(forWritingTo: outputURL)", f"{func_name} must stream through FileHandle")
+        assert_contains(match.group(0), "FileHandle(forWritingTo: outputURL)", f"{func_name} must continue streaming through FileHandle")
+
+    probe = r'''
+import Foundation
+
+@main
+struct GenerationPublicationProbe {
+    enum ProbeError: Error { case cancelled }
+
+    static func main() throws {
+        let root = URL(fileURLWithPath: CommandLine.arguments[1], isDirectory: true)
+        let final = root.appendingPathComponent("chat.txt")
+        let source = root.appendingPathComponent("source.bin")
+        let fileManager = FileManager.default
+        try Data("NEW_ATTACHMENT".utf8).write(to: source)
+
+        // The completed transcript points at its own immutable old generation.
+        let oldGeneration = root.appendingPathComponent("chat-txt_attachments-old", isDirectory: true)
+        try fileManager.createDirectory(at: oldGeneration, withIntermediateDirectories: true)
+        try Data("OLD_ATTACHMENT".utf8).write(to: oldGeneration.appendingPathComponent("old.bin"))
+        try Data("OLD:chat-txt_attachments-old/old.bin".utf8).write(to: final)
+
+        let item = MessageAttachmentExporter.Item(key: "attachment", displayName: "new.bin", sourcePath: source.path)
+
+        // Model abrupt process death after publishing a new sidecar but before
+        // replacing the transcript. The old transcript must still resolve its old
+        // sidecar; the new directory is merely an orphan recoverable on next run.
+        let orphan = try MessageAttachmentExporter.prepareGeneration([item], beside: final.path)
+        guard try String(contentsOf: final, encoding: .utf8) == "OLD:chat-txt_attachments-old/old.bin",
+              fileManager.fileExists(atPath: oldGeneration.appendingPathComponent("old.bin").path),
+              let orphanPath = orphan.paths["attachment"],
+              let orphanURL = orphan.directoryURL,
+              fileManager.fileExists(atPath: root.appendingPathComponent(orphanPath).path) else {
+            exit(1)
+        }
+
+        // In-process writer failure removes the unreferenced new generation and
+        // leaves the old published transcript/sidecar pair intact.
+        do {
+            try MessageExportTransaction.write(to: final, prepareAttachments: {
+                try MessageAttachmentExporter.prepareGeneration([item], beside: final.path)
+            }) { staged, paths in
+                try Data("PARTIAL:\(paths["attachment"]!)".utf8).write(to: staged)
+                throw ProbeError.cancelled
+            }
+            exit(2)
+        } catch ProbeError.cancelled {}
+        guard try String(contentsOf: final, encoding: .utf8) == "OLD:chat-txt_attachments-old/old.bin",
+              fileManager.fileExists(atPath: oldGeneration.appendingPathComponent("old.bin").path),
+              !fileManager.fileExists(atPath: root.appendingPathComponent("chat-txt_attachments").path) else {
+            exit(3)
+        }
+
+        // A subsequent successful publication commits a transcript that embeds
+        // the generation it references, then reclaims old/orphan generations.
+        try MessageExportTransaction.write(to: final, prepareAttachments: {
+            try MessageAttachmentExporter.prepareGeneration([item], beside: final.path)
+        }) { staged, paths in
+            try Data("NEW:\(paths["attachment"]!)".utf8).write(to: staged)
+        }
+        let transcript = try String(contentsOf: final, encoding: .utf8)
+        let hasExpectedPrefix = transcript.hasPrefix("NEW:chat-txt_attachments-")
+        let relativePath = transcript.split(separator: ":", maxSplits: 1).last.map(String.init)
+        let newSidecarExists = relativePath.map { fileManager.fileExists(atPath: root.appendingPathComponent($0).path) } ?? false
+        let oldGenerationExists = fileManager.fileExists(atPath: oldGeneration.path)
+        let orphanExists = fileManager.fileExists(atPath: orphanURL.path)
+        guard hasExpectedPrefix, newSidecarExists, !oldGenerationExists, !orphanExists else {
+            fputs("prefix=\(hasExpectedPrefix) new=\(newSidecarExists) old=\(oldGenerationExists) orphan=\(orphanExists)\n", stderr)
+            exit(4)
+        }
+    }
+}
+'''
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp = Path(temp_dir)
+        probe_path = temp / "Probe.swift"
+        probe_path.write_text(probe)
+        executable = temp / "generation-publication-probe"
+        compile_result = subprocess.run(
+            ["swiftc", "-parse-as-library", str(attachment_exporter), str(transaction), str(probe_path), "-o", str(executable)],
+            capture_output=True, text=True, timeout=60,
+        )
+        assert compile_result.returncode == 0, compile_result.stderr
+        result = subprocess.run([str(executable), str(temp)], capture_output=True, text=True, timeout=20)
+        assert result.returncode == 0, f"generation publication probe exited {result.returncode}: {result.stderr}"
 
 
 def test_message_pdf_export_is_registered_and_uses_native_pdf_writer(root: Path) -> None:
@@ -500,17 +587,19 @@ struct AttachmentSidecarProbe {
         try Data("A".utf8).write(to: first)
         try Data("B".utf8).write(to: second)
 
-        let initial = try MessageAttachmentExporter.export([
+        let initialGeneration = try MessageAttachmentExporter.prepareGeneration([
             .init(key: "first", displayName: "photo.jpg", sourcePath: first.path),
             .init(key: "second", displayName: "photo.jpg", sourcePath: second.path),
         ], beside: htmlExport.path)
-        guard initial["first"] == "conversation-html_attachments/photo.jpg",
-              initial["second"] == "conversation-html_attachments/photo-2.jpg" else {
+        let initial = initialGeneration.paths
+        MessageAttachmentExporter.cleanupObsoleteGenerations(for: initialGeneration)
+        guard initial["first"]?.hasSuffix("/photo.jpg") == true,
+              initial["second"]?.hasSuffix("/photo-2.jpg") == true else {
             fputs("duplicate attachment names were not made collision-safe\n", stderr)
             exit(1)
         }
 
-        let sidecar = root.appendingPathComponent("conversation-html_attachments", isDirectory: true)
+        let sidecar = initialGeneration.directoryURL!
         guard !fileManager.fileExists(atPath: legacySidecar.path) else {
             fputs("legacy HTML sidecar was not cleaned after successful replacement\n", stderr)
             exit(2)
@@ -521,26 +610,29 @@ struct AttachmentSidecarProbe {
             exit(2)
         }
 
-        let refreshed = try MessageAttachmentExporter.export([
+        let refreshedGeneration = try MessageAttachmentExporter.prepareGeneration([
             .init(key: "first", displayName: "photo.jpg", sourcePath: first.path),
         ], beside: htmlExport.path)
-        let remaining = try Set(fileManager.contentsOfDirectory(atPath: sidecar.path))
+        let refreshed = refreshedGeneration.paths
+        MessageAttachmentExporter.cleanupObsoleteGenerations(for: refreshedGeneration)
+        let refreshedSidecar = refreshedGeneration.directoryURL!
+        let remaining = try Set(fileManager.contentsOfDirectory(atPath: refreshedSidecar.path))
         guard refreshed.count == 1,
               remaining == ["photo.jpg"],
-              try Data(contentsOf: sidecar.appendingPathComponent("photo.jpg")) == Data("A".utf8) else {
+              try Data(contentsOf: refreshedSidecar.appendingPathComponent("photo.jpg")) == Data("A".utf8) else {
             fputs("rerun did not replace stale sidecar content\n", stderr)
             exit(3)
         }
 
-        _ = try MessageAttachmentExporter.export([], beside: pdfExport.path)
-        guard fileManager.fileExists(atPath: sidecar.appendingPathComponent("photo.jpg").path) else {
+        _ = try MessageAttachmentExporter.prepareGeneration([], beside: pdfExport.path)
+        guard fileManager.fileExists(atPath: refreshedSidecar.appendingPathComponent("photo.jpg").path) else {
             fputs("exporting another transcript format removed the HTML sidecar\n", stderr)
             exit(4)
         }
 
         var checks = 0
         do {
-            _ = try MessageAttachmentExporter.export([
+            _ = try MessageAttachmentExporter.prepareGeneration([
                 .init(key: "second", displayName: "photo.jpg", sourcePath: second.path),
                 .init(key: "first", displayName: "photo.jpg", sourcePath: first.path),
             ], beside: htmlExport.path) {
@@ -550,16 +642,17 @@ struct AttachmentSidecarProbe {
             fputs("cancelled attachment export unexpectedly succeeded\n", stderr)
             exit(5)
         } catch is CancellationError {
-            let preserved = try Data(contentsOf: sidecar.appendingPathComponent("photo.jpg"))
+            let preserved = try Data(contentsOf: refreshedSidecar.appendingPathComponent("photo.jpg"))
             guard preserved == Data("A".utf8),
-                  !fileManager.fileExists(atPath: sidecar.appendingPathComponent("photo-2.jpg").path) else {
+                  !fileManager.fileExists(atPath: refreshedSidecar.appendingPathComponent("photo-2.jpg").path) else {
                 fputs("cancellation replaced the previously completed attachment folder\n", stderr)
                 exit(6)
             }
         }
 
-        _ = try MessageAttachmentExporter.export([], beside: htmlExport.path)
-        guard !fileManager.fileExists(atPath: sidecar.path) else {
+        let emptyGeneration = try MessageAttachmentExporter.prepareGeneration([], beside: htmlExport.path)
+        MessageAttachmentExporter.cleanupObsoleteGenerations(for: emptyGeneration)
+        guard !fileManager.fileExists(atPath: refreshedSidecar.path) else {
             fputs("empty re-export did not clean the stale attachment folder\n", stderr)
             exit(7)
         }
@@ -595,10 +688,10 @@ def test_original_attachment_option_applies_to_every_message_export_format(root:
     body = export_messages.group("body")
     assert_contains(
         body,
-        "stageOriginalAttachments(",
-        "every export format should stage original attachments before format-specific rendering",
+        "prepareOriginalAttachmentGeneration(",
+        "every export format should prepare a generation before format-specific rendering",
     )
-    assert body.index("stageOriginalAttachments") < body.index("switch format"), (
+    assert body.index("prepareOriginalAttachmentGeneration") < body.index("switch format"), (
         "original attachment export must not be limited to HTML, PDF, or MBOX"
     )
     assert_contains(

--- a/Scripts/regression/checks/message_export.py
+++ b/Scripts/regression/checks/message_export.py
@@ -628,6 +628,99 @@ def test_original_attachment_option_applies_to_every_message_export_format(root:
     )
 
 
+def test_all_formats_message_bundle_is_atomic_and_collision_safe(root: Path) -> None:
+    helper = root / "Sources/Phosphor/Utilities/MessageExportBundleWriter.swift"
+    assert helper.exists(), "all-formats exports should use a dedicated atomic bundle writer"
+
+    probe = r'''
+import Foundation
+
+@main
+struct MessageExportBundleProbe {
+    static func main() throws {
+        let parent = URL(fileURLWithPath: CommandLine.arguments[1], isDirectory: true)
+        let fileManager = FileManager.default
+
+        let first = try MessageExportBundleWriter.write(in: parent) { root in
+            let conversation = root.appendingPathComponent("Jane Doe-chat-42", isDirectory: true)
+            try fileManager.createDirectory(at: conversation, withIntermediateDirectories: true)
+            try Data("pdf".utf8).write(to: conversation.appendingPathComponent("Jane Doe.pdf"))
+            return 1
+        }
+        guard first.count == 1,
+              first.directory.lastPathComponent == "Messages Export",
+              fileManager.fileExists(atPath: first.directory.appendingPathComponent("Jane Doe-chat-42/Jane Doe.pdf").path) else {
+            fputs("first bundle did not produce the expected export folder\n", stderr)
+            exit(1)
+        }
+
+        let second = try MessageExportBundleWriter.write(in: parent) { root in
+            try Data("second".utf8).write(to: root.appendingPathComponent("marker.txt"))
+            return 1
+        }
+        guard second.directory.lastPathComponent == "Messages Export 2",
+              fileManager.fileExists(atPath: first.directory.path),
+              fileManager.fileExists(atPath: second.directory.path) else {
+            fputs("bundle naming overwrote a prior completed export\n", stderr)
+            exit(2)
+        }
+
+        do {
+            _ = try MessageExportBundleWriter.write(in: parent) { root in
+                try Data("partial".utf8).write(to: root.appendingPathComponent("partial.txt"))
+                throw CancellationError()
+            }
+            fputs("cancelled bundle unexpectedly succeeded\n", stderr)
+            exit(3)
+        } catch is CancellationError {
+            let names = try fileManager.contentsOfDirectory(atPath: parent.path)
+            guard !names.contains("Messages Export 3"),
+                  !names.contains(where: { $0.contains("staging-") }) else {
+                fputs("cancelled bundle left visible or staged partial output\n", stderr)
+                exit(4)
+            }
+        }
+    }
+}
+'''
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp = Path(temp_dir)
+        probe_path = temp / "Probe.swift"
+        probe_path.write_text(probe)
+        executable = temp / "message-export-bundle-probe"
+        compile_result = subprocess.run(
+            ["swiftc", "-parse-as-library", str(helper), str(probe_path), "-o", str(executable)],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        assert compile_result.returncode == 0, compile_result.stderr
+        result = subprocess.run([str(executable), str(temp)], capture_output=True, text=True, timeout=10)
+        assert result.returncode == 0, result.stderr
+
+
+def test_all_formats_message_bundle_has_one_folder_per_conversation(root: Path) -> None:
+    exporter = read(root, "Sources/Phosphor/Services/MessageExporter.swift")
+    view_model = read(root, "Sources/Phosphor/ViewModels/MessageViewModel.swift")
+    view = read(root, "Sources/Phosphor/Views/Messages/MessageListView.swift")
+
+    bundle = re.search(
+        r"func exportAllChatsAllFormats\(.*?\) throws -> MessageExportBundleWriter.Result \{(?P<body>.*?)\n    \}",
+        exporter,
+        re.S,
+    )
+    assert bundle is not None, "MessageExporter should expose an all-formats bundle export"
+    body = bundle.group("body")
+    assert_contains(body, "MessageExportFormat.allCases", "each conversation should be written in every supported format")
+    assert_contains(body, "includeChatID: true", "conversation folders should retain collision-safe chat IDs")
+    assert_contains(body, 'appendingPathComponent("Attachments"', "each conversation should contain one shared Attachments folder")
+    assert_contains(body, "attachmentMap: attachmentMap", "HTML should link to the shared conversation attachment folder")
+    assert_contains(view_model, "startExportAllChatsAllFormats", "the background export view model should expose the bundle action")
+    assert_contains(view, 'Button("All Formats + Attachments")', "Export All should offer the complete conversation bundle")
+    assert_contains(view, "exportAllConversationsAllFormats", "the all-formats menu option should open its folder picker")
+
+
 def test_message_view_clears_stale_loaded_backup_and_preserves_readiness(root: Path) -> None:
     view_model = read(root, "Sources/Phosphor/ViewModels/MessageViewModel.swift")
     assert_contains(view_model, "func clear()", "MessageViewModel should expose a clear path for stale backup state")
@@ -733,9 +826,13 @@ def test_message_export_writers_check_cancellation_inside_long_loops(root: Path)
         match = re.search(rf"private func {func_name}.*?(?=\n    private func|\n    ///|\Z)", src, re.S)
         assert match is not None, f"{func_name} not found"
         assert_contains(match.group(0), "try cancellationCheck?()", f"{func_name} should stop promptly during large single-chat exports")
-    stage = re.search(r"private func stageOriginalAttachments.*?(?=\n    private func|\n    ///|\Z)", src, re.S)
-    assert stage is not None, "stageOriginalAttachments should exist"
-    assert_contains(stage.group(0), "try cancellationCheck?()", "attachment resolution should be cancellable")
+    attachment_items = re.search(r"private func originalAttachmentItems.*?(?=\n    private func|\n    ///|\Z)", src, re.S)
+    assert attachment_items is not None, "originalAttachmentItems should exist"
+    assert_contains(
+        attachment_items.group(0),
+        "try cancellationCheck?()",
+        "attachment resolution should be cancellable",
+    )
     helper = read(root, "Sources/Phosphor/Utilities/MessageAttachmentExporter.swift")
     assert_contains(helper, "try cancellationCheck?()", "original attachment copying should be cancellable between files")
 

--- a/Scripts/regression/checks/message_export.py
+++ b/Scripts/regression/checks/message_export.py
@@ -435,12 +435,17 @@ def test_background_message_exports_keep_loaded_contact_directory(root: Path) ->
     )
 
 
-def test_html_export_cleans_stale_attachment_folder(root: Path) -> None:
+def test_html_export_uses_shared_fresh_attachment_sidecar(root: Path) -> None:
     src = read(root, "Sources/Phosphor/Services/MessageExporter.swift")
-    assert_contains(src, "private func removeAttachmentFolder(forHTMLPath", "HTML export should have explicit stale attachment cleanup")
+    helper = read(root, "Sources/Phosphor/Utilities/MessageAttachmentExporter.swift")
+    assert_contains(helper, "stagingURL", "attachment sidecars should stage a fresh folder before replacing prior output")
+    assert_contains(helper, "replaceItemAt", "attachment sidecars should atomically replace prior completed output")
     html = re.search(r"private func exportHTML\(.*?\) throws \{(?P<body>.*?)\n    \}", src, re.S)
     assert html is not None, "exportHTML should exist"
-    assert_contains(html.group("body"), "removeAttachmentFolder(forHTMLPath: path)", "HTML export should remove stale attachment folders before staging/writing")
+    assert "stageOriginalAttachments" not in html.group("body"), "HTML should not copy attachments a second time"
+    assert_contains(html.group("body"), "attachmentMap", "HTML should link to the shared original-attachment sidecar")
+
+
 def test_json_overwrite_fixture_has_no_stale_tail(root: Path) -> None:
     del root  # fixture mirrors the Swift export invariant without touching source files.
     with tempfile.TemporaryDirectory() as tmp:
@@ -462,6 +467,165 @@ def test_attachment_path_cache_invariants(root: Path) -> None:
     assert_contains(src, "missingAttachmentDiskPaths.contains(filename)", "resolver should hit negative cache")
     assert_contains(src, "attachmentDiskPathCache[filename] = candidate", "resolver should store positive cache")
     assert_contains(src, "missingAttachmentDiskPaths.insert(filename)", "resolver should store negative cache")
+
+
+def test_message_attachment_sidecars_are_collision_safe_and_cancellation_safe(root: Path) -> None:
+    exporter = root / "Sources/Phosphor/Utilities/MessageAttachmentExporter.swift"
+    assert exporter.exists(), "message exports should have a reusable original-attachment sidecar writer"
+
+    probe = r'''
+import Foundation
+
+@main
+struct AttachmentSidecarProbe {
+    static func main() throws {
+        let root = URL(fileURLWithPath: CommandLine.arguments[1], isDirectory: true)
+        let htmlExport = root.appendingPathComponent("conversation.html")
+        let pdfExport = root.appendingPathComponent("conversation.pdf")
+        let first = root.appendingPathComponent("source-a/photo.jpg")
+        let second = root.appendingPathComponent("source-b/photo.jpg")
+        let fileManager = FileManager.default
+        let legacySidecar = root.appendingPathComponent("conversation_attachments", isDirectory: true)
+        try fileManager.createDirectory(at: legacySidecar, withIntermediateDirectories: true)
+        try Data("stale".utf8).write(to: legacySidecar.appendingPathComponent("old.jpg"))
+        let encodedPath = MessageAttachmentExporter.relativeURL(
+            for: "conversation-html_attachments/photo#1? 50%.jpg"
+        )
+        guard encodedPath == "conversation-html_attachments/photo%231%3F%2050%25.jpg" else {
+            fputs("HTML attachment paths were not URL encoded by segment\n", stderr)
+            exit(1)
+        }
+        try fileManager.createDirectory(at: first.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try fileManager.createDirectory(at: second.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try Data("A".utf8).write(to: first)
+        try Data("B".utf8).write(to: second)
+
+        let initial = try MessageAttachmentExporter.export([
+            .init(key: "first", displayName: "photo.jpg", sourcePath: first.path),
+            .init(key: "second", displayName: "photo.jpg", sourcePath: second.path),
+        ], beside: htmlExport.path)
+        guard initial["first"] == "conversation-html_attachments/photo.jpg",
+              initial["second"] == "conversation-html_attachments/photo-2.jpg" else {
+            fputs("duplicate attachment names were not made collision-safe\n", stderr)
+            exit(1)
+        }
+
+        let sidecar = root.appendingPathComponent("conversation-html_attachments", isDirectory: true)
+        guard !fileManager.fileExists(atPath: legacySidecar.path) else {
+            fputs("legacy HTML sidecar was not cleaned after successful replacement\n", stderr)
+            exit(2)
+        }
+        let initialNames = try Set(fileManager.contentsOfDirectory(atPath: sidecar.path))
+        guard initialNames == ["photo.jpg", "photo-2.jpg"] else {
+            fputs("initial sidecar contents were incomplete\n", stderr)
+            exit(2)
+        }
+
+        let refreshed = try MessageAttachmentExporter.export([
+            .init(key: "first", displayName: "photo.jpg", sourcePath: first.path),
+        ], beside: htmlExport.path)
+        let remaining = try Set(fileManager.contentsOfDirectory(atPath: sidecar.path))
+        guard refreshed.count == 1,
+              remaining == ["photo.jpg"],
+              try Data(contentsOf: sidecar.appendingPathComponent("photo.jpg")) == Data("A".utf8) else {
+            fputs("rerun did not replace stale sidecar content\n", stderr)
+            exit(3)
+        }
+
+        _ = try MessageAttachmentExporter.export([], beside: pdfExport.path)
+        guard fileManager.fileExists(atPath: sidecar.appendingPathComponent("photo.jpg").path) else {
+            fputs("exporting another transcript format removed the HTML sidecar\n", stderr)
+            exit(4)
+        }
+
+        var checks = 0
+        do {
+            _ = try MessageAttachmentExporter.export([
+                .init(key: "second", displayName: "photo.jpg", sourcePath: second.path),
+                .init(key: "first", displayName: "photo.jpg", sourcePath: first.path),
+            ], beside: htmlExport.path) {
+                checks += 1
+                if checks == 2 { throw CancellationError() }
+            }
+            fputs("cancelled attachment export unexpectedly succeeded\n", stderr)
+            exit(5)
+        } catch is CancellationError {
+            let preserved = try Data(contentsOf: sidecar.appendingPathComponent("photo.jpg"))
+            guard preserved == Data("A".utf8),
+                  !fileManager.fileExists(atPath: sidecar.appendingPathComponent("photo-2.jpg").path) else {
+                fputs("cancellation replaced the previously completed attachment folder\n", stderr)
+                exit(6)
+            }
+        }
+
+        _ = try MessageAttachmentExporter.export([], beside: htmlExport.path)
+        guard !fileManager.fileExists(atPath: sidecar.path) else {
+            fputs("empty re-export did not clean the stale attachment folder\n", stderr)
+            exit(7)
+        }
+    }
+}
+'''
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp = Path(temp_dir)
+        probe_path = temp / "Probe.swift"
+        probe_path.write_text(probe)
+        executable = temp / "attachment-sidecar-probe"
+        compile_result = subprocess.run(
+            ["swiftc", "-parse-as-library", str(exporter), str(probe_path), "-o", str(executable)],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        assert compile_result.returncode == 0, compile_result.stderr
+        result = subprocess.run([str(executable), str(temp)], capture_output=True, text=True, timeout=10)
+        assert result.returncode == 0, result.stderr
+
+
+def test_original_attachment_option_applies_to_every_message_export_format(root: Path) -> None:
+    exporter = read(root, "Sources/Phosphor/Services/MessageExporter.swift")
+    view = read(root, "Sources/Phosphor/Views/Messages/MessageListView.swift")
+    export_messages = re.search(
+        r"func exportMessages\(.*?\) throws \{(?P<body>.*?)\n    \}",
+        exporter,
+        re.S,
+    )
+    assert export_messages is not None, "exportMessages should exist"
+    body = export_messages.group("body")
+    assert_contains(
+        body,
+        "stageOriginalAttachments(",
+        "every export format should stage original attachments before format-specific rendering",
+    )
+    assert body.index("stageOriginalAttachments") < body.index("switch format"), (
+        "original attachment export must not be limited to HTML, PDF, or MBOX"
+    )
+    assert_contains(
+        exporter,
+        "MessageAttachmentExporter.export",
+        "message exports should use the cancellation-safe sidecar writer",
+    )
+    assert_contains(
+        exporter,
+        "attachmentMap: attachmentMap",
+        "HTML should link to the same original attachment sidecar instead of copying files twice",
+    )
+    assert_contains(
+        exporter,
+        "MessageAttachmentExporter.relativeURL(for: relPath)",
+        "HTML attachment src/href values should URL-encode reserved filename characters",
+    )
+    assert_contains(
+        view,
+        'Toggle("Export Attachments", isOn: $includeAttachments)',
+        "the Messages export control should clearly say that it exports original attachments",
+    )
+    assert_contains(
+        view,
+        "Copies original photos, videos, audio, and files",
+        "the attachment option should explain that originals are written beside the transcript",
+    )
 
 
 def test_message_view_clears_stale_loaded_backup_and_preserves_readiness(root: Path) -> None:
@@ -569,9 +733,11 @@ def test_message_export_writers_check_cancellation_inside_long_loops(root: Path)
         match = re.search(rf"private func {func_name}.*?(?=\n    private func|\n    ///|\Z)", src, re.S)
         assert match is not None, f"{func_name} not found"
         assert_contains(match.group(0), "try cancellationCheck?()", f"{func_name} should stop promptly during large single-chat exports")
-    stage = re.search(r"private func stageAttachments.*?(?=\n    private func|\n    ///|\Z)", src, re.S)
-    assert stage is not None, "stageAttachments should exist"
-    assert_contains(stage.group(0), "try cancellationCheck?()", "HTML attachment staging should be cancellable")
+    stage = re.search(r"private func stageOriginalAttachments.*?(?=\n    private func|\n    ///|\Z)", src, re.S)
+    assert stage is not None, "stageOriginalAttachments should exist"
+    assert_contains(stage.group(0), "try cancellationCheck?()", "attachment resolution should be cancellable")
+    helper = read(root, "Sources/Phosphor/Utilities/MessageAttachmentExporter.swift")
+    assert_contains(helper, "try cancellationCheck?()", "original attachment copying should be cancellable between files")
 
 
 def test_minimal_sms_schema_fixture_supports_limited_attachment_query(root: Path) -> None:

--- a/Scripts/regression/checks/message_export.py
+++ b/Scripts/regression/checks/message_export.py
@@ -329,6 +329,23 @@ struct ContactFilenameProbe {
         assert run.returncode == 0, run.stderr
 
 
+def test_background_message_exports_keep_loaded_contact_directory(root: Path) -> None:
+    view_model = read(root, "Sources/Phosphor/ViewModels/MessageViewModel.swift")
+    assert_contains(
+        view_model,
+        "private var contactDirectory: ContactDirectory = .empty",
+        "MessageViewModel should retain the contact directory loaded for the selected backup",
+    )
+    assert_contains(
+        view_model,
+        "self.contactDirectory = directory",
+        "Loading chats should retain the resolved contacts for later background exports",
+    )
+    assert view_model.count("contacts: contactDirectory") >= 2, (
+        "Single-chat and bulk detached exporters should preserve resolved contact names and sender labels"
+    )
+
+
 def test_html_export_cleans_stale_attachment_folder(root: Path) -> None:
     src = read(root, "Sources/Phosphor/Services/MessageExporter.swift")
     assert_contains(src, "private func removeAttachmentFolder(forHTMLPath", "HTML export should have explicit stale attachment cleanup")

--- a/Scripts/regression/checks/message_export.py
+++ b/Scripts/regression/checks/message_export.py
@@ -907,6 +907,26 @@ struct MessageExportBundleProbe {
                 exit(4)
             }
         }
+
+        // Stale lookalikes from a hard crash are ambiguous user data and must
+        // never be recursively deleted merely because their names match.
+        let ambiguous = parent.appendingPathComponent(
+            ".Messages Export.staging-11111111-1111-4111-8111-111111111111",
+            isDirectory: true
+        )
+        try fileManager.createDirectory(at: ambiguous, withIntermediateDirectories: true)
+        try Data("must survive".utf8).write(to: ambiguous.appendingPathComponent("user-data.txt"))
+        let third = try MessageExportBundleWriter.write(in: parent) { root in
+            try Data("third".utf8).write(to: root.appendingPathComponent("marker.txt"))
+            return 1
+        }
+        let postSuccessNames = try fileManager.contentsOfDirectory(atPath: parent.path)
+        guard third.directory.lastPathComponent == "Messages Export 3",
+              fileManager.fileExists(atPath: ambiguous.appendingPathComponent("user-data.txt").path),
+              !postSuccessNames.contains(where: { $0.hasPrefix(".Messages Export 3.staging-") }) else {
+            fputs("successful publication deleted ambiguous data or left active staging\n", stderr)
+            exit(5)
+        }
     }
 }
 '''
@@ -925,6 +945,13 @@ struct MessageExportBundleProbe {
         assert compile_result.returncode == 0, compile_result.stderr
         result = subprocess.run([str(executable), str(temp)], capture_output=True, text=True, timeout=10)
         assert result.returncode == 0, result.stderr
+
+    source = helper.read_text()
+    assert "removeCurrentStagingDirectoryIfPresent" in source, "handled failures must explicitly remove and verify active staging"
+    assert "stagingCleanupError" in source, "cleanup failures must be visible instead of silently discarded"
+    assert "successful same-parent move is the publication commit point" in source, "successful publication must return without touching the vacated staging pathname"
+    assert "removeStaleStagingDirectories" not in source, "ambiguous crash leftovers must not be recursively auto-deleted from user-selected folders"
+    assert "try? fileManager.removeItem(at: stagingDirectory)" not in source, "active staging cleanup failure must not be silently ignored"
 
 
 def test_single_pdf_bundle_serializes_same_parent_across_processes(root: Path) -> None:

--- a/Scripts/regression/checks/message_export.py
+++ b/Scripts/regression/checks/message_export.py
@@ -16,6 +16,21 @@ def assert_contains(text: str, needle: str, message: str) -> None:
     assert needle in text, message
 
 
+def test_single_pdf_export_is_a_self_contained_folder(root: Path) -> None:
+    exporter = read(root, "Sources/Phosphor/Services/MessageExporter.swift")
+    view_model = read(root, "Sources/Phosphor/ViewModels/MessageViewModel.swift")
+    view = read(root, "Sources/Phosphor/Views/Messages/MessageListView.swift")
+    bundle_writer = read(root, "Sources/Phosphor/Utilities/MessageExportBundleWriter.swift")
+
+    assert_contains(exporter, "func exportChatPDFBundle(", "MessageExporter needs a dedicated single-conversation PDF bundle API")
+    assert_contains(exporter, "appendingPathComponent(\"Attachments\"", "A single PDF bundle must contain an Attachments folder")
+    assert_contains(exporter, "format: .pdf", "A single PDF bundle must generate a PDF transcript")
+    assert_contains(view_model, "func startExportChatPDFBundle(", "The view model needs a background PDF-bundle export route")
+    assert_contains(view, "exportSingleChatPDFBundle()", "The PDF menu action must use the bundle route")
+    assert_contains(view, "Choose where Phosphor should create a folder", "PDF bundle UI must ask for the parent folder, not a lone PDF filename")
+    assert_contains(bundle_writer, "directoryName:", "Bundle writer must allow a collision-safe per-conversation directory name")
+
+
 def test_message_exports_publish_generation_sidecars_without_crash_mismatch(root: Path) -> None:
     src = read(root, "Sources/Phosphor/Services/MessageExporter.swift")
     transaction = root / "Sources/Phosphor/Utilities/MessageExportTransaction.swift"

--- a/Scripts/regression/checks/message_export.py
+++ b/Scripts/regression/checks/message_export.py
@@ -939,6 +939,12 @@ struct MessageExportBundleRaceProbe {
         let mode = CommandLine.arguments[2]
         let ready = URL(fileURLWithPath: CommandLine.arguments[3])
         let release = URL(fileURLWithPath: CommandLine.arguments[4])
+        let secondStarted = URL(fileURLWithPath: CommandLine.arguments[5])
+        let secondEnteredPopulate = URL(fileURLWithPath: CommandLine.arguments[6])
+
+        if mode == "run" {
+            try Data().write(to: secondStarted)
+        }
 
         let result = try MessageExportBundleWriter.write(in: parent, directoryName: "Conversation") { root in
             if mode == "hold" {
@@ -946,6 +952,8 @@ struct MessageExportBundleRaceProbe {
                 while !FileManager.default.fileExists(atPath: release.path) {
                     Thread.sleep(forTimeInterval: 0.01)
                 }
+            } else {
+                try Data().write(to: secondEnteredPopulate)
             }
             try Data(mode.utf8).write(to: root.appendingPathComponent("marker.txt"))
             return 1
@@ -971,8 +979,10 @@ struct MessageExportBundleRaceProbe {
         parent = temp / "exports"
         ready = temp / "ready"
         release = temp / "release"
+        second_started = temp / "second-started"
+        second_entered_populate = temp / "second-entered-populate"
         first = subprocess.Popen(
-            [str(executable), str(parent), "hold", str(ready), str(release)],
+            [str(executable), str(parent), "hold", str(ready), str(release), str(second_started), str(second_entered_populate)],
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
             text=True,
@@ -984,16 +994,23 @@ struct MessageExportBundleRaceProbe {
             assert ready.exists(), "first PDF bundle did not reach its staged write"
 
             second = subprocess.Popen(
-                [str(executable), str(parent), "run", str(ready), str(release)],
+                [str(executable), str(parent), "run", str(ready), str(release), str(second_started), str(second_entered_populate)],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 text=True,
             )
+            deadline = time.monotonic() + 5
+            while not second_started.exists() and time.monotonic() < deadline:
+                time.sleep(0.01)
+            assert second_started.exists(), "second PDF bundle process did not reach the writer"
+            time.sleep(0.25)
+            assert not second_entered_populate.exists(), "second PDF bundle entered name selection before the first export released its lock"
             release.write_text("go")
             first_out, first_err = first.communicate(timeout=10)
             second_out, second_err = second.communicate(timeout=10)
             assert first.returncode == 0, first_err
             assert second.returncode == 0, second_err
+            assert second_entered_populate.exists(), "second PDF bundle never populated after the first export released its lock"
             assert {first_out.strip(), second_out.strip()} == {"Conversation", "Conversation 2"}
             assert (parent / "Conversation" / "marker.txt").exists()
             assert (parent / "Conversation 2" / "marker.txt").exists()

--- a/Scripts/regression/checks/message_export.py
+++ b/Scripts/regression/checks/message_export.py
@@ -5,6 +5,7 @@ import re
 import sqlite3
 import subprocess
 import tempfile
+import time
 from pathlib import Path
 
 
@@ -126,6 +127,84 @@ struct GenerationPublicationProbe {
         assert compile_result.returncode == 0, compile_result.stderr
         result = subprocess.run([str(executable), str(temp)], capture_output=True, text=True, timeout=20)
         assert result.returncode == 0, f"generation publication probe exited {result.returncode}: {result.stderr}"
+
+
+def test_same_destination_exports_serialize_sidecar_publication(root: Path) -> None:
+    transaction_path = root / "Sources/Phosphor/Utilities/MessageExportTransaction.swift"
+    transaction = transaction_path.read_text()
+    attachment_exporter = root / "Sources/Phosphor/Utilities/MessageAttachmentExporter.swift"
+
+    assert_contains(
+        transaction,
+        "withDestinationLock",
+        "same-destination exports must serialize generation cleanup after transcript publication",
+    )
+    assert_contains(
+        transaction, "flock(",
+        "the publication lock must also protect separate Phosphor processes",
+    )
+    assert_contains(
+        transaction,
+        "withDestinationLock(for: finalTranscriptURL)",
+        "the complete prepare, publish, and cleanup transaction must run under the destination lock",
+    )
+
+    worker = r'''
+import Foundation
+
+@main
+struct ConcurrentPublicationWorker {
+    static func main() throws {
+        let root = URL(fileURLWithPath: CommandLine.arguments[1], isDirectory: true)
+        let marker = CommandLine.arguments[2]
+        let fileManager = FileManager.default
+        let final = root.appendingPathComponent("conversation.html")
+        let source = root.appendingPathComponent("source-\(marker).jpg")
+        try Data(marker.utf8).write(to: source)
+        let item = MessageAttachmentExporter.Item(key: "image", displayName: "image.jpg", sourcePath: source.path)
+
+        try MessageExportTransaction.write(to: final, prepareAttachments: {
+            let generation = try MessageAttachmentExporter.prepareGeneration([item], beside: final.path)
+            if marker == "A" {
+                try Data().write(to: root.appendingPathComponent("A-sidecar-ready"))
+            }
+            return generation
+        }) { staged, paths in
+            if marker == "A" { Thread.sleep(forTimeInterval: 0.45) }
+            try Data("\(marker):\(paths["image"]!)".utf8).write(to: staged)
+        }
+
+        guard fileManager.fileExists(atPath: final.path) else { exit(1) }
+    }
+}
+'''
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp = Path(temp_dir)
+        worker_path = temp / "ConcurrentPublicationWorker.swift"
+        worker_path.write_text(worker)
+        executable = temp / "concurrent-publication-worker"
+        compile_result = subprocess.run(
+            ["swiftc", "-parse-as-library", str(attachment_exporter), str(transaction_path), str(worker_path), "-o", str(executable)],
+            capture_output=True, text=True, timeout=60,
+        )
+        assert compile_result.returncode == 0, compile_result.stderr
+
+        first = subprocess.Popen([str(executable), str(temp), "A"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True)
+        ready = temp / "A-sidecar-ready"
+        deadline = time.monotonic() + 5
+        while not ready.exists() and time.monotonic() < deadline:
+            time.sleep(0.01)
+        assert ready.exists(), "first worker did not publish its sidecar generation"
+
+        second = subprocess.run([str(executable), str(temp), "B"], capture_output=True, text=True, timeout=10)
+        first_stdout, first_stderr = first.communicate(timeout=10)
+        assert first.returncode == 0, first_stderr or first_stdout
+        assert second.returncode == 0, second.stderr or second.stdout
+
+        transcript = (temp / "conversation.html").read_text()
+        marker, relative_path = transcript.split(":", maxsplit=1)
+        assert marker == "B", "the later same-destination export must win after serialized publication"
+        assert (temp / relative_path).is_file(), "the completed transcript must retain the sidecar generation it references"
 
 
 def test_message_pdf_export_is_registered_and_uses_native_pdf_writer(root: Path) -> None:

--- a/Scripts/regression/checks/message_export.py
+++ b/Scripts/regression/checks/message_export.py
@@ -51,10 +51,99 @@ def test_message_pdf_export_is_registered_and_uses_native_pdf_writer(root: Path)
     assert_contains(exporter, "inlineReply: replyPreview(for: msg)", "PDF export should pass inline reply previews into the PDF writer")
     assert_contains(exporter, "thread_originator_guid", "Message export should read iMessage inline reply thread metadata")
     assert_contains(exporter, "reply_to_guid", "Message export should read modern inline reply target metadata")
-    assert_contains(exporter, "attachments: attachmentSummaries", "PDF export should pass attachment metadata into the PDF writer")
+    assert_contains(exporter, "attachments: pdfAttachments", "PDF export should pass attachment metadata and resolved image paths into the PDF writer")
+    assert_contains(exporter, "resolveAttachmentDiskPath(filename: filename)", "PDF export should resolve image attachments from the backup")
+    assert_contains(writer, "CGImageSourceCreateThumbnailAtIndex", "PDF image previews should use bounded ImageIO thumbnails")
     assert_contains(exporter, "linkURL: msg.linkURL", "PDF export should pass rich-link URLs into the PDF writer")
     assert_contains(exporter, "status: statusParts.isEmpty ? nil", "PDF export should pass service/read status into the PDF writer")
     assert_contains(writer, "entry.isFromMe ? margin + contentWidth - bubbleWidth : margin", "PDF writer should right-align outgoing bubbles and left-align incoming bubbles")
+
+
+def test_message_pdf_export_renders_image_attachments(root: Path) -> None:
+    writer = root / "Sources/Phosphor/Utilities/PDFTranscriptWriter.swift"
+    probe = r'''
+import AppKit
+import Foundation
+import PDFKit
+
+@main
+struct PDFAttachmentProbe {
+    static func main() throws {
+        let imagePath = CommandLine.arguments[1]
+        let pdfPath = CommandLine.arguments[2]
+        let bitmap = NSBitmapImageRep(
+            bitmapDataPlanes: nil,
+            pixelsWide: 120,
+            pixelsHigh: 90,
+            bitsPerSample: 8,
+            samplesPerPixel: 4,
+            hasAlpha: true,
+            isPlanar: false,
+            colorSpaceName: .deviceRGB,
+            bytesPerRow: 0,
+            bitsPerPixel: 0
+        )!
+        for y in 0..<bitmap.pixelsHigh {
+            for x in 0..<bitmap.pixelsWide {
+                bitmap.setColor(NSColor(calibratedRed: 1, green: 0, blue: 0, alpha: 1), atX: x, y: y)
+            }
+        }
+        try bitmap.representation(using: .png, properties: [:])!.write(to: URL(fileURLWithPath: imagePath))
+
+        try PDFTranscriptWriter.write(
+            title: "Attachment Regression",
+            subtitle: "",
+            entries: [PDFTranscriptWriter.Entry(
+                title: "Me",
+                subtitle: "",
+                body: "",
+                isFromMe: true,
+                attachments: [.init(summary: "photo.png • image/png", imagePath: imagePath)]
+            )],
+            to: pdfPath
+        )
+
+        guard let document = PDFDocument(url: URL(fileURLWithPath: pdfPath)),
+              let page = document.page(at: 0) else { exit(1) }
+        let rendered = page.thumbnail(of: CGSize(width: 612, height: 792), for: .mediaBox)
+        guard let tiff = rendered.tiffRepresentation, let pixels = NSBitmapImageRep(data: tiff) else { exit(2) }
+        var foundRedPixel = false
+        for y in stride(from: 0, to: pixels.pixelsHigh, by: 2) {
+            for x in stride(from: 0, to: pixels.pixelsWide, by: 2) {
+                guard let color = pixels.colorAt(x: x, y: y)?.usingColorSpace(.deviceRGB) else { continue }
+                if color.redComponent > 0.8 && color.greenComponent < 0.2 && color.blueComponent < 0.2 {
+                    foundRedPixel = true
+                    break
+                }
+            }
+            if foundRedPixel { break }
+        }
+        guard foundRedPixel else {
+            fputs("PDF did not visibly render the image attachment\n", stderr)
+            exit(3)
+        }
+    }
+}
+'''
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp = Path(temp_dir)
+        probe_path = temp / "Probe.swift"
+        probe_path.write_text(probe)
+        executable = temp / "pdf-attachment-probe"
+        compile_result = subprocess.run(
+            ["swiftc", "-parse-as-library", str(writer), str(probe_path), "-framework", "PDFKit", "-o", str(executable)],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        assert compile_result.returncode == 0, compile_result.stderr
+        result = subprocess.run(
+            [str(executable), str(temp / "photo.png"), str(temp / "attachment.pdf")],
+            capture_output=True,
+            text=True,
+            timeout=20,
+        )
+        assert result.returncode == 0, result.stderr
 
 
 def test_attributed_message_body_is_decoded_when_plain_text_is_missing(root: Path) -> None:

--- a/Scripts/regression/checks/message_export.py
+++ b/Scripts/regression/checks/message_export.py
@@ -256,11 +256,77 @@ struct OversizedAttributedBodyProbe {
 
 def test_bulk_message_exports_use_collision_safe_filenames(root: Path) -> None:
     src = read(root, "Sources/Phosphor/Services/MessageExporter.swift")
-    assert_contains(src, "private func exportFilename(for chat", "Bulk message export should centralize filename generation")
-    assert_contains(src, "-chat-\\(chat.id)", "Bulk message export filenames should include chat id to avoid duplicate-title overwrites")
     export_all = re.search(r"func exportAllChats\(.*?\) throws -> Int \{(?P<body>.*?)\n    \}", src, re.S)
     assert export_all is not None, "exportAllChats should exist"
-    assert_contains(export_all.group("body"), "exportFilename(for: chat", "exportAllChats should use collision-safe filenames")
+    assert_contains(
+        export_all.group("body"),
+        "chat.exportFilename(format: format, includeChatID: true)",
+        "exportAllChats should preserve contact names and include collision-safe chat IDs",
+    )
+
+
+def test_pdf_export_filenames_preserve_resolved_contact_name(root: Path) -> None:
+    model = root / "Sources/Phosphor/Models/Message.swift"
+    exporter = read(root, "Sources/Phosphor/Services/MessageExporter.swift")
+    view = read(root, "Sources/Phosphor/Views/Messages/MessageListView.swift")
+    assert_contains(
+        model.read_text(),
+        "func exportFilename(format: MessageExportFormat, includeChatID: Bool)",
+        "MessageChat should own contact-preserving export filename generation",
+    )
+    assert_contains(
+        exporter,
+        "chat.exportFilename(format: format, includeChatID: true)",
+        "Bulk exports should preserve the resolved contact name while retaining collision-safe chat IDs",
+    )
+    assert_contains(
+        view,
+        "chat.exportFilename(format: format, includeChatID: false)",
+        "Single-chat save panels should default PDF files to the resolved contact name",
+    )
+
+    probe = r'''
+import Foundation
+
+extension Date {
+    var shortString: String { "" }
+}
+
+@main
+struct ContactFilenameProbe {
+    static func main() {
+        let chat = MessageChat(
+            id: 42,
+            chatIdentifier: "+15551234567",
+            displayName: "",
+            participants: ["+15551234567"],
+            resolvedTitle: "Jane Doe",
+            lastMessageDate: nil,
+            messageCount: 1,
+            isGroupChat: false
+        )
+        guard chat.exportFilename(format: .pdf, includeChatID: false) == "Jane Doe.pdf",
+              chat.exportFilename(format: .pdf, includeChatID: true) == "Jane Doe-chat-42.pdf" else {
+            fputs("PDF export filename did not preserve the resolved contact name\n", stderr)
+            exit(1)
+        }
+    }
+}
+'''
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp = Path(temp_dir)
+        probe_path = temp / "Probe.swift"
+        probe_path.write_text(probe)
+        executable = temp / "contact-filename-probe"
+        result = subprocess.run(
+            ["swiftc", "-parse-as-library", str(model), str(probe_path), "-o", str(executable)],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        assert result.returncode == 0, result.stderr
+        run = subprocess.run([str(executable)], capture_output=True, text=True, timeout=10)
+        assert run.returncode == 0, run.stderr
 
 
 def test_html_export_cleans_stale_attachment_folder(root: Path) -> None:

--- a/Scripts/regression/checks/message_export.py
+++ b/Scripts/regression/checks/message_export.py
@@ -927,6 +927,83 @@ struct MessageExportBundleProbe {
         assert result.returncode == 0, result.stderr
 
 
+def test_single_pdf_bundle_serializes_same_parent_across_processes(root: Path) -> None:
+    helper = root / "Sources/Phosphor/Utilities/MessageExportBundleWriter.swift"
+    probe = r'''
+import Foundation
+
+@main
+struct MessageExportBundleRaceProbe {
+    static func main() throws {
+        let parent = URL(fileURLWithPath: CommandLine.arguments[1], isDirectory: true)
+        let mode = CommandLine.arguments[2]
+        let ready = URL(fileURLWithPath: CommandLine.arguments[3])
+        let release = URL(fileURLWithPath: CommandLine.arguments[4])
+
+        let result = try MessageExportBundleWriter.write(in: parent, directoryName: "Conversation") { root in
+            if mode == "hold" {
+                try Data().write(to: ready)
+                while !FileManager.default.fileExists(atPath: release.path) {
+                    Thread.sleep(forTimeInterval: 0.01)
+                }
+            }
+            try Data(mode.utf8).write(to: root.appendingPathComponent("marker.txt"))
+            return 1
+        }
+        print(result.directory.lastPathComponent)
+    }
+}
+'''
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp = Path(temp_dir)
+        probe_path = temp / "RaceProbe.swift"
+        probe_path.write_text(probe)
+        executable = temp / "message-export-bundle-race-probe"
+        compile_result = subprocess.run(
+            ["swiftc", "-parse-as-library", str(helper), str(probe_path), "-o", str(executable)],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        assert compile_result.returncode == 0, compile_result.stderr
+
+        parent = temp / "exports"
+        ready = temp / "ready"
+        release = temp / "release"
+        first = subprocess.Popen(
+            [str(executable), str(parent), "hold", str(ready), str(release)],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        try:
+            deadline = time.monotonic() + 5
+            while not ready.exists() and time.monotonic() < deadline:
+                time.sleep(0.01)
+            assert ready.exists(), "first PDF bundle did not reach its staged write"
+
+            second = subprocess.Popen(
+                [str(executable), str(parent), "run", str(ready), str(release)],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            release.write_text("go")
+            first_out, first_err = first.communicate(timeout=10)
+            second_out, second_err = second.communicate(timeout=10)
+            assert first.returncode == 0, first_err
+            assert second.returncode == 0, second_err
+            assert {first_out.strip(), second_out.strip()} == {"Conversation", "Conversation 2"}
+            assert (parent / "Conversation" / "marker.txt").exists()
+            assert (parent / "Conversation 2" / "marker.txt").exists()
+        finally:
+            if first.poll() is None:
+                release.write_text("cleanup")
+                first.terminate()
+                first.wait(timeout=5)
+
+
 def test_all_formats_message_bundle_has_one_folder_per_conversation(root: Path) -> None:
     exporter = read(root, "Sources/Phosphor/Services/MessageExporter.swift")
     view_model = read(root, "Sources/Phosphor/ViewModels/MessageViewModel.swift")

--- a/Scripts/regression/checks/message_export.py
+++ b/Scripts/regression/checks/message_export.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import re
 import sqlite3
+import subprocess
 import tempfile
 from pathlib import Path
 
@@ -54,6 +55,200 @@ def test_message_pdf_export_is_registered_and_uses_native_pdf_writer(root: Path)
     assert_contains(exporter, "linkURL: msg.linkURL", "PDF export should pass rich-link URLs into the PDF writer")
     assert_contains(exporter, "status: statusParts.isEmpty ? nil", "PDF export should pass service/read status into the PDF writer")
     assert_contains(writer, "entry.isFromMe ? margin + contentWidth - bubbleWidth : margin", "PDF writer should right-align outgoing bubbles and left-align incoming bubbles")
+
+
+def test_attributed_message_body_is_decoded_when_plain_text_is_missing(root: Path) -> None:
+    exporter = read(root, "Sources/Phosphor/Services/MessageExporter.swift")
+    decoder = root / "Sources/Phosphor/Utilities/MessageAttributedBodyDecoder.swift"
+    typedstream_sources = sorted((root / "Sources/Phosphor/Utilities/MessageTypedStream").glob("*.swift"))
+    writer = root / "Sources/Phosphor/Utilities/PDFTranscriptWriter.swift"
+    notices = root / "THIRD_PARTY_NOTICES.md"
+    build_script = read(root, "Scripts/build.sh")
+    assert decoder.exists(), "Message exports should include an attributedBody typedstream decoder"
+    assert typedstream_sources, "Message exports should include the bounded pure-Swift typedstream parser"
+    assert notices.exists() and "Madrid TypedStream" in notices.read_text(), "Vendored typedstream code should retain its MIT notice"
+    assert_contains(build_script, 'THIRD_PARTY_NOTICES.md', "Release bundles should include third-party license notices")
+    assert_contains(exporter, '"attributedBody"', "Message queries should select attributedBody when the schema provides it")
+    assert_contains(exporter, "MessageAttributedBodyDecoder.text", "Message parsing should fall back to decoded attributedBody text")
+    assert "NSUnarchiver" not in decoder.read_text(), "Backup-controlled attributedBody data must not use unsafe Foundation unarchiving"
+
+    probe = r'''
+import Foundation
+import PDFKit
+
+@main
+struct AttributedBodyProbe {
+    static func main() throws {
+        let expected = "INLINE_ATTRIBUTED_BODY_SENTINEL"
+        let archived = NSArchiver.archivedData(withRootObject: NSAttributedString(string: expected))
+        guard let decoded = MessageAttributedBodyDecoder.text(from: archived), decoded == expected else {
+            fputs("failed to decode NSArchiver attributed string\n", stderr)
+            exit(1)
+        }
+        guard MessageAttributedBodyDecoder.text(from: Data([0x00, 0x01, 0x02])) == nil else {
+            fputs("malformed archives must fail closed\n", stderr)
+            exit(2)
+        }
+        let truncatedTypedstream = Data([0x04, 0x0B]) + Data("streamtyped".utf8)
+        guard MessageAttributedBodyDecoder.text(from: truncatedTypedstream) == nil else {
+            fputs("truncated typedstreams must fail closed\n", stderr)
+            exit(3)
+        }
+        let referenceRun = truncatedTypedstream + Data(repeating: 0xFF, count: 1_048_576)
+        guard MessageAttributedBodyDecoder.text(from: referenceRun) == nil else {
+            fputs("malformed reference runs must fail closed\n", stderr)
+            exit(4)
+        }
+        var amplifiedTypes = truncatedTypedstream + Data([0x81, 0xE8, 0x03])
+        amplifiedTypes.append(contentsOf: [0x84, 0x82, 0x00, 0x00, 0x01, 0x00])
+        amplifiedTypes.append(Data(repeating: 0x7F, count: 65_536))
+        for _ in 0..<100 {
+            amplifiedTypes.append(contentsOf: [0x92, 0x86])
+        }
+        do {
+            _ = try MessageTypedStreamDecoder.decode(amplifiedTypes)
+            fputs("repeated type references must exhaust a decoded-output budget\n", stderr)
+            exit(5)
+        } catch MessageTypedStreamDecoderError.resourceLimit {
+            // Expected: references must not amplify a small archive into an unbounded output graph.
+        }
+        try PDFTranscriptWriter.write(
+            title: "Attributed Body Regression",
+            subtitle: "",
+            entries: [PDFTranscriptWriter.Entry(
+                title: "Me",
+                subtitle: "",
+                body: decoded,
+                isFromMe: true,
+                inlineReply: "original message"
+            )],
+            to: CommandLine.arguments[1]
+        )
+        guard let text = PDFDocument(url: URL(fileURLWithPath: CommandLine.arguments[1]))?.string,
+              text.filter({ $0.isLetter || $0.isNumber }).contains(expected.filter({ $0.isLetter || $0.isNumber })),
+              text.contains("Inline reply") else {
+            fputs("decoded attributedBody text was missing from PDF output\n", stderr)
+            exit(6)
+        }
+    }
+}
+'''
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp = Path(temp_dir)
+        probe_path = temp / "Probe.swift"
+        probe_path.write_text(probe)
+        executable = temp / "attributed-body-probe"
+        compile_result = subprocess.run(
+            [
+                "swiftc", "-parse-as-library", *map(str, typedstream_sources), str(decoder), str(writer), str(probe_path),
+                "-framework", "PDFKit", "-o", str(executable),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        assert compile_result.returncode == 0, compile_result.stderr
+        result = subprocess.run([str(executable), str(temp / "attributed-body.pdf")], capture_output=True, text=True, timeout=10)
+        assert result.returncode == 0, result.stderr
+
+
+def test_oversized_attributed_body_is_null_before_sqlite_materialization(root: Path) -> None:
+    exporter = read(root, "Sources/Phosphor/Services/MessageExporter.swift")
+    decoder = root / "Sources/Phosphor/Utilities/MessageAttributedBodyDecoder.swift"
+    sqlite_reader = root / "Sources/Phosphor/Utilities/SQLiteReader.swift"
+    typedstream_sources = sorted((root / "Sources/Phosphor/Utilities/MessageTypedStream").glob("*.swift"))
+    assert_contains(
+        exporter,
+        "MessageAttributedBodyDecoder.attributedBodyCandidateSQLProjection",
+        "Bulk message queries should select only bounded attributedBody candidate row IDs",
+    )
+    assert_contains(
+        exporter,
+        "loadAttributedBodyText(messageId:",
+        "Attributed bodies should be loaded and decoded one row at a time instead of retained across a result set",
+    )
+    assert_contains(
+        exporter,
+        "remainingAttributedBodyTextBytes",
+        "Each message query should cap the aggregate recovered attributedBody text retained in memory",
+    )
+    select_fields = re.search(
+        r"private func messageSelectFields\(\) -> String \{(?P<body>.*?)\n    \}",
+        exporter,
+        re.S,
+    )
+    assert select_fields is not None
+    assert "fields.append(MessageAttributedBodyDecoder.attributedBodySQLProjection)" not in select_fields.group("body"), (
+        "Bulk message SELECTs must not materialize attributedBody BLOBs"
+    )
+
+    probe = r'''
+import Foundation
+
+@main
+struct OversizedAttributedBodyProbe {
+    static func main() throws {
+        let reader = try SQLiteReader(path: CommandLine.arguments[1])
+        let candidates = try reader.query(
+            "SELECT \(MessageAttributedBodyDecoder.attributedBodyCandidateSQLProjection) FROM message m ORDER BY m.ROWID"
+        )
+        guard candidates.count == 3,
+              candidates[0]["attributed_body_rowid"] as? Int == 1,
+              (candidates[1]["attributed_body_rowid"] ?? nil) == nil,
+              (candidates[2]["attributed_body_rowid"] ?? nil) == nil else {
+            fputs("bulk query did not reduce attributedBody values to bounded candidate row IDs\n", stderr)
+            exit(1)
+        }
+
+        let smallRows = try reader.query(
+            "SELECT \(MessageAttributedBodyDecoder.attributedBodySQLProjection) FROM message m WHERE m.ROWID = 1 LIMIT 1"
+        )
+        let oversizedRows = try reader.query(
+            "SELECT \(MessageAttributedBodyDecoder.attributedBodySQLProjection) FROM message m WHERE m.ROWID = 2 LIMIT 1"
+        )
+        guard let small = smallRows.first?["attributedBody"] as? Data,
+              small == Data([0x01, 0x02, 0x03]),
+              (oversizedRows.first?["attributedBody"] ?? nil) == nil else {
+            fputs("oversized attributedBody was materialized instead of projected as NULL\n", stderr)
+            exit(2)
+        }
+    }
+}
+'''
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp = Path(temp_dir)
+        database = temp / "sms.db"
+        connection = sqlite3.connect(database)
+        try:
+            connection.execute("CREATE TABLE message (text TEXT, attributedBody BLOB)")
+            connection.execute("INSERT INTO message (text, attributedBody) VALUES (NULL, ?)", (sqlite3.Binary(b"\x01\x02\x03"),))
+            connection.execute(
+                "INSERT INTO message (text, attributedBody) VALUES (NULL, zeroblob(?))",
+                (16 * 1024 * 1024 + 1,),
+            )
+            connection.execute(
+                "INSERT INTO message (text, attributedBody) VALUES ('plain text wins', ?)",
+                (sqlite3.Binary(b"\x04\x05\x06"),),
+            )
+            connection.commit()
+        finally:
+            connection.close()
+
+        probe_path = temp / "Probe.swift"
+        probe_path.write_text(probe)
+        executable = temp / "oversized-attributed-body-probe"
+        compile_result = subprocess.run(
+            [
+                "swiftc", "-parse-as-library", *map(str, typedstream_sources), str(decoder), str(sqlite_reader),
+                str(probe_path), "-lsqlite3", "-o", str(executable),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        assert compile_result.returncode == 0, compile_result.stderr
+        result = subprocess.run([str(executable), str(database)], capture_output=True, text=True, timeout=10)
+        assert result.returncode == 0, result.stderr
 
 
 

--- a/Scripts/regression/checks/message_export.py
+++ b/Scripts/regression/checks/message_export.py
@@ -535,7 +535,7 @@ def test_bulk_message_exports_use_collision_safe_filenames(root: Path) -> None:
     )
 
 
-def test_pdf_export_filenames_preserve_resolved_contact_name(root: Path) -> None:
+def test_message_export_filenames_preserve_names_without_chat_label(root: Path) -> None:
     model = root / "Sources/Phosphor/Models/Message.swift"
     exporter = read(root, "Sources/Phosphor/Services/MessageExporter.swift")
     view = read(root, "Sources/Phosphor/Views/Messages/MessageListView.swift")
@@ -576,8 +576,8 @@ struct ContactFilenameProbe {
             isGroupChat: false
         )
         guard chat.exportFilename(format: .pdf, includeChatID: false) == "Jane Doe.pdf",
-              chat.exportFilename(format: .pdf, includeChatID: true) == "Jane Doe-chat-42.pdf" else {
-            fputs("PDF export filename did not preserve the resolved contact name\n", stderr)
+              chat.exportFilename(format: .pdf, includeChatID: true) == "Jane Doe-42.pdf" else {
+            fputs("Export filename did not preserve the resolved contact name without adding Chat\n", stderr)
             exit(1)
         }
     }
@@ -597,6 +597,46 @@ struct ContactFilenameProbe {
         assert result.returncode == 0, result.stderr
         run = subprocess.run([str(executable)], capture_output=True, text=True, timeout=10)
         assert run.returncode == 0, run.stderr
+
+
+def test_message_export_progress_survives_messages_navigation(root: Path) -> None:
+    app = read(root, "Sources/Phosphor/App/PhosphorApp.swift")
+    content = read(root, "Sources/Phosphor/Views/ContentView.swift")
+    messages = read(root, "Sources/Phosphor/Views/Messages/MessageListView.swift")
+
+    assert_contains(
+        app,
+        "@StateObject private var messageVM = MessageViewModel()",
+        "the export task must outlive the Messages screen",
+    )
+    assert_contains(
+        app,
+        ".environmentObject(messageVM)",
+        "the app must provide one shared message export state to every section",
+    )
+    assert_contains(
+        content,
+        "@EnvironmentObject var messageVM: MessageViewModel",
+        "the root content view must observe shared message export progress",
+    )
+    assert_contains(
+        content,
+        "if messageVM.isExporting { messageExportProgressView }",
+        "the export progress bar must stay visible while navigating away from Messages",
+    )
+    assert_contains(
+        content,
+        "Button(\"Cancel\") { messageVM.cancelExport() }",
+        "the persistent export progress bar must retain cancellation",
+    )
+    assert_contains(
+        messages,
+        "@EnvironmentObject var messageVM: MessageViewModel",
+        "Messages must consume the shared export state instead of recreating it",
+    )
+    assert "@StateObject private var messageVM = MessageViewModel()" not in messages, (
+        "recreating the Messages view must not make an active export progress bar disappear"
+    )
 
 
 def test_background_message_exports_keep_loaded_contact_directory(root: Path) -> None:
@@ -829,14 +869,14 @@ struct MessageExportBundleProbe {
         let fileManager = FileManager.default
 
         let first = try MessageExportBundleWriter.write(in: parent) { root in
-            let conversation = root.appendingPathComponent("Jane Doe-chat-42", isDirectory: true)
+            let conversation = root.appendingPathComponent("Jane Doe-42", isDirectory: true)
             try fileManager.createDirectory(at: conversation, withIntermediateDirectories: true)
             try Data("pdf".utf8).write(to: conversation.appendingPathComponent("Jane Doe.pdf"))
             return 1
         }
         guard first.count == 1,
               first.directory.lastPathComponent == "Messages Export",
-              fileManager.fileExists(atPath: first.directory.appendingPathComponent("Jane Doe-chat-42/Jane Doe.pdf").path) else {
+              fileManager.fileExists(atPath: first.directory.appendingPathComponent("Jane Doe-42/Jane Doe.pdf").path) else {
             fputs("first bundle did not produce the expected export folder\n", stderr)
             exit(1)
         }

--- a/Scripts/regression/checks/pdf_export_polish.py
+++ b/Scripts/regression/checks/pdf_export_polish.py
@@ -9,9 +9,11 @@ def _read(root: Path, relative_path: str) -> str:
 
 def test_pdf_links_are_clickable_and_timestamps_follow_conversation_gaps(root: Path) -> None:
     exporter = _read(root, "Sources/Phosphor/Services/MessageExporter.swift")
+    whatsapp_exporter = _read(root, "Sources/Phosphor/Services/WhatsAppExporter.swift")
     writer = _read(root, "Sources/Phosphor/Utilities/PDFTranscriptWriter.swift")
 
     assert "timestamp: msg.date" in exporter, "PDF entries must carry message Date values for calendar/gap separators"
+    assert "timestamp: msg.date" in whatsapp_exporter, "WhatsApp PDF entries must carry message Date values for calendar/gap separators"
     assert "context.setURL" in writer, "PDF link cards must publish a real PDF URI annotation"
     assert "calendar.isDate" in writer, "PDF timestamp separators must account for calendar-day changes"
     assert "timeIntervalSince" in writer, "PDF timestamp separators must account for meaningful message gaps"

--- a/Scripts/regression/checks/pdf_export_polish.py
+++ b/Scripts/regression/checks/pdf_export_polish.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def _read(root: Path, relative_path: str) -> str:
+    return (root / relative_path).read_text()
+
+
+def test_pdf_links_are_clickable_and_timestamps_follow_conversation_gaps(root: Path) -> None:
+    exporter = _read(root, "Sources/Phosphor/Services/MessageExporter.swift")
+    writer = _read(root, "Sources/Phosphor/Utilities/PDFTranscriptWriter.swift")
+
+    assert "timestamp: msg.date" in exporter, "PDF entries must carry message Date values for calendar/gap separators"
+    assert "context.setURL" in writer, "PDF link cards must publish a real PDF URI annotation"
+    assert "calendar.isDate" in writer, "PDF timestamp separators must account for calendar-day changes"
+    assert "timeIntervalSince" in writer, "PDF timestamp separators must account for meaningful message gaps"

--- a/Scripts/regression/checks/whatsapp_export.py
+++ b/Scripts/regression/checks/whatsapp_export.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def read(root: Path, rel: str) -> str:
+    return (root / rel).read_text()
+
+
+def assert_contains(text: str, needle: str, message: str) -> None:
+    assert needle in text, message
+
+
+def test_whatsapp_exports_match_messages_export_controls(root: Path) -> None:
+    exporter = read(root, "Sources/Phosphor/Services/WhatsAppExporter.swift")
+    view_model_path = root / "Sources/Phosphor/ViewModels/WhatsAppViewModel.swift"
+    assert view_model_path.exists(), "WhatsApp exports need an app-owned view model"
+    view_model = view_model_path.read_text()
+    view = read(root, "Sources/Phosphor/Views/WhatsApp/WhatsAppView.swift")
+    app = read(root, "Sources/Phosphor/App/PhosphorApp.swift")
+    content = read(root, "Sources/Phosphor/Views/ContentView.swift")
+
+    for contract in [
+        "func exportChatPDFBundle(",
+        "func exportAllChats(",
+        "func exportAllChatsAllFormats(",
+        "MessageExportOptions",
+        "cancellationCheck:",
+        "onProgress:",
+        "MessageExportTransaction.write",
+        "MessageExportBundleWriter.write",
+        "MessageAttachmentExporter",
+    ]:
+        assert_contains(exporter, contract, f"WhatsApp exporter is missing Messages parity contract: {contract}")
+
+    assert "case .mbox:\n            try exportTXT" not in exporter, "WhatsApp MBOX must be a real MBOX export"
+    assert_contains(exporter, "multipart/mixed", "WhatsApp MBOX should embed available media as MIME attachments")
+    assert_contains(exporter, "base64EncodedString", "WhatsApp MBOX media should be encoded for portable import")
+    assert_contains(exporter, "includeChatID", "Bulk WhatsApp filenames need collision-safe chat-ID suffixes")
+    bulk_start = exporter.index("func exportAllChats(")
+    bulk_end = exporter.index("func exportAllChatsAllFormats(")
+    assert_contains(
+        exporter[bulk_start:bulk_end],
+        "MessageExportBundleWriter.write",
+        "Single-format bulk WhatsApp exports must publish one complete folder atomically",
+    )
+    assert "|| candidate.fileName == filename" not in exporter, (
+        "WhatsApp media resolution must not select the first same-named file from another message"
+    )
+    assert_contains(exporter, "commonPathSuffixLength", "WhatsApp media resolution should disambiguate repeated filenames by path suffix")
+
+    for contract in [
+        "startExportChatPDFBundle(",
+        "startExportChat(",
+        "startExportAllChats(",
+        "startExportAllChatsAllFormats(",
+        "cancelExport()",
+        "filteredMessages(",
+        "@Published var exportResult",
+    ]:
+        assert_contains(view_model, contract, f"WhatsApp view model is missing Messages parity contract: {contract}")
+
+    assert_contains(
+        view,
+        "guard backupVM.openBackupBrowser(backup) else { return }",
+        "Locked or unreadable backups must wait for successful unlock before loading WhatsApp",
+    )
+
+    for contract in [
+        "exportAllMenu",
+        "backupPicker",
+        "exportOptionsBar",
+        "Export All Conversations As...",
+        "All Formats + Attachments",
+        "Choose Backup Folder",
+        "visibleMessages: displayedMessages",
+    ]:
+        assert_contains(view, contract, f"WhatsApp UI is missing Messages export control: {contract}")
+
+    assert_contains(app, "@StateObject private var whatsAppVM", "WhatsApp export state must survive navigation")
+    assert_contains(app, ".environmentObject(whatsAppVM)", "WhatsApp view model must be app-owned")
+    assert_contains(content, "if whatsAppVM.isExporting", "WhatsApp progress must remain visible outside its section")
+    assert_contains(content, "whatsAppVM.cancelExport()", "Root WhatsApp progress needs the same cancel action as Messages")

--- a/Sources/Phosphor/App/PhosphorApp.swift
+++ b/Sources/Phosphor/App/PhosphorApp.swift
@@ -38,6 +38,7 @@ struct PhosphorApp: App {
     @StateObject private var backupVM = BackupViewModel()
     @StateObject private var backupOperations = BackupOperationCoordinator.shared
     @StateObject private var messageVM = MessageViewModel()
+    @StateObject private var whatsAppVM = WhatsAppViewModel()
     @StateObject private var scheduler = BackupScheduler()
     @AppStorage("phosphor.hasCompletedOnboarding") private var hasCompletedOnboarding = false
     @State private var selectedSection: SidebarSection? = .devices
@@ -55,6 +56,7 @@ struct PhosphorApp: App {
                 .environmentObject(deviceVM)
                 .environmentObject(backupVM)
                 .environmentObject(messageVM)
+                .environmentObject(whatsAppVM)
                 .frame(minWidth: 960, minHeight: 640)
                 .onAppear {
                     Task {

--- a/Sources/Phosphor/App/PhosphorApp.swift
+++ b/Sources/Phosphor/App/PhosphorApp.swift
@@ -36,6 +36,7 @@ struct PhosphorApp: App {
     @NSApplicationDelegateAdaptor(PhosphorAppDelegate.self) private var appDelegate
     @StateObject private var deviceVM = DeviceViewModel()
     @StateObject private var backupVM = BackupViewModel()
+    @StateObject private var messageVM = MessageViewModel()
     @StateObject private var scheduler = BackupScheduler()
     @AppStorage("phosphor.hasCompletedOnboarding") private var hasCompletedOnboarding = false
 
@@ -51,6 +52,7 @@ struct PhosphorApp: App {
             ContentView()
                 .environmentObject(deviceVM)
                 .environmentObject(backupVM)
+                .environmentObject(messageVM)
                 .frame(minWidth: 960, minHeight: 640)
                 .onAppear {
                     Task {

--- a/Sources/Phosphor/App/PhosphorApp.swift
+++ b/Sources/Phosphor/App/PhosphorApp.swift
@@ -36,6 +36,7 @@ struct PhosphorApp: App {
     @NSApplicationDelegateAdaptor(PhosphorAppDelegate.self) private var appDelegate
     @StateObject private var deviceVM = DeviceViewModel()
     @StateObject private var backupVM = BackupViewModel()
+    @StateObject private var backupOperations = BackupOperationCoordinator.shared
     @StateObject private var messageVM = MessageViewModel()
     @StateObject private var scheduler = BackupScheduler()
     @AppStorage("phosphor.hasCompletedOnboarding") private var hasCompletedOnboarding = false
@@ -77,7 +78,7 @@ struct PhosphorApp: App {
                 Button("Backup Now") {
                     startBackupNow()
                 }
-                .disabled(deviceVM.selectedDevice == nil || backupVM.isCreating)
+                .disabled(deviceVM.selectedDevice == nil || backupOperations.isRunning)
 
                 Button("Open Backup Folder") {
                     openBackupFolder()
@@ -137,7 +138,7 @@ struct PhosphorApp: App {
                     startBackupNow()
                 }
                 .keyboardShortcut("b", modifiers: .command)
-                .disabled(deviceVM.selectedDevice == nil || backupVM.isCreating)
+                .disabled(deviceVM.selectedDevice == nil || backupOperations.isRunning)
 
                 Button("Open Backup Folder") {
                     openBackupFolder()
@@ -163,7 +164,7 @@ struct PhosphorApp: App {
     }
 
     private func startBackupNow() {
-        guard let device = deviceVM.selectedDevice, !backupVM.isCreating else { return }
+        guard let device = deviceVM.selectedDevice, !backupOperations.isRunning else { return }
         if device.connectionType == .wifi && !BackupManager.hasExistingBackup(for: device.id) {
             guard confirmFirstFullWiFiBackup(for: device) else { return }
         }

--- a/Sources/Phosphor/App/PhosphorApp.swift
+++ b/Sources/Phosphor/App/PhosphorApp.swift
@@ -39,6 +39,7 @@ struct PhosphorApp: App {
     @StateObject private var messageVM = MessageViewModel()
     @StateObject private var scheduler = BackupScheduler()
     @AppStorage("phosphor.hasCompletedOnboarding") private var hasCompletedOnboarding = false
+    @State private var selectedSection: SidebarSection? = .devices
 
     init() {
         // Pre-1.0.4 users defaulted to Apple's MobileSync directory implicitly.
@@ -49,7 +50,7 @@ struct PhosphorApp: App {
 
     var body: some Scene {
         WindowGroup {
-            ContentView()
+            ContentView(selectedSection: $selectedSection)
                 .environmentObject(deviceVM)
                 .environmentObject(backupVM)
                 .environmentObject(messageVM)
@@ -72,6 +73,45 @@ struct PhosphorApp: App {
         .windowToolbarStyle(.unified(showsTitle: true))
         .defaultSize(width: 1100, height: 720)
         .commands {
+            CommandMenu("Quick Actions") {
+                Button("Backup Now") {
+                    startBackupNow()
+                }
+                .disabled(deviceVM.selectedDevice == nil || backupVM.isCreating)
+
+                Button("Open Backup Folder") {
+                    openBackupFolder()
+                }
+
+                Divider()
+
+                Button("Refresh Devices") {
+                    Task { await deviceVM.refresh() }
+                }
+
+                Button("Refresh Backups") {
+                    backupVM.loadBackups()
+                }
+
+                Divider()
+
+                Button("Show Backups") {
+                    selectedSection = .backups
+                }
+
+                Button("Show Messages") {
+                    selectedSection = .messages
+                }
+
+                Button("Show Photos") {
+                    selectedSection = .photos
+                }
+
+                Button("Show Files") {
+                    selectedSection = .files
+                }
+            }
+
             CommandMenu("Device") {
                 Button("Refresh Devices") {
                     Task { await deviceVM.refresh() }
@@ -93,21 +133,15 @@ struct PhosphorApp: App {
             }
 
             CommandMenu("Backup") {
-                Button("New Backup") {
-                    guard let device = deviceVM.selectedDevice else { return }
-                    if device.connectionType == .wifi && !BackupManager.hasExistingBackup(for: device.id) {
-                        guard confirmFirstFullWiFiBackup(for: device) else { return }
-                    }
-                    Task {
-                        await backupVM.createBackup(
-                            udid: device.id,
-                            incremental: false,
-                            preferNetwork: device.connectionType == .wifi
-                        )
-                    }
+                Button("Backup Now") {
+                    startBackupNow()
                 }
                 .keyboardShortcut("b", modifiers: .command)
-                .disabled(deviceVM.selectedDevice == nil)
+                .disabled(deviceVM.selectedDevice == nil || backupVM.isCreating)
+
+                Button("Open Backup Folder") {
+                    openBackupFolder()
+                }
 
                 Button("Refresh Backups") {
                     backupVM.loadBackups()
@@ -126,6 +160,25 @@ struct PhosphorApp: App {
             get: { !hasCompletedOnboarding },
             set: { if !$0 { hasCompletedOnboarding = true } }
         )
+    }
+
+    private func startBackupNow() {
+        guard let device = deviceVM.selectedDevice, !backupVM.isCreating else { return }
+        if device.connectionType == .wifi && !BackupManager.hasExistingBackup(for: device.id) {
+            guard confirmFirstFullWiFiBackup(for: device) else { return }
+        }
+        selectedSection = .backups
+        Task {
+            await backupVM.createBackup(
+                udid: device.id,
+                incremental: false,
+                preferNetwork: device.connectionType == .wifi
+            )
+        }
+    }
+
+    private func openBackupFolder() {
+        NSWorkspace.shared.open(URL(fileURLWithPath: BackupManager.activeBackupDir, isDirectory: true))
     }
 
     private func confirmFirstFullWiFiBackup(for device: DeviceInfo) -> Bool {

--- a/Sources/Phosphor/Models/Message.swift
+++ b/Sources/Phosphor/Models/Message.swift
@@ -27,7 +27,7 @@ struct MessageChat: Identifiable, Hashable {
             .replacingOccurrences(of: ":", with: "-")
         let contactName = String(sanitized.prefix(80))
         let baseName = contactName.isEmpty ? "Conversation" : contactName
-        let chatIDSuffix = includeChatID ? "-chat-\(id)" : ""
+        let chatIDSuffix = includeChatID ? "-\(id)" : ""
         return "\(baseName)\(chatIDSuffix).\(format.fileExtension)"
     }
 }

--- a/Sources/Phosphor/Models/Message.swift
+++ b/Sources/Phosphor/Models/Message.swift
@@ -18,6 +18,18 @@ struct MessageChat: Identifiable, Hashable {
     var title: String {
         resolvedTitle.isEmpty ? chatIdentifier : resolvedTitle
     }
+
+    /// Keeps the resolved contact/group name in exported filenames while bulk
+    /// exports retain the chat ID suffix that prevents same-name collisions.
+    func exportFilename(format: MessageExportFormat, includeChatID: Bool) -> String {
+        let sanitized = title
+            .replacingOccurrences(of: "/", with: "-")
+            .replacingOccurrences(of: ":", with: "-")
+        let contactName = String(sanitized.prefix(80))
+        let baseName = contactName.isEmpty ? "Conversation" : contactName
+        let chatIDSuffix = includeChatID ? "-chat-\(id)" : ""
+        return "\(baseName)\(chatIDSuffix).\(format.fileExtension)"
+    }
 }
 
 /// Represents a single message within a conversation.

--- a/Sources/Phosphor/Services/BackupManager.swift
+++ b/Sources/Phosphor/Services/BackupManager.swift
@@ -481,6 +481,15 @@ final class BackupManager: ObservableObject {
         preferNetwork: Bool = false,
         onProgress: @escaping (String) -> Void
     ) async -> Bool {
+        guard let backupLease = BackupOperationCoordinator.shared.acquire() else {
+            let message = "Another backup is already running. Wait for it to finish before starting a new backup."
+            backupProgress = message
+            lastError = message
+            onProgress(message)
+            return false
+        }
+        defer { BackupOperationCoordinator.shared.release(backupLease) }
+
         isCreatingBackup = true
         let operationID = beginCancellableOperation()
         backupProgress = "Starting backup..."
@@ -696,6 +705,15 @@ final class BackupManager: ObservableObject {
         preferNetwork: Bool = false,
         onProgress: @escaping (String) -> Void
     ) async -> Bool {
+        guard let backupLease = BackupOperationCoordinator.shared.acquire() else {
+            let message = "Another backup is already running. Wait for it to finish before starting a new backup."
+            backupProgress = message
+            lastError = message
+            onProgress(message)
+            return false
+        }
+        defer { BackupOperationCoordinator.shared.release(backupLease) }
+
         isCreatingBackup = true
         let operationID = beginCancellableOperation()
         backupProgress = "Starting incremental backup..."

--- a/Sources/Phosphor/Services/BackupOperationCoordinator.swift
+++ b/Sources/Phosphor/Services/BackupOperationCoordinator.swift
@@ -1,0 +1,44 @@
+import Combine
+import Foundation
+
+/// Process-wide lease for operations that write iOS backup metadata.
+///
+/// Backup owners deliberately use separate `BackupManager` instances (manual,
+/// scheduled, and clone flows), so instance-local `isCreatingBackup` cannot
+/// prevent two subprocesses from targeting the same backup directory.
+@MainActor
+final class BackupOperationCoordinator: ObservableObject {
+
+    enum Kind: String {
+        case backup = "backup"
+    }
+
+    struct Lease {
+        fileprivate let id: UUID
+    }
+
+    static let shared = BackupOperationCoordinator()
+
+    @Published private(set) var activeKind: Kind?
+    private var activeLeaseID: UUID?
+
+    var isRunning: Bool {
+        activeLeaseID != nil
+    }
+
+    private init() {}
+
+    func acquire(kind: Kind = .backup) -> Lease? {
+        guard activeLeaseID == nil else { return nil }
+        let lease = Lease(id: UUID())
+        activeLeaseID = lease.id
+        activeKind = kind
+        return lease
+    }
+
+    func release(_ lease: Lease) {
+        guard activeLeaseID == lease.id else { return }
+        activeLeaseID = nil
+        activeKind = nil
+    }
+}

--- a/Sources/Phosphor/Services/MessageExporter.swift
+++ b/Sources/Phosphor/Services/MessageExporter.swift
@@ -561,7 +561,7 @@ final class MessageExporter {
         for chat in chats {
             try cancellationCheck?()
             try onProgress?(count, chats.count, chat.title)
-            let filename = exportFilename(for: chat, format: format)
+            let filename = chat.exportFilename(format: format, includeChatID: true)
             let path = (directory as NSString).appendingPathComponent(filename)
             try exportChat(chatId: chat.id, format: format, to: path, options: options, cancellationCheck: cancellationCheck)
             count += 1
@@ -595,14 +595,6 @@ final class MessageExporter {
     }
 
     // MARK: - Private Export Implementations
-
-    private func exportFilename(for chat: MessageChat, format: MessageExportFormat) -> String {
-        let safeName = chat.title
-            .replacingOccurrences(of: "/", with: "-")
-            .replacingOccurrences(of: ":", with: "-")
-            .prefix(50)
-        return "\(safeName)-chat-\(chat.id).\(format.fileExtension)"
-    }
 
     private func exportCSV(messages: [Message], chatTitle: String, to path: String, cancellationCheck: (() throws -> Void)? = nil) throws {
         let outputURL = URL(fileURLWithPath: path)

--- a/Sources/Phosphor/Services/MessageExporter.swift
+++ b/Sources/Phosphor/Services/MessageExporter.swift
@@ -545,6 +545,52 @@ final class MessageExporter {
         try exportMessages(messages, chatTitle: chatTitle, format: format, to: path, options: options, cancellationCheck: cancellationCheck)
     }
 
+    /// Export one conversation as a self-contained PDF bundle with the readable
+    /// originals in `Attachments`. The bundle writer keeps the entire folder
+    /// private until the transcript and attachment copy have both completed.
+    func exportChatPDFBundle(
+        chat: MessageChat,
+        messages: [Message],
+        to parentDirectory: String,
+        options: MessageExportOptions = MessageExportOptions(),
+        cancellationCheck: (() throws -> Void)? = nil
+    ) throws -> MessageExportBundleWriter.Result {
+        let fileManager = FileManager.default
+        var bundleOptions = options
+        bundleOptions.includeAttachments = true
+        let pdfFilename = chat.exportFilename(format: .pdf, includeChatID: false)
+        let directoryName = (pdfFilename as NSString).deletingPathExtension
+        let filteredMessages = bundleOptions.apply(to: messages)
+
+        return try MessageExportBundleWriter.write(
+            in: URL(fileURLWithPath: parentDirectory, isDirectory: true),
+            directoryName: directoryName
+        ) { conversationDirectory in
+            try cancellationCheck?()
+            let attachmentsDirectory = conversationDirectory.appendingPathComponent("Attachments", isDirectory: true)
+            let attachmentMap = try stageOriginalAttachments(
+                messages: filteredMessages,
+                attachmentDirectory: attachmentsDirectory,
+                includeAttachments: true,
+                cancellationCheck: cancellationCheck
+            )
+            if attachmentMap.isEmpty {
+                try fileManager.createDirectory(at: attachmentsDirectory, withIntermediateDirectories: true)
+            }
+
+            try exportMessages(
+                filteredMessages,
+                chatTitle: chat.title,
+                format: .pdf,
+                to: conversationDirectory.appendingPathComponent(pdfFilename).path,
+                options: bundleOptions,
+                attachmentMap: attachmentMap,
+                cancellationCheck: cancellationCheck
+            )
+            return 1
+        }
+    }
+
     /// Export all conversations.
     func exportAllChats(
         format: MessageExportFormat,

--- a/Sources/Phosphor/Services/MessageExporter.swift
+++ b/Sources/Phosphor/Services/MessageExporter.swift
@@ -266,6 +266,11 @@ final class MessageExporter {
             "m.service", "m.cache_has_attachments", "m.is_read",
             "COALESCE(h.id, '') as handle_id"
         ]
+        if messageColumns.contains("attributedBody") {
+            // Keep backup-controlled BLOBs out of the bulk result set. Rows that
+            // need the fallback are loaded and decoded individually below.
+            fields.append(MessageAttributedBodyDecoder.attributedBodyCandidateSQLProjection)
+        }
         for opt in [
             "associated_message_type", "associated_message_guid", "balloon_bundle_id", "payload_data",
             "reply_to_guid", "thread_originator_guid", "thread_originator_part", "expressive_send_style_id",
@@ -334,12 +339,20 @@ final class MessageExporter {
             }
         }
 
+        // Recovered fallback strings are retained in the returned Message array.
+        // Bound their aggregate contribution per query just like each source BLOB.
+        var remainingAttributedBodyTextBytes = 64 * 1024 * 1024
         return primaryRows.compactMap { row in
             let rowId = (row["ROWID"] ?? nil) as? Int
             let guid = (row["guid"] ?? nil) as? String
             let attachments = rowId.flatMap { attachmentsByMessage[$0] } ?? []
             let reactionList = guid.flatMap { reactionsByTarget[$0] } ?? []
-            return parseMessage(row, attachments: attachments, reactions: reactionList)
+            return parseMessage(
+                row,
+                attachments: attachments,
+                reactions: reactionList,
+                remainingAttributedBodyTextBytes: &remainingAttributedBodyTextBytes
+            )
         }
     }
 
@@ -1139,7 +1152,8 @@ final class MessageExporter {
 
     private func parseMessage(_ row: [String: Any?],
                               attachments: [MessageAttachment],
-                              reactions: [Reaction]) -> Message? {
+                              reactions: [Reaction],
+                              remainingAttributedBodyTextBytes: inout Int) -> Message? {
         guard let rowId = row["ROWID"] as? Int,
               let guid = row["guid"] as? String else { return nil }
 
@@ -1154,7 +1168,22 @@ final class MessageExporter {
         let isFromMe = (row["is_from_me"] as? Int) == 1
         let visibleAttachments = attachments.filter { !$0.isPluginPayload }
 
-        let text = row["text"] as? String
+        let plainText = row["text"] as? String
+        let text: String?
+        if let plainText, !plainText.isEmpty {
+            text = plainText
+        } else if let messageId = row["attributed_body_rowid"] as? Int,
+                  let recovered = loadAttributedBodyText(messageId: messageId) {
+            let recoveredByteCount = recovered.utf8.count
+            if recoveredByteCount <= remainingAttributedBodyTextBytes {
+                remainingAttributedBodyTextBytes -= recoveredByteCount
+                text = recovered
+            } else {
+                text = plainText
+            }
+        } else {
+            text = plainText
+        }
         let balloonBundle = row["balloon_bundle_id"] as? String
         let payload = row["payload_data"] as? Data
 
@@ -1188,6 +1217,22 @@ final class MessageExporter {
             linkURL: linkURL,
             balloonBundleID: balloonBundle
         )
+    }
+
+    /// Loads at most one schema- and size-gated attributed body at a time so a
+    /// full chat query never retains every backup-controlled BLOB in memory.
+    private func loadAttributedBodyText(messageId: Int) -> String? {
+        let sql = """
+            SELECT \(MessageAttributedBodyDecoder.attributedBodySQLProjection)
+            FROM message m
+            WHERE m.ROWID = ?
+            LIMIT 1
+        """
+        guard let rows = try? db.query(sql, params: [String(messageId)]),
+              let body = rows.first?["attributedBody"] as? Data else {
+            return nil
+        }
+        return MessageAttributedBodyDecoder.text(from: body)
     }
 
     /// First http(s) URL inside a string, using a cached `NSDataDetector`.

--- a/Sources/Phosphor/Services/MessageExporter.swift
+++ b/Sources/Phosphor/Services/MessageExporter.swift
@@ -849,6 +849,7 @@ final class MessageExporter {
             return PDFTranscriptWriter.Entry(
                 title: msg.senderLabel,
                 subtitle: msg.formattedDate,
+                timestamp: msg.date,
                 body: body,
                 isFromMe: msg.isFromMe,
                 reactions: reactionBadges,

--- a/Sources/Phosphor/Services/MessageExporter.swift
+++ b/Sources/Phosphor/Services/MessageExporter.swift
@@ -570,20 +570,85 @@ final class MessageExporter {
         return count
     }
 
+    /// Export every conversation into its own folder with every supported
+    /// transcript format and one shared folder containing the original files.
+    func exportAllChatsAllFormats(
+        to parentDirectory: String,
+        options: MessageExportOptions = MessageExportOptions(),
+        onProgress: ((Int, Int, String) throws -> Void)? = nil,
+        cancellationCheck: (() throws -> Void)? = nil
+    ) throws -> MessageExportBundleWriter.Result {
+        let chats = try getChats()
+        let fileManager = FileManager.default
+        var bundleOptions = options
+        bundleOptions.includeAttachments = true
+
+        return try MessageExportBundleWriter.write(
+            in: URL(fileURLWithPath: parentDirectory, isDirectory: true)
+        ) { rootDirectory in
+            var count = 0
+            for chat in chats {
+                try cancellationCheck?()
+                try onProgress?(count, chats.count, chat.title)
+
+                let folderFilename = chat.exportFilename(format: .html, includeChatID: true)
+                let folderName = (folderFilename as NSString).deletingPathExtension
+                let conversationDirectory = rootDirectory.appendingPathComponent(folderName, isDirectory: true)
+                try fileManager.createDirectory(at: conversationDirectory, withIntermediateDirectories: true)
+
+                let messages = bundleOptions.apply(to: try getMessages(chatId: chat.id))
+                let attachmentsDirectory = conversationDirectory.appendingPathComponent("Attachments", isDirectory: true)
+                let attachmentMap = try stageOriginalAttachments(
+                    messages: messages,
+                    attachmentDirectory: attachmentsDirectory,
+                    includeAttachments: true,
+                    cancellationCheck: cancellationCheck
+                )
+                if attachmentMap.isEmpty {
+                    try fileManager.createDirectory(at: attachmentsDirectory, withIntermediateDirectories: true)
+                }
+
+                for format in MessageExportFormat.allCases {
+                    try cancellationCheck?()
+                    let filename = chat.exportFilename(format: format, includeChatID: false)
+                    let path = conversationDirectory.appendingPathComponent(filename).path
+                    try exportMessages(
+                        messages,
+                        chatTitle: chat.title,
+                        format: format,
+                        to: path,
+                        options: bundleOptions,
+                        attachmentMap: attachmentMap,
+                        cancellationCheck: cancellationCheck
+                    )
+                }
+                count += 1
+            }
+            try onProgress?(count, chats.count, "Complete")
+            return count
+        }
+    }
+
     func exportMessages(
         _ messages: [Message],
         chatTitle: String,
         format: MessageExportFormat,
         to path: String,
         options: MessageExportOptions = MessageExportOptions(),
+        attachmentMap providedAttachmentMap: [String: String]? = nil,
         cancellationCheck: (() throws -> Void)? = nil
     ) throws {
-        let attachmentMap = try stageOriginalAttachments(
-            messages: messages,
-            exportPath: path,
-            includeAttachments: options.includeAttachments,
-            cancellationCheck: cancellationCheck
-        )
+        let attachmentMap: [String: String]
+        if let providedAttachmentMap {
+            attachmentMap = providedAttachmentMap
+        } else {
+            attachmentMap = try stageOriginalAttachments(
+                messages: messages,
+                exportPath: path,
+                includeAttachments: options.includeAttachments,
+                cancellationCheck: cancellationCheck
+            )
+        }
         switch format {
         case .csv:
             try exportCSV(messages: messages, chatTitle: chatTitle, to: path, cancellationCheck: cancellationCheck)
@@ -758,31 +823,59 @@ final class MessageExporter {
         includeAttachments: Bool,
         cancellationCheck: (() throws -> Void)? = nil
     ) throws -> [String: String] {
-        var seenFilenames: Set<String> = []
-        var items: [MessageAttachmentExporter.Item] = []
-
-        if includeAttachments {
-            for message in messages {
-                try cancellationCheck?()
-                for attachment in message.attachments where !attachment.isPluginPayload {
-                    guard let filename = attachment.filename,
-                          !filename.isEmpty,
-                          seenFilenames.insert(filename).inserted,
-                          let sourcePath = resolveAttachmentDiskPath(filename: filename) else { continue }
-                    items.append(.init(
-                        key: filename,
-                        displayName: attachment.displayName,
-                        sourcePath: sourcePath
-                    ))
-                }
-            }
-        }
-
+        let items = try originalAttachmentItems(
+            messages: messages,
+            includeAttachments: includeAttachments,
+            cancellationCheck: cancellationCheck
+        )
         return try MessageAttachmentExporter.export(
             items,
             beside: exportPath,
             cancellationCheck: cancellationCheck
         )
+    }
+
+    private func stageOriginalAttachments(
+        messages: [Message],
+        attachmentDirectory: URL,
+        includeAttachments: Bool,
+        cancellationCheck: (() throws -> Void)? = nil
+    ) throws -> [String: String] {
+        let items = try originalAttachmentItems(
+            messages: messages,
+            includeAttachments: includeAttachments,
+            cancellationCheck: cancellationCheck
+        )
+        return try MessageAttachmentExporter.export(
+            items,
+            to: attachmentDirectory,
+            cancellationCheck: cancellationCheck
+        )
+    }
+
+    private func originalAttachmentItems(
+        messages: [Message],
+        includeAttachments: Bool,
+        cancellationCheck: (() throws -> Void)? = nil
+    ) throws -> [MessageAttachmentExporter.Item] {
+        guard includeAttachments else { return [] }
+        var seenFilenames: Set<String> = []
+        var items: [MessageAttachmentExporter.Item] = []
+        for message in messages {
+            try cancellationCheck?()
+            for attachment in message.attachments where !attachment.isPluginPayload {
+                guard let filename = attachment.filename,
+                      !filename.isEmpty,
+                      seenFilenames.insert(filename).inserted,
+                      let sourcePath = resolveAttachmentDiskPath(filename: filename) else { continue }
+                items.append(.init(
+                    key: filename,
+                    displayName: attachment.displayName,
+                    sourcePath: sourcePath
+                ))
+            }
+        }
+        return items
     }
 
     private func exportHTML(

--- a/Sources/Phosphor/Services/MessageExporter.swift
+++ b/Sources/Phosphor/Services/MessageExporter.swift
@@ -638,37 +638,44 @@ final class MessageExporter {
         attachmentMap providedAttachmentMap: [String: String]? = nil,
         cancellationCheck: (() throws -> Void)? = nil
     ) throws {
-        let attachmentMap: [String: String]
-        if let providedAttachmentMap {
-            attachmentMap = providedAttachmentMap
-        } else {
-            attachmentMap = try stageOriginalAttachments(
-                messages: messages,
-                exportPath: path,
-                includeAttachments: options.includeAttachments,
-                cancellationCheck: cancellationCheck
-            )
-        }
-        switch format {
-        case .csv:
-            try exportCSV(messages: messages, chatTitle: chatTitle, to: path, cancellationCheck: cancellationCheck)
-        case .txt:
-            try exportPlainText(messages: messages, chatTitle: chatTitle, to: path, cancellationCheck: cancellationCheck)
-        case .pdf:
-            try exportPDF(messages: messages, chatTitle: chatTitle, to: path, includeAttachments: options.includeAttachments, cancellationCheck: cancellationCheck)
-        case .html:
-            try exportHTML(
-                messages: messages,
-                chatTitle: chatTitle,
-                to: path,
-                includeAttachments: options.includeAttachments,
-                attachmentMap: attachmentMap,
-                cancellationCheck: cancellationCheck
-            )
-        case .json:
-            try exportJSON(messages: messages, chatTitle: chatTitle, to: path, cancellationCheck: cancellationCheck)
-        case .mbox:
-            try exportMbox(messages: messages, chatTitle: chatTitle, to: path, includeAttachments: options.includeAttachments, cancellationCheck: cancellationCheck)
+        let finalTranscriptURL = URL(fileURLWithPath: path)
+        let prepareAttachments: (() throws -> MessageAttachmentExporter.Generation)? = providedAttachmentMap == nil
+            ? { [self] in
+                try prepareOriginalAttachmentGeneration(
+                    messages: messages,
+                    exportPath: path,
+                    includeAttachments: options.includeAttachments,
+                    cancellationCheck: cancellationCheck
+                )
+            }
+            : nil
+
+        try MessageExportTransaction.write(
+            to: finalTranscriptURL,
+            attachmentMap: providedAttachmentMap ?? [:],
+            prepareAttachments: prepareAttachments
+        ) { stagedTranscriptURL, attachmentMap in
+            switch format {
+            case .csv:
+                try exportCSV(messages: messages, chatTitle: chatTitle, to: stagedTranscriptURL.path, cancellationCheck: cancellationCheck)
+            case .txt:
+                try exportPlainText(messages: messages, chatTitle: chatTitle, to: stagedTranscriptURL.path, cancellationCheck: cancellationCheck)
+            case .pdf:
+                try exportPDF(messages: messages, chatTitle: chatTitle, to: stagedTranscriptURL.path, includeAttachments: options.includeAttachments, cancellationCheck: cancellationCheck)
+            case .html:
+                try exportHTML(
+                    messages: messages,
+                    chatTitle: chatTitle,
+                    to: stagedTranscriptURL.path,
+                    includeAttachments: options.includeAttachments,
+                    attachmentMap: attachmentMap,
+                    cancellationCheck: cancellationCheck
+                )
+            case .json:
+                try exportJSON(messages: messages, chatTitle: chatTitle, to: stagedTranscriptURL.path, cancellationCheck: cancellationCheck)
+            case .mbox:
+                try exportMbox(messages: messages, chatTitle: chatTitle, to: stagedTranscriptURL.path, includeAttachments: options.includeAttachments, cancellationCheck: cancellationCheck)
+            }
         }
     }
 
@@ -817,18 +824,18 @@ final class MessageExporter {
 
     /// Resolve user-visible attachment blobs and stage originals beside every
     /// transcript format. Rich-link plugin payloads remain internal metadata.
-    private func stageOriginalAttachments(
+    private func prepareOriginalAttachmentGeneration(
         messages: [Message],
         exportPath: String,
         includeAttachments: Bool,
         cancellationCheck: (() throws -> Void)? = nil
-    ) throws -> [String: String] {
+    ) throws -> MessageAttachmentExporter.Generation {
         let items = try originalAttachmentItems(
             messages: messages,
             includeAttachments: includeAttachments,
             cancellationCheck: cancellationCheck
         )
-        return try MessageAttachmentExporter.export(
+        return try MessageAttachmentExporter.prepareGeneration(
             items,
             beside: exportPath,
             cancellationCheck: cancellationCheck

--- a/Sources/Phosphor/Services/MessageExporter.swift
+++ b/Sources/Phosphor/Services/MessageExporter.swift
@@ -681,13 +681,33 @@ final class MessageExporter {
 
         let entries = messages.map { msg -> PDFTranscriptWriter.Entry in
             let visibleAttachments = includeAttachments ? msg.attachments.filter { !$0.isPluginPayload } : []
-            let body = (msg.text?.isEmpty == false) ? (msg.text ?? "") : msg.displayText
+            let body: String
+            if msg.text?.isEmpty == false {
+                body = msg.text ?? ""
+            } else if !visibleAttachments.isEmpty || msg.linkURL != nil {
+                // The attachment/link card is the visible message content. Avoid
+                // adding a redundant "[Attachment]" transcript line beneath it.
+                body = ""
+            } else {
+                body = msg.displayText
+            }
             let reactionBadges = msg.reactions.map { $0.type.emoji }
-            let attachmentSummaries = visibleAttachments.map { attachment in
+            var renderedImageCount = 0
+            let pdfAttachments = visibleAttachments.map { attachment in
                 var parts: [String] = [attachment.displayName]
                 if let mime = attachment.mimeType, !mime.isEmpty { parts.append(mime) }
                 if attachment.totalBytes > 0 { parts.append(ByteCountFormatter.string(fromByteCount: Int64(attachment.totalBytes), countStyle: .file)) }
-                return parts.joined(separator: " • ")
+                var imagePath: String?
+                if attachment.isImage,
+                   renderedImageCount < 3,
+                   let filename = attachment.filename {
+                    imagePath = resolveAttachmentDiskPath(filename: filename)
+                    if imagePath != nil { renderedImageCount += 1 }
+                }
+                return PDFTranscriptWriter.Attachment(
+                    summary: parts.joined(separator: " • "),
+                    imagePath: imagePath
+                )
             }
             // Keep PDF exports conversation-like: don't print "iMessage" or
             // read/unread under every bubble. Surface the service only when it
@@ -702,7 +722,7 @@ final class MessageExporter {
                 isFromMe: msg.isFromMe,
                 reactions: reactionBadges,
                 inlineReply: replyPreview(for: msg),
-                attachments: attachmentSummaries,
+                attachments: pdfAttachments,
                 linkURL: msg.linkURL,
                 status: statusParts.isEmpty ? nil : statusParts.joined(separator: " • ")
             )

--- a/Sources/Phosphor/Services/MessageExporter.swift
+++ b/Sources/Phosphor/Services/MessageExporter.swift
@@ -578,6 +578,12 @@ final class MessageExporter {
         options: MessageExportOptions = MessageExportOptions(),
         cancellationCheck: (() throws -> Void)? = nil
     ) throws {
+        let attachmentMap = try stageOriginalAttachments(
+            messages: messages,
+            exportPath: path,
+            includeAttachments: options.includeAttachments,
+            cancellationCheck: cancellationCheck
+        )
         switch format {
         case .csv:
             try exportCSV(messages: messages, chatTitle: chatTitle, to: path, cancellationCheck: cancellationCheck)
@@ -586,7 +592,14 @@ final class MessageExporter {
         case .pdf:
             try exportPDF(messages: messages, chatTitle: chatTitle, to: path, includeAttachments: options.includeAttachments, cancellationCheck: cancellationCheck)
         case .html:
-            try exportHTML(messages: messages, chatTitle: chatTitle, to: path, includeAttachments: options.includeAttachments, cancellationCheck: cancellationCheck)
+            try exportHTML(
+                messages: messages,
+                chatTitle: chatTitle,
+                to: path,
+                includeAttachments: options.includeAttachments,
+                attachmentMap: attachmentMap,
+                cancellationCheck: cancellationCheck
+            )
         case .json:
             try exportJSON(messages: messages, chatTitle: chatTitle, to: path, cancellationCheck: cancellationCheck)
         case .mbox:
@@ -737,66 +750,49 @@ final class MessageExporter {
         )
     }
 
-    /// Copy referenced attachments into a sibling `<export>_attachments` folder so the
-    /// HTML can <img>/<a href> them. Returns map of attachment filename -> relative
-    /// path used inside the HTML. Failures are silent: attachments missing from the
-    /// backup just stay as text annotations.
-    ///
-    /// Plugin payload blobs (rich-link metadata) are skipped because they are
-    /// binary plists that macOS has no handler for and would clutter the export
-    /// folder with `*.pluginPayloadAttachment` files (issue #17).
-    private func stageAttachments(messages: [Message], htmlPath: String, cancellationCheck: (() throws -> Void)? = nil) throws -> [String: String] {
-        let baseName = (htmlPath as NSString).deletingPathExtension
-        let dir = "\(baseName)_attachments"
-        let fm = FileManager.default
-        var map: [String: String] = [:]
-        var folderCreated = false
+    /// Resolve user-visible attachment blobs and stage originals beside every
+    /// transcript format. Rich-link plugin payloads remain internal metadata.
+    private func stageOriginalAttachments(
+        messages: [Message],
+        exportPath: String,
+        includeAttachments: Bool,
+        cancellationCheck: (() throws -> Void)? = nil
+    ) throws -> [String: String] {
+        var seenFilenames: Set<String> = []
+        var items: [MessageAttachmentExporter.Item] = []
 
-        for msg in messages {
-            try cancellationCheck?()
-            for attachment in msg.attachments {
-                guard !attachment.isPluginPayload else { continue }
-                guard let filename = attachment.filename, !filename.isEmpty else { continue }
-                if map[filename] != nil { continue }
-                guard let source = resolveAttachmentDiskPath(filename: filename) else { continue }
-
-                if !folderCreated {
-                    try? fm.createDirectory(atPath: dir, withIntermediateDirectories: true)
-                    folderCreated = true
-                }
-
-                let displayName = (filename as NSString).lastPathComponent
-                var unique = displayName
-                var dest = (dir as NSString).appendingPathComponent(unique)
-                var i = 2
-                while fm.fileExists(atPath: dest) {
-                    let ext = (displayName as NSString).pathExtension
-                    let stem = (displayName as NSString).deletingPathExtension
-                    unique = ext.isEmpty ? "\(stem)-\(i)" : "\(stem)-\(i).\(ext)"
-                    dest = (dir as NSString).appendingPathComponent(unique)
-                    i += 1
-                }
-                do {
-                    try fm.copyItem(atPath: source, toPath: dest)
-                    let folderName = (dir as NSString).lastPathComponent
-                    map[filename] = "\(folderName)/\(unique)"
-                } catch {
-                    continue
+        if includeAttachments {
+            for message in messages {
+                try cancellationCheck?()
+                for attachment in message.attachments where !attachment.isPluginPayload {
+                    guard let filename = attachment.filename,
+                          !filename.isEmpty,
+                          seenFilenames.insert(filename).inserted,
+                          let sourcePath = resolveAttachmentDiskPath(filename: filename) else { continue }
+                    items.append(.init(
+                        key: filename,
+                        displayName: attachment.displayName,
+                        sourcePath: sourcePath
+                    ))
                 }
             }
         }
-        return map
+
+        return try MessageAttachmentExporter.export(
+            items,
+            beside: exportPath,
+            cancellationCheck: cancellationCheck
+        )
     }
 
-    private func removeAttachmentFolder(forHTMLPath htmlPath: String) {
-        let baseName = (htmlPath as NSString).deletingPathExtension
-        let dir = "\(baseName)_attachments"
-        try? FileManager.default.removeItem(atPath: dir)
-    }
-
-    private func exportHTML(messages: [Message], chatTitle: String, to path: String, includeAttachments: Bool = true, cancellationCheck: (() throws -> Void)? = nil) throws {
-        removeAttachmentFolder(forHTMLPath: path)
-        let attachmentMap = includeAttachments ? try stageAttachments(messages: messages, htmlPath: path, cancellationCheck: cancellationCheck) : [:]
+    private func exportHTML(
+        messages: [Message],
+        chatTitle: String,
+        to path: String,
+        includeAttachments: Bool = true,
+        attachmentMap: [String: String],
+        cancellationCheck: (() throws -> Void)? = nil
+    ) throws {
         let outputURL = URL(fileURLWithPath: path)
         try? FileManager.default.removeItem(at: outputURL)
         FileManager.default.createFile(atPath: path, contents: nil)
@@ -879,7 +875,7 @@ final class MessageExporter {
                 bubbleHTML += text
             }
 
-            for attachment in msg.attachments where !attachment.isPluginPayload {
+            for attachment in msg.attachments where includeAttachments && !attachment.isPluginPayload {
                 guard let filename = attachment.filename,
                       let relPath = attachmentMap[filename] else {
                     if !bubbleHTML.isEmpty { bubbleHTML += "<br>" }
@@ -887,13 +883,14 @@ final class MessageExporter {
                     continue
                 }
                 if !bubbleHTML.isEmpty { bubbleHTML += "<br>" }
+                let relativeURL = MessageAttachmentExporter.relativeURL(for: relPath)
                 if attachment.isImage {
-                    bubbleHTML += "<img class=\"attach-img\" src=\"\(htmlEscape(relPath))\" loading=\"lazy\">"
+                    bubbleHTML += "<img class=\"attach-img\" src=\"\(htmlEscape(relativeURL))\" loading=\"lazy\">"
                 } else if attachment.isVideo {
-                    bubbleHTML += "<video class=\"attach-video\" controls src=\"\(htmlEscape(relPath))\"></video>"
+                    bubbleHTML += "<video class=\"attach-video\" controls src=\"\(htmlEscape(relativeURL))\"></video>"
                 } else {
                     let name = (relPath as NSString).lastPathComponent
-                    bubbleHTML += "<a class=\"attach-link\" href=\"\(htmlEscape(relPath))\">\(htmlEscape(name))</a>"
+                    bubbleHTML += "<a class=\"attach-link\" href=\"\(htmlEscape(relativeURL))\">\(htmlEscape(name))</a>"
                 }
             }
 

--- a/Sources/Phosphor/Services/WhatsAppExporter.swift
+++ b/Sources/Phosphor/Services/WhatsAppExporter.swift
@@ -14,6 +14,9 @@ import Foundation
 final class WhatsAppExporter {
 
     private let db: SQLiteReader
+    private let manifest: BackupManifest?
+    private var mediaPathCache: [String: String] = [:]
+    private var missingMediaPaths: Set<String> = []
 
     struct WAChat: Identifiable, Hashable {
         let id: Int
@@ -26,10 +29,19 @@ final class WhatsAppExporter {
 
         var displayName: String {
             if !partnerName.isEmpty { return partnerName }
-            // Clean up JID: "+1234567890@s.whatsapp.net" -> "+1234567890"
+            // Clean up JID: "+123****7890@s.whatsapp.net" -> "+123****7890"
             return contactJid
                 .replacingOccurrences(of: "@s.whatsapp.net", with: "")
                 .replacingOccurrences(of: "@g.us", with: " (Group)")
+        }
+
+        func exportFilename(format: MessageExportFormat, includeChatID: Bool) -> String {
+            let sanitized = displayName
+                .replacingOccurrences(of: "/", with: "-")
+                .replacingOccurrences(of: ":", with: "-")
+            let contactName = String(sanitized.prefix(80))
+            let baseName = contactName.isEmpty ? "WhatsApp Conversation" : contactName
+            return "\(baseName)\(includeChatID ? "-\(id)" : "").\(format.fileExtension)"
         }
     }
 
@@ -67,8 +79,9 @@ final class WhatsAppExporter {
         }
     }
 
-    init(databasePath: String) throws {
+    init(databasePath: String, manifest: BackupManifest? = nil) throws {
         self.db = try SQLiteReader(path: databasePath)
+        self.manifest = manifest
     }
 
     /// Initialize from a backup by finding WhatsApp's ChatStorage.sqlite.
@@ -82,7 +95,7 @@ final class WhatsAppExporter {
                 throw NSError(domain: "Phosphor", code: 404,
                               userInfo: [NSLocalizedDescriptionKey: "WhatsApp database file not found on disk"])
             }
-            try self.init(databasePath: filePath)
+            try self.init(databasePath: filePath, manifest: manifest)
             return
         }
 
@@ -91,7 +104,7 @@ final class WhatsAppExporter {
         for candidate in candidates where candidate.isFile {
             let filePath = try manifest.readablePath(for: candidate)
             if FileManager.default.fileExists(atPath: filePath) {
-                try self.init(databasePath: filePath)
+                try self.init(databasePath: filePath, manifest: manifest)
                 return
             }
         }
@@ -192,49 +205,283 @@ final class WhatsAppExporter {
 
     // MARK: - Export
 
-    func exportChat(chatId: Int, format: MessageExportFormat, to path: String) throws {
-        let messages = try getMessages(chatId: chatId)
-        let chats = try getChats()
-        let chat = chats.first { $0.id == chatId }
-        let chatTitle = chat?.displayName ?? "WhatsApp Chat"
+    func exportChat(
+        chatId: Int,
+        format: MessageExportFormat,
+        to path: String,
+        options: MessageExportOptions = MessageExportOptions(),
+        cancellationCheck: (() throws -> Void)? = nil
+    ) throws {
+        try cancellationCheck?()
+        let messages = filtered(try getMessages(chatId: chatId), options: options)
+        let chat = try getChats().first { $0.id == chatId }
+        try exportMessages(
+            messages,
+            title: chat?.displayName ?? "WhatsApp Chat",
+            format: format,
+            to: path,
+            options: options,
+            cancellationCheck: cancellationCheck
+        )
+    }
 
-        switch format {
-        case .csv:
-            try exportCSV(messages: messages, title: chatTitle, to: path)
-        case .txt:
-            try exportTXT(messages: messages, title: chatTitle, to: path)
-        case .pdf:
-            try exportPDF(messages: messages, title: chatTitle, to: path)
-        case .html:
-            try exportHTML(messages: messages, title: chatTitle, to: path)
-        case .json:
-            try exportJSON(messages: messages, title: chatTitle, to: path)
-        case .mbox:
-            // WhatsApp export reuses the iMessage MBOX writer via a minimal shim:
-            // serialise to TXT for now since WhatsApp media live in a separate
-            // ChatStorage layout. MBOX support tracked for iMessage in issue #13.
-            try exportTXT(messages: messages, title: chatTitle, to: path)
+    func exportChatPDFBundle(
+        chat: WAChat,
+        messages: [WAMessage],
+        to parentDirectory: String,
+        options: MessageExportOptions = MessageExportOptions(),
+        cancellationCheck: (() throws -> Void)? = nil
+    ) throws -> MessageExportBundleWriter.Result {
+        var bundleOptions = options
+        bundleOptions.includeAttachments = true
+        let filteredMessages = filtered(messages, options: bundleOptions)
+        let filename = chat.exportFilename(format: .pdf, includeChatID: false)
+        let directoryName = (filename as NSString).deletingPathExtension
+        return try MessageExportBundleWriter.write(
+            in: URL(fileURLWithPath: parentDirectory, isDirectory: true),
+            directoryName: directoryName
+        ) { conversationDirectory in
+            let attachmentsDirectory = conversationDirectory.appendingPathComponent("Attachments", isDirectory: true)
+            let attachmentMap = try stageMedia(
+                messages: filteredMessages,
+                to: attachmentsDirectory,
+                cancellationCheck: cancellationCheck
+            )
+            if attachmentMap.isEmpty {
+                try FileManager.default.createDirectory(at: attachmentsDirectory, withIntermediateDirectories: true)
+            }
+            try exportMessages(
+                filteredMessages,
+                title: chat.displayName,
+                format: .pdf,
+                to: conversationDirectory.appendingPathComponent(filename).path,
+                options: bundleOptions,
+                attachmentMap: attachmentMap,
+                cancellationCheck: cancellationCheck
+            )
+            return 1
         }
     }
 
-    func exportAllChats(format: MessageExportFormat, to directory: String) throws -> Int {
+    func exportAllChats(
+        format: MessageExportFormat,
+        to parentDirectory: String,
+        options: MessageExportOptions = MessageExportOptions(),
+        onProgress: ((Int, Int, String) throws -> Void)? = nil,
+        cancellationCheck: (() throws -> Void)? = nil
+    ) throws -> MessageExportBundleWriter.Result {
         let chats = try getChats()
-        try FileManager.default.createDirectory(atPath: directory, withIntermediateDirectories: true)
+        return try MessageExportBundleWriter.write(
+            in: URL(fileURLWithPath: parentDirectory, isDirectory: true),
+            directoryName: "WhatsApp \(format.fileExtension.uppercased()) Export"
+        ) { exportDirectory in
+            for (index, chat) in chats.enumerated() {
+                try cancellationCheck?()
+                try onProgress?(index, chats.count, chat.displayName)
+                let path = exportDirectory.appendingPathComponent(
+                    chat.exportFilename(format: format, includeChatID: true)
+                ).path
+                try exportChat(
+                    chatId: chat.id,
+                    format: format,
+                    to: path,
+                    options: options,
+                    cancellationCheck: cancellationCheck
+                )
+            }
+            try onProgress?(chats.count, chats.count, "Complete")
+            return chats.count
+        }
+    }
 
+    func exportAllChatsAllFormats(
+        to parentDirectory: String,
+        options: MessageExportOptions = MessageExportOptions(),
+        onProgress: ((Int, Int, String) throws -> Void)? = nil,
+        cancellationCheck: (() throws -> Void)? = nil
+    ) throws -> MessageExportBundleWriter.Result {
+        let chats = try getChats()
+        var bundleOptions = options
+        bundleOptions.includeAttachments = true
+        return try MessageExportBundleWriter.write(
+            in: URL(fileURLWithPath: parentDirectory, isDirectory: true),
+            directoryName: "WhatsApp Export"
+        ) { rootDirectory in
+            for (index, chat) in chats.enumerated() {
+                try cancellationCheck?()
+                try onProgress?(index, chats.count, chat.displayName)
+                let folderName = (chat.exportFilename(format: .html, includeChatID: true) as NSString)
+                    .deletingPathExtension
+                let conversationDirectory = rootDirectory.appendingPathComponent(folderName, isDirectory: true)
+                try FileManager.default.createDirectory(at: conversationDirectory, withIntermediateDirectories: true)
+                let messages = filtered(try getMessages(chatId: chat.id), options: bundleOptions)
+                let attachmentsDirectory = conversationDirectory.appendingPathComponent("Attachments", isDirectory: true)
+                let attachmentMap = try stageMedia(
+                    messages: messages,
+                    to: attachmentsDirectory,
+                    cancellationCheck: cancellationCheck
+                )
+                if attachmentMap.isEmpty {
+                    try FileManager.default.createDirectory(at: attachmentsDirectory, withIntermediateDirectories: true)
+                }
+                for format in MessageExportFormat.allCases {
+                    try cancellationCheck?()
+                    try exportMessages(
+                        messages,
+                        title: chat.displayName,
+                        format: format,
+                        to: conversationDirectory.appendingPathComponent(
+                            chat.exportFilename(format: format, includeChatID: false)
+                        ).path,
+                        options: bundleOptions,
+                        attachmentMap: attachmentMap,
+                        cancellationCheck: cancellationCheck
+                    )
+                }
+            }
+            try onProgress?(chats.count, chats.count, "Complete")
+            return chats.count
+        }
+    }
+
+    func exportMessages(
+        _ messages: [WAMessage],
+        title: String,
+        format: MessageExportFormat,
+        to path: String,
+        options: MessageExportOptions = MessageExportOptions(),
+        attachmentMap providedAttachmentMap: [String: String]? = nil,
+        cancellationCheck: (() throws -> Void)? = nil
+    ) throws {
+        let finalURL = URL(fileURLWithPath: path)
+        let prepareAttachments: (() throws -> MessageAttachmentExporter.Generation)? = providedAttachmentMap == nil
+            ? { [self] in
+                try prepareMediaGeneration(
+                    messages: messages,
+                    beside: path,
+                    includeAttachments: options.includeAttachments,
+                    cancellationCheck: cancellationCheck
+                )
+            }
+            : nil
+        try MessageExportTransaction.write(
+            to: finalURL,
+            attachmentMap: providedAttachmentMap ?? [:],
+            prepareAttachments: prepareAttachments
+        ) { stagedURL, attachmentMap in
+            switch format {
+            case .csv:
+                try exportCSV(messages: messages, title: title, to: stagedURL.path, cancellationCheck: cancellationCheck)
+            case .txt:
+                try exportTXT(messages: messages, title: title, to: stagedURL.path, cancellationCheck: cancellationCheck)
+            case .pdf:
+                try exportPDF(messages: messages, title: title, to: stagedURL.path, attachmentMap: attachmentMap, cancellationCheck: cancellationCheck)
+            case .html:
+                try exportHTML(messages: messages, title: title, to: stagedURL.path, attachmentMap: attachmentMap, cancellationCheck: cancellationCheck)
+            case .json:
+                try exportJSON(messages: messages, title: title, to: stagedURL.path, cancellationCheck: cancellationCheck)
+            case .mbox:
+                try exportMbox(messages: messages, title: title, to: stagedURL.path, attachmentMap: attachmentMap, cancellationCheck: cancellationCheck)
+            }
+        }
+    }
+
+    // MARK: - Private
+
+    private func filtered(_ messages: [WAMessage], options: MessageExportOptions) -> [WAMessage] {
+        messages.filter { message in
+            if let startDate = options.startDate, message.date < startDate { return false }
+            if let endDate = options.endDate, message.date > endDate { return false }
+            return true
+        }
+    }
+
+    private func mediaItems(for messages: [WAMessage]) -> [MessageAttachmentExporter.Item] {
+        messages.compactMap { message in
+            guard let localPath = message.mediaLocalPath,
+                  let sourcePath = resolveMediaDiskPath(localPath) else { return nil }
+            let displayName = (localPath as NSString).lastPathComponent.isEmpty
+                ? "WhatsApp Media-\(message.id)"
+                : (localPath as NSString).lastPathComponent
+            return MessageAttachmentExporter.Item(
+                key: String(message.id),
+                displayName: displayName,
+                sourcePath: sourcePath
+            )
+        }
+    }
+
+    private func prepareMediaGeneration(
+        messages: [WAMessage],
+        beside path: String,
+        includeAttachments: Bool,
+        cancellationCheck: (() throws -> Void)?
+    ) throws -> MessageAttachmentExporter.Generation {
+        try MessageAttachmentExporter.prepareGeneration(
+            includeAttachments ? mediaItems(for: messages) : [],
+            beside: path,
+            cancellationCheck: cancellationCheck
+        )
+    }
+
+    private func stageMedia(
+        messages: [WAMessage],
+        to directory: URL,
+        cancellationCheck: (() throws -> Void)?
+    ) throws -> [String: String] {
+        try MessageAttachmentExporter.export(
+            mediaItems(for: messages),
+            to: directory,
+            cancellationCheck: cancellationCheck
+        )
+    }
+
+    private func resolveMediaDiskPath(_ localPath: String) -> String? {
+        if let cached = mediaPathCache[localPath] { return cached }
+        if missingMediaPaths.contains(localPath) { return nil }
+        guard let manifest else { return nil }
+
+        let normalized = localPath
+            .replacingOccurrences(of: "file://", with: "")
+            .replacingOccurrences(of: "/private/var/mobile/Containers/Shared/AppGroup/", with: "")
+            .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        let filename = (normalized as NSString).lastPathComponent
+        let candidates = ((try? manifest.search(filename)) ?? []).filter {
+            $0.isFile
+                && $0.domain.localizedCaseInsensitiveContains("whatsapp")
+                && $0.fileName == filename
+        }
+        let exactEntry = candidates.first {
+            $0.relativePath == normalized || normalized.hasSuffix("/\($0.relativePath)")
+        }
+        let ranked = candidates.map { candidate in
+            (entry: candidate, score: Self.commonPathSuffixLength(candidate.relativePath, normalized))
+        }.sorted { $0.score > $1.score }
+        let bestSuffixEntry: BackupManifest.FileEntry? = {
+            guard let first = ranked.first, first.score >= 2 else { return nil }
+            guard ranked.dropFirst().first?.score != first.score else { return nil }
+            return first.entry
+        }()
+        let entry = exactEntry ?? bestSuffixEntry ?? (candidates.count == 1 ? candidates[0] : nil)
+        guard let entry, let path = try? manifest.readablePath(for: entry),
+              FileManager.default.fileExists(atPath: path) else {
+            missingMediaPaths.insert(localPath)
+            return nil
+        }
+        mediaPathCache[localPath] = path
+        return path
+    }
+
+    private static func commonPathSuffixLength(_ lhs: String, _ rhs: String) -> Int {
+        let left = lhs.split(separator: "/")
+        let right = rhs.split(separator: "/")
         var count = 0
-        for chat in chats {
-            let safeName = chat.displayName
-                .replacingOccurrences(of: "/", with: "-")
-                .replacingOccurrences(of: ":", with: "-")
-                .prefix(50)
-            let path = (directory as NSString).appendingPathComponent("\(safeName).\(format.fileExtension)")
-            try exportChat(chatId: chat.id, format: format, to: path)
+        while count < min(left.count, right.count),
+              left[left.count - 1 - count] == right[right.count - 1 - count] {
             count += 1
         }
         return count
     }
-
-    // MARK: - Private
 
     private func parseMessage(_ row: [String: Any?]) -> WAMessage? {
         guard let pk = row["Z_PK"] as? Int else { return nil }
@@ -260,34 +507,46 @@ final class WhatsAppExporter {
         )
     }
 
-    private func exportCSV(messages: [WAMessage], title: String, to path: String) throws {
+    private func exportCSV(messages: [WAMessage], title: String, to path: String, cancellationCheck: (() throws -> Void)? = nil) throws {
         var csv = "Date,Sender,Text,Media Type\n"
         for msg in messages {
+            try cancellationCheck?()
             let sender = msg.isFromMe ? "Me" : (msg.senderJid ?? "Unknown")
             csv += CSVExport.row([msg.formattedDate, sender, msg.displayText, msg.mediaTypeLabel])
         }
         try csv.write(toFile: path, atomically: true, encoding: .utf8)
     }
 
-    private func exportTXT(messages: [WAMessage], title: String, to path: String) throws {
+    private func exportTXT(messages: [WAMessage], title: String, to path: String, cancellationCheck: (() throws -> Void)? = nil) throws {
         var lines = "WhatsApp Chat: \(title)\n"
         lines += "Exported by Phosphor\n"
         lines += String(repeating: "-", count: 60) + "\n\n"
         for msg in messages {
+            try cancellationCheck?()
             let sender = msg.isFromMe ? "Me" : (msg.senderJid ?? "Unknown")
             lines += "[\(msg.formattedDate)] \(sender):\n\(msg.displayText)\n\n"
         }
         try lines.write(toFile: path, atomically: true, encoding: .utf8)
     }
 
-    private func exportPDF(messages: [WAMessage], title: String, to path: String) throws {
-        let entries = messages.map { msg in
-            PDFTranscriptWriter.Entry(
+    private func exportPDF(messages: [WAMessage], title: String, to path: String, attachmentMap: [String: String], cancellationCheck: (() throws -> Void)? = nil) throws {
+        let entries = try messages.map { msg in
+            try cancellationCheck?()
+            let relativePath = attachmentMap[String(msg.id)]
+            let absolutePath = relativePath.map {
+                URL(fileURLWithPath: path).deletingLastPathComponent().appendingPathComponent($0).path
+            }
+            let attachments: [PDFTranscriptWriter.Attachment] = relativePath.map { _ in
+                [.init(summary: (msg.mediaLocalPath as NSString?)?.lastPathComponent ?? msg.mediaTypeLabel,
+                       imagePath: (msg.mediaType == 1 || msg.mediaType == 9 || msg.mediaType == 15) ? absolutePath : nil)]
+            } ?? []
+            return PDFTranscriptWriter.Entry(
                 title: msg.isFromMe ? "Me" : (msg.senderJid ?? "Unknown"),
                 subtitle: msg.formattedDate,
                 timestamp: msg.date,
                 body: msg.displayText,
-                isFromMe: msg.isFromMe
+                isFromMe: msg.isFromMe,
+                attachments: attachments
             )
         }
         try PDFTranscriptWriter.write(
@@ -298,7 +557,7 @@ final class WhatsAppExporter {
         )
     }
 
-    private func exportHTML(messages: [WAMessage], title: String, to path: String) throws {
+    private func exportHTML(messages: [WAMessage], title: String, to path: String, attachmentMap: [String: String], cancellationCheck: (() throws -> Void)? = nil) throws {
         var html = """
         <!DOCTYPE html>
         <html lang="en"><head><meta charset="UTF-8">
@@ -321,6 +580,7 @@ final class WhatsAppExporter {
         """
 
         for msg in messages {
+            try cancellationCheck?()
             let cls = msg.isFromMe ? "me" : ""
             let bubble = msg.isFromMe ? "from-me" : "from-them"
             let text = msg.displayText.htmlEscaped
@@ -332,6 +592,10 @@ final class WhatsAppExporter {
             }
             if msg.mediaType != 0 {
                 html += "<span class=\"media\">\(text)</span>"
+                if let relativePath = attachmentMap[String(msg.id)] {
+                    let href = MessageAttachmentExporter.relativeURL(for: relativePath).htmlEscaped
+                    html += "<br><a href=\"\(href)\">Open original attachment</a>"
+                }
             } else {
                 html += text
             }
@@ -342,9 +606,106 @@ final class WhatsAppExporter {
         try html.write(toFile: path, atomically: true, encoding: .utf8)
     }
 
-    private func exportJSON(messages: [WAMessage], title: String, to path: String) throws {
-        let entries: [[String: Any]] = messages.map { msg in
-            [
+    private func exportMbox(
+        messages: [WAMessage],
+        title: String,
+        to path: String,
+        attachmentMap: [String: String],
+        cancellationCheck: (() throws -> Void)? = nil
+    ) throws {
+        let crlf = "\r\n"
+        let envelopeFormatter = DateFormatter()
+        envelopeFormatter.locale = Locale(identifier: "en_US_POSIX")
+        envelopeFormatter.timeZone = TimeZone(identifier: "UTC")
+        envelopeFormatter.dateFormat = "EEE MMM d HH:mm:ss yyyy"
+        let headerFormatter = DateFormatter()
+        headerFormatter.locale = Locale(identifier: "en_US_POSIX")
+        headerFormatter.dateFormat = "EEE, d MMM yyyy HH:mm:ss Z"
+        let transcriptURL = URL(fileURLWithPath: path)
+        var output = ""
+
+        for message in messages {
+            try cancellationCheck?()
+            let sender = message.isFromMe ? "Me" : (message.senderJid ?? "Unknown")
+            let relativePath = attachmentMap[String(message.id)]
+            let attachmentURL = relativePath.map {
+                transcriptURL.deletingLastPathComponent().appendingPathComponent($0)
+            }
+            let attachmentData = attachmentURL.flatMap { try? Data(contentsOf: $0) }
+            let attachmentName = attachmentURL?.lastPathComponent ?? "WhatsApp Media"
+
+            output += "From phosphor@localhost \(envelopeFormatter.string(from: message.date))\(crlf)"
+            output += "Date: \(headerFormatter.string(from: message.date))\(crlf)"
+            output += "From: \(mboxHeaderValue(sender)) <phosphor@localhost>\(crlf)"
+            output += "Subject: \(mboxHeaderValue("WhatsApp - \(title)"))\(crlf)"
+            output += "Message-ID: <whatsapp-\(message.id)@phosphor.local>\(crlf)"
+            output += "MIME-Version: 1.0\(crlf)"
+
+            if let attachmentData {
+                let boundary = "----=_Phosphor_WhatsApp_\(message.id)_\(UUID().uuidString)"
+                output += "Content-Type: multipart/mixed; boundary=\"\(boundary)\"\(crlf)\(crlf)"
+                output += "--\(boundary)\(crlf)"
+                output += "Content-Type: text/plain; charset=UTF-8\(crlf)"
+                output += "Content-Transfer-Encoding: 8bit\(crlf)\(crlf)"
+                output += mboxEscape(message.displayText) + crlf + crlf
+                output += "--\(boundary)\(crlf)"
+                output += "Content-Type: \(mediaMIMEType(message.mediaType, filename: attachmentName)); name=\"\(mboxHeaderValue(attachmentName))\"\(crlf)"
+                output += "Content-Disposition: attachment; filename=\"\(mboxHeaderValue(attachmentName))\"\(crlf)"
+                output += "Content-Transfer-Encoding: base64\(crlf)\(crlf)"
+                output += attachmentData.base64EncodedString(options: [.lineLength76Characters, .endLineWithCarriageReturn, .endLineWithLineFeed])
+                output += crlf + "--\(boundary)--\(crlf)\(crlf)"
+            } else {
+                output += "Content-Type: text/plain; charset=UTF-8\(crlf)"
+                output += "Content-Transfer-Encoding: 8bit\(crlf)\(crlf)"
+                var body = message.displayText
+                if relativePath != nil { body += "\n\n[Attachment unavailable: \(attachmentName)]" }
+                output += mboxEscape(body) + crlf + crlf
+            }
+        }
+        try output.write(toFile: path, atomically: true, encoding: .utf8)
+    }
+
+    private func mboxEscape(_ body: String) -> String {
+        body.components(separatedBy: "\n").map {
+            $0.hasPrefix("From ") ? ">" + $0 : $0
+        }.joined(separator: "\r\n")
+    }
+
+    private func mboxHeaderValue(_ raw: String) -> String {
+        let sanitized = raw
+            .replacingOccurrences(of: "\r", with: " ")
+            .replacingOccurrences(of: "\n", with: " ")
+            .replacingOccurrences(of: "\"", with: "'")
+        guard !sanitized.allSatisfy({ $0.isASCII }) else { return sanitized }
+        return "=?UTF-8?B?\(Data(sanitized.utf8).base64EncodedString())?="
+    }
+
+    private func mediaMIMEType(_ mediaType: Int, filename: String) -> String {
+        switch (filename as NSString).pathExtension.lowercased() {
+        case "jpg", "jpeg": return "image/jpeg"
+        case "png": return "image/png"
+        case "gif": return "image/gif"
+        case "heic", "heif": return "image/heic"
+        case "mp4", "m4v": return "video/mp4"
+        case "mov": return "video/quicktime"
+        case "mp3": return "audio/mpeg"
+        case "m4a": return "audio/mp4"
+        case "ogg", "opus": return "audio/ogg"
+        case "pdf": return "application/pdf"
+        default:
+            switch mediaType {
+            case 1, 9, 15: return "image/jpeg"
+            case 2: return "video/mp4"
+            case 3: return "audio/mpeg"
+            default: return "application/octet-stream"
+            }
+        }
+    }
+
+    private func exportJSON(messages: [WAMessage], title: String, to path: String, cancellationCheck: (() throws -> Void)? = nil) throws {
+        let entries: [[String: Any]] = try messages.map { msg in
+            try cancellationCheck?()
+            return [
                 "id": msg.id,
                 "date": msg.date.iso8601String,
                 "sender": msg.isFromMe ? "Me" : (msg.senderJid ?? ""),

--- a/Sources/Phosphor/Services/WhatsAppExporter.swift
+++ b/Sources/Phosphor/Services/WhatsAppExporter.swift
@@ -285,6 +285,7 @@ final class WhatsAppExporter {
             PDFTranscriptWriter.Entry(
                 title: msg.isFromMe ? "Me" : (msg.senderJid ?? "Unknown"),
                 subtitle: msg.formattedDate,
+                timestamp: msg.date,
                 body: msg.displayText,
                 isFromMe: msg.isFromMe
             )

--- a/Sources/Phosphor/Utilities/MessageAttachmentExporter.swift
+++ b/Sources/Phosphor/Utilities/MessageAttachmentExporter.swift
@@ -1,8 +1,11 @@
 import Foundation
 
-/// Copies original message attachments into a collision-safe sibling folder.
-/// Work is staged before replacing a previous completed sidecar so cancellation
-/// never leaves users with a partially refreshed attachment export.
+/// Copies original message attachments into collision-safe directories.
+///
+/// Single-transcript exports publish a fresh immutable generation before their
+/// transcript is replaced. The transcript embeds that generation's relative
+/// name, so an interrupted process can only leave an unreferenced orphan; it
+/// cannot make a completed transcript point at moved or replaced sidecars.
 enum MessageAttachmentExporter {
     struct Item {
         let key: String
@@ -10,36 +13,94 @@ enum MessageAttachmentExporter {
         let sourcePath: String
     }
 
-    static func export(
+    /// A sidecar generation that has been made visible but is not necessarily
+    /// referenced by a committed transcript yet.
+    struct Generation {
+        let directoryURL: URL?
+        let paths: [String: String]
+        fileprivate let exportURL: URL
+    }
+
+    /// Copy originals into a unique, immutable generation beside an export.
+    /// The caller must either commit the transcript containing `paths` or call
+    /// `discard(_:)`; successful transcript publication calls
+    /// `cleanupObsoleteGenerations(for:)` afterwards.
+    static func prepareGeneration(
         _ items: [Item],
         beside exportPath: String,
         cancellationCheck: (() throws -> Void)? = nil
-    ) throws -> [String: String] {
+    ) throws -> Generation {
         let fileManager = FileManager.default
         let exportURL = URL(fileURLWithPath: exportPath)
-        let parentURL = exportURL.deletingLastPathComponent()
-        let baseName = exportURL.deletingPathExtension().lastPathComponent
-        let formatSuffix = exportURL.pathExtension.lowercased()
-        let sidecarName = formatSuffix.isEmpty
-            ? "\(baseName)_attachments"
-            : "\(baseName)-\(formatSuffix)_attachments"
-        let sidecarURL = parentURL.appendingPathComponent(sidecarName, isDirectory: true)
-        let exportedPaths = try export(items, to: sidecarURL, cancellationCheck: cancellationCheck)
-
-        // Older Phosphor HTML exports used `<base>_attachments`. Remove that
-        // stale sidecar only after the new format-isolated export succeeds.
-        if formatSuffix == "html" {
-            let legacySidecarURL = parentURL.appendingPathComponent("\(baseName)_attachments", isDirectory: true)
-            if legacySidecarURL != sidecarURL {
-                try? fileManager.removeItem(at: legacySidecarURL)
-            }
+        guard !items.isEmpty else {
+            return Generation(directoryURL: nil, paths: [:], exportURL: exportURL)
         }
 
-        return exportedPaths
+        let parentURL = exportURL.deletingLastPathComponent()
+        try fileManager.createDirectory(at: parentURL, withIntermediateDirectories: true)
+        let generationName = "\(sidecarBaseName(for: exportURL))-\(UUID().uuidString)"
+        let generationURL = parentURL.appendingPathComponent(generationName, isDirectory: true)
+        let stagingURL = parentURL.appendingPathComponent(
+            ".\(generationName).staging-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        defer { try? fileManager.removeItem(at: stagingURL) }
+
+        try fileManager.createDirectory(at: stagingURL, withIntermediateDirectories: true)
+        var exportedPaths: [String: String] = [:]
+        for item in items {
+            try cancellationCheck?()
+            guard exportedPaths[item.key] == nil else { continue }
+
+            let baseName = safeFilename(item.displayName)
+            let uniqueName = availableFilename(baseName, in: stagingURL, fileManager: fileManager)
+            let destinationURL = stagingURL.appendingPathComponent(uniqueName)
+            try fileManager.copyItem(at: URL(fileURLWithPath: item.sourcePath), to: destinationURL)
+            exportedPaths[item.key] = "\(generationName)/\(uniqueName)"
+        }
+        try cancellationCheck?()
+        try fileManager.moveItem(at: stagingURL, to: generationURL)
+        return Generation(directoryURL: generationURL, paths: exportedPaths, exportURL: exportURL)
     }
 
-    /// Export to a caller-selected folder. Multi-format bundles use this to
-    /// share one `Attachments` directory across every transcript in a chat.
+    /// Remove a sidecar generation that was published but never referenced by a
+    /// committed transcript. Errors are deliberately best-effort during the
+    /// caller's failure path; an unreferenced generation is safe to recover.
+    static func discard(_ generation: Generation) {
+        guard let directoryURL = generation.directoryURL else { return }
+        try? FileManager.default.removeItem(at: directoryURL)
+    }
+
+    /// Reclaim sidecars from completed exports only after the transcript commit.
+    /// Cleanup intentionally tolerates crashes and deletion failures: stale
+    /// generations are harmless because every transcript names its own one.
+    static func cleanupObsoleteGenerations(for generation: Generation) {
+        let fileManager = FileManager.default
+        let exportURL = generation.exportURL
+        let parentURL = exportURL.deletingLastPathComponent()
+        let currentURL = generation.directoryURL
+        let baseName = sidecarBaseName(for: exportURL)
+        let generationPrefix = "\(baseName)-"
+        let legacyNames = legacySidecarNames(for: exportURL)
+
+        guard let entries = try? fileManager.contentsOfDirectory(
+            at: parentURL,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: [.skipsHiddenFiles]
+        ) else { return }
+
+        for entry in entries {
+            let name = entry.lastPathComponent
+            guard name.hasPrefix(generationPrefix) || legacyNames.contains(name) else { continue }
+            guard entry.standardizedFileURL.path != currentURL?.standardizedFileURL.path else { continue }
+            var isDirectory: ObjCBool = false
+            guard fileManager.fileExists(atPath: entry.path, isDirectory: &isDirectory), isDirectory.boolValue else { continue }
+            try? fileManager.removeItem(at: entry)
+        }
+    }
+
+    /// Export to a caller-selected unpublished folder. Multi-format bundles use
+    /// this while their enclosing bundle root is still private staging state.
     static func export(
         _ items: [Item],
         to directoryURL: URL,
@@ -52,9 +113,7 @@ enum MessageAttachmentExporter {
             ".\(directoryName).staging-\(UUID().uuidString)",
             isDirectory: true
         )
-        defer {
-            try? fileManager.removeItem(at: stagingURL)
-        }
+        defer { try? fileManager.removeItem(at: stagingURL) }
 
         var exportedPaths: [String: String] = [:]
         if !items.isEmpty {
@@ -97,6 +156,24 @@ enum MessageAttachmentExporter {
                 String(segment).addingPercentEncoding(withAllowedCharacters: allowed) ?? String(segment)
             }
             .joined(separator: "/")
+    }
+
+    private static func sidecarBaseName(for exportURL: URL) -> String {
+        let baseName = exportURL.deletingPathExtension().lastPathComponent
+        let formatSuffix = exportURL.pathExtension.lowercased()
+        return formatSuffix.isEmpty
+            ? "\(baseName)_attachments"
+            : "\(baseName)-\(formatSuffix)_attachments"
+    }
+
+    private static func legacySidecarNames(for exportURL: URL) -> Set<String> {
+        let baseName = exportURL.deletingPathExtension().lastPathComponent
+        let formatSuffix = exportURL.pathExtension.lowercased()
+        var names = [sidecarBaseName(for: exportURL)]
+        if formatSuffix == "html" {
+            names.append("\(baseName)_attachments")
+        }
+        return Set(names)
     }
 
     private static func safeFilename(_ displayName: String) -> String {

--- a/Sources/Phosphor/Utilities/MessageAttachmentExporter.swift
+++ b/Sources/Phosphor/Utilities/MessageAttachmentExporter.swift
@@ -1,0 +1,108 @@
+import Foundation
+
+/// Copies original message attachments into a collision-safe sibling folder.
+/// Work is staged before replacing a previous completed sidecar so cancellation
+/// never leaves users with a partially refreshed attachment export.
+enum MessageAttachmentExporter {
+    struct Item {
+        let key: String
+        let displayName: String
+        let sourcePath: String
+    }
+
+    static func export(
+        _ items: [Item],
+        beside exportPath: String,
+        cancellationCheck: (() throws -> Void)? = nil
+    ) throws -> [String: String] {
+        let fileManager = FileManager.default
+        let exportURL = URL(fileURLWithPath: exportPath)
+        let parentURL = exportURL.deletingLastPathComponent()
+        let baseName = exportURL.deletingPathExtension().lastPathComponent
+        let formatSuffix = exportURL.pathExtension.lowercased()
+        let sidecarName = formatSuffix.isEmpty
+            ? "\(baseName)_attachments"
+            : "\(baseName)-\(formatSuffix)_attachments"
+        let sidecarURL = parentURL.appendingPathComponent(sidecarName, isDirectory: true)
+        let stagingURL = parentURL.appendingPathComponent(".\(sidecarName).staging-\(UUID().uuidString)", isDirectory: true)
+        defer {
+            try? fileManager.removeItem(at: stagingURL)
+        }
+
+        var exportedPaths: [String: String] = [:]
+        if !items.isEmpty {
+            try fileManager.createDirectory(at: stagingURL, withIntermediateDirectories: true)
+        }
+
+        for item in items {
+            try cancellationCheck?()
+            guard exportedPaths[item.key] == nil else { continue }
+
+            let baseName = safeFilename(item.displayName)
+            let uniqueName = availableFilename(baseName, in: stagingURL, fileManager: fileManager)
+            let destinationURL = stagingURL.appendingPathComponent(uniqueName)
+            try fileManager.copyItem(at: URL(fileURLWithPath: item.sourcePath), to: destinationURL)
+            exportedPaths[item.key] = "\(sidecarName)/\(uniqueName)"
+        }
+        try cancellationCheck?()
+
+        if items.isEmpty {
+            if fileManager.fileExists(atPath: sidecarURL.path) {
+                try fileManager.removeItem(at: sidecarURL)
+            }
+        } else if fileManager.fileExists(atPath: sidecarURL.path) {
+            _ = try fileManager.replaceItemAt(sidecarURL, withItemAt: stagingURL)
+        } else {
+            try fileManager.moveItem(at: stagingURL, to: sidecarURL)
+        }
+
+        // Older Phosphor HTML exports used `<base>_attachments`. Remove that
+        // stale sidecar only after the new format-isolated export succeeds.
+        if formatSuffix == "html" {
+            let legacySidecarURL = parentURL.appendingPathComponent("\(baseName)_attachments", isDirectory: true)
+            if legacySidecarURL != sidecarURL {
+                try? fileManager.removeItem(at: legacySidecarURL)
+            }
+        }
+
+        return exportedPaths
+    }
+
+    /// Encode each filename segment for use in HTML src/href attributes while
+    /// retaining the sidecar directory separator.
+    static func relativeURL(for relativePath: String) -> String {
+        var allowed = CharacterSet.urlPathAllowed
+        allowed.remove(charactersIn: "/?#%")
+        return relativePath
+            .split(separator: "/", omittingEmptySubsequences: false)
+            .map { segment in
+                String(segment).addingPercentEncoding(withAllowedCharacters: allowed) ?? String(segment)
+            }
+            .joined(separator: "/")
+    }
+
+    private static func safeFilename(_ displayName: String) -> String {
+        let candidate = (displayName as NSString).lastPathComponent
+        if candidate.isEmpty || candidate == "." || candidate == ".." {
+            return "Attachment"
+        }
+        return candidate
+    }
+
+    private static func availableFilename(
+        _ filename: String,
+        in directory: URL,
+        fileManager: FileManager
+    ) -> String {
+        var candidate = filename
+        var suffix = 2
+        while fileManager.fileExists(atPath: directory.appendingPathComponent(candidate).path) {
+            let name = filename as NSString
+            let ext = name.pathExtension
+            let stem = name.deletingPathExtension
+            candidate = ext.isEmpty ? "\(stem)-\(suffix)" : "\(stem)-\(suffix).\(ext)"
+            suffix += 1
+        }
+        return candidate
+    }
+}

--- a/Sources/Phosphor/Utilities/MessageAttachmentExporter.swift
+++ b/Sources/Phosphor/Utilities/MessageAttachmentExporter.swift
@@ -24,7 +24,34 @@ enum MessageAttachmentExporter {
             ? "\(baseName)_attachments"
             : "\(baseName)-\(formatSuffix)_attachments"
         let sidecarURL = parentURL.appendingPathComponent(sidecarName, isDirectory: true)
-        let stagingURL = parentURL.appendingPathComponent(".\(sidecarName).staging-\(UUID().uuidString)", isDirectory: true)
+        let exportedPaths = try export(items, to: sidecarURL, cancellationCheck: cancellationCheck)
+
+        // Older Phosphor HTML exports used `<base>_attachments`. Remove that
+        // stale sidecar only after the new format-isolated export succeeds.
+        if formatSuffix == "html" {
+            let legacySidecarURL = parentURL.appendingPathComponent("\(baseName)_attachments", isDirectory: true)
+            if legacySidecarURL != sidecarURL {
+                try? fileManager.removeItem(at: legacySidecarURL)
+            }
+        }
+
+        return exportedPaths
+    }
+
+    /// Export to a caller-selected folder. Multi-format bundles use this to
+    /// share one `Attachments` directory across every transcript in a chat.
+    static func export(
+        _ items: [Item],
+        to directoryURL: URL,
+        cancellationCheck: (() throws -> Void)? = nil
+    ) throws -> [String: String] {
+        let fileManager = FileManager.default
+        let parentURL = directoryURL.deletingLastPathComponent()
+        let directoryName = directoryURL.lastPathComponent
+        let stagingURL = parentURL.appendingPathComponent(
+            ".\(directoryName).staging-\(UUID().uuidString)",
+            isDirectory: true
+        )
         defer {
             try? fileManager.removeItem(at: stagingURL)
         }
@@ -42,27 +69,18 @@ enum MessageAttachmentExporter {
             let uniqueName = availableFilename(baseName, in: stagingURL, fileManager: fileManager)
             let destinationURL = stagingURL.appendingPathComponent(uniqueName)
             try fileManager.copyItem(at: URL(fileURLWithPath: item.sourcePath), to: destinationURL)
-            exportedPaths[item.key] = "\(sidecarName)/\(uniqueName)"
+            exportedPaths[item.key] = "\(directoryName)/\(uniqueName)"
         }
         try cancellationCheck?()
 
         if items.isEmpty {
-            if fileManager.fileExists(atPath: sidecarURL.path) {
-                try fileManager.removeItem(at: sidecarURL)
+            if fileManager.fileExists(atPath: directoryURL.path) {
+                try fileManager.removeItem(at: directoryURL)
             }
-        } else if fileManager.fileExists(atPath: sidecarURL.path) {
-            _ = try fileManager.replaceItemAt(sidecarURL, withItemAt: stagingURL)
+        } else if fileManager.fileExists(atPath: directoryURL.path) {
+            _ = try fileManager.replaceItemAt(directoryURL, withItemAt: stagingURL)
         } else {
-            try fileManager.moveItem(at: stagingURL, to: sidecarURL)
-        }
-
-        // Older Phosphor HTML exports used `<base>_attachments`. Remove that
-        // stale sidecar only after the new format-isolated export succeeds.
-        if formatSuffix == "html" {
-            let legacySidecarURL = parentURL.appendingPathComponent("\(baseName)_attachments", isDirectory: true)
-            if legacySidecarURL != sidecarURL {
-                try? fileManager.removeItem(at: legacySidecarURL)
-            }
+            try fileManager.moveItem(at: stagingURL, to: directoryURL)
         }
 
         return exportedPaths

--- a/Sources/Phosphor/Utilities/MessageAttributedBodyDecoder.swift
+++ b/Sources/Phosphor/Utilities/MessageAttributedBodyDecoder.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+/// Recovers message text that recent iOS versions store only in the
+/// `message.attributedBody` NSArchiver typedstream blob.
+enum MessageAttributedBodyDecoder {
+    private static let typedstreamSignature = Data([0x04, 0x0B]) + Data("streamtyped".utf8)
+    static let maximumArchiveSize = 16 * 1024 * 1024
+    static let attributedBodyCandidateSQLProjection = """
+        CASE WHEN (m.text IS NULL OR m.text = '')
+                  AND length(m.attributedBody) <= \(maximumArchiveSize)
+             THEN m.ROWID ELSE NULL END AS attributed_body_rowid
+        """
+    static let attributedBodySQLProjection = """
+        CASE WHEN length(m.attributedBody) <= \(maximumArchiveSize)
+             THEN m.attributedBody ELSE NULL END AS attributedBody
+        """
+
+    static func text(from data: Data) -> String? {
+        guard data.count >= typedstreamSignature.count,
+              data.count <= maximumArchiveSize,
+              data.starts(with: typedstreamSignature),
+              let values = try? MessageTypedStreamDecoder.decode(data) else {
+            return nil
+        }
+
+        // An archived NSAttributedString stores its visible body as the first
+        // NSString/NSMutableString object. Later strings are formatting keys and
+        // attribute metadata, so joining every decoded string corrupts the body.
+        for value in values {
+            guard case let .object(classInfo, objects) = value,
+                  classInfo.name == "NSString" || classInfo.name == "NSMutableString",
+                  let first = objects.first,
+                  case let .string(text) = first else {
+                continue
+            }
+            return text.isEmpty ? nil : text
+        }
+        return nil
+    }
+}

--- a/Sources/Phosphor/Utilities/MessageExportBundleWriter.swift
+++ b/Sources/Phosphor/Utilities/MessageExportBundleWriter.swift
@@ -1,3 +1,4 @@
+import Darwin
 import Foundation
 
 /// Builds a complete multi-conversation export out of sight, then reveals it
@@ -17,27 +18,29 @@ enum MessageExportBundleWriter {
         let fileManager = FileManager.default
         try fileManager.createDirectory(at: parentDirectory, withIntermediateDirectories: true)
 
-        let finalDirectory = availableDirectory(
-            named: directoryName,
-            in: parentDirectory,
-            fileManager: fileManager
-        )
-        let stagingDirectory = parentDirectory.appendingPathComponent(
-            ".\(finalDirectory.lastPathComponent).staging-\(UUID().uuidString)",
-            isDirectory: true
-        )
-        var stagingExists = true
-        defer {
-            if stagingExists {
-                try? fileManager.removeItem(at: stagingDirectory)
+        return try withPublicationLock(in: parentDirectory) {
+            let finalDirectory = availableDirectory(
+                named: directoryName,
+                in: parentDirectory,
+                fileManager: fileManager
+            )
+            let stagingDirectory = parentDirectory.appendingPathComponent(
+                ".\(finalDirectory.lastPathComponent).staging-\(UUID().uuidString)",
+                isDirectory: true
+            )
+            var stagingExists = true
+            defer {
+                if stagingExists {
+                    try? fileManager.removeItem(at: stagingDirectory)
+                }
             }
-        }
 
-        try fileManager.createDirectory(at: stagingDirectory, withIntermediateDirectories: true)
-        let count = try populate(stagingDirectory)
-        try fileManager.moveItem(at: stagingDirectory, to: finalDirectory)
-        stagingExists = false
-        return Result(count: count, directory: finalDirectory)
+            try fileManager.createDirectory(at: stagingDirectory, withIntermediateDirectories: true)
+            let count = try populate(stagingDirectory)
+            try fileManager.moveItem(at: stagingDirectory, to: finalDirectory)
+            stagingExists = false
+            return Result(count: count, directory: finalDirectory)
+        }
     }
 
     private static func availableDirectory(
@@ -52,5 +55,28 @@ enum MessageExportBundleWriter {
             suffix += 1
         }
         return parentDirectory.appendingPathComponent(name, isDirectory: true)
+    }
+
+    /// Keep the name-selection and final move together across Phosphor
+    /// processes. A persistent lock avoids the check-then-move race where two
+    /// same-parent exports both choose the same collision-free folder name.
+    private static func withPublicationLock<T>(
+        in parentDirectory: URL,
+        operation: () throws -> T
+    ) throws -> T {
+        let lockURL = parentDirectory.appendingPathComponent(
+            ".phosphor-message-export-bundle.lock"
+        )
+        let descriptor = open(lockURL.path, O_CREAT | O_RDWR | O_CLOEXEC | O_NOFOLLOW, S_IRUSR | S_IWUSR)
+        guard descriptor >= 0 else { throw posixError() }
+        defer { close(descriptor) }
+
+        guard flock(descriptor, LOCK_EX) == 0 else { throw posixError() }
+        defer { _ = flock(descriptor, LOCK_UN) }
+        return try operation()
+    }
+
+    private static func posixError() -> NSError {
+        NSError(domain: NSPOSIXErrorDomain, code: Int(errno))
     }
 }

--- a/Sources/Phosphor/Utilities/MessageExportBundleWriter.swift
+++ b/Sources/Phosphor/Utilities/MessageExportBundleWriter.swift
@@ -28,18 +28,48 @@ enum MessageExportBundleWriter {
                 ".\(finalDirectory.lastPathComponent).staging-\(UUID().uuidString)",
                 isDirectory: true
             )
-            var stagingExists = true
-            defer {
-                if stagingExists {
-                    try? fileManager.removeItem(at: stagingDirectory)
-                }
-            }
-
             try fileManager.createDirectory(at: stagingDirectory, withIntermediateDirectories: true)
-            let count = try populate(stagingDirectory)
-            try fileManager.moveItem(at: stagingDirectory, to: finalDirectory)
-            stagingExists = false
-            return Result(count: count, directory: finalDirectory)
+            do {
+                let count = try populate(stagingDirectory)
+                // A successful same-parent move is the publication commit point:
+                // the staging pathname no longer exists and must not be inspected
+                // or removed after this succeeds.
+                try fileManager.moveItem(at: stagingDirectory, to: finalDirectory)
+                return Result(count: count, directory: finalDirectory)
+            } catch {
+                let exportError = error
+                do {
+                    try removeCurrentStagingDirectoryIfPresent(
+                        stagingDirectory,
+                        fileManager: fileManager
+                    )
+                } catch let cleanupFailure {
+                    throw stagingCleanupError(
+                        path: stagingDirectory.path,
+                        exportError: exportError,
+                        cleanupFailure: cleanupFailure
+                    )
+                }
+                throw exportError
+            }
+        }
+    }
+
+    private static func removeCurrentStagingDirectoryIfPresent(
+        _ stagingDirectory: URL,
+        fileManager: FileManager
+    ) throws {
+        guard fileManager.fileExists(atPath: stagingDirectory.path) else { return }
+        try fileManager.removeItem(at: stagingDirectory)
+        guard !fileManager.fileExists(atPath: stagingDirectory.path) else {
+            throw NSError(
+                domain: "Phosphor.MessageExportBundleWriter",
+                code: 2,
+                userInfo: [
+                    NSLocalizedDescriptionKey: "Phosphor could not verify removal of its active message-export staging folder.",
+                    NSFilePathErrorKey: stagingDirectory.path
+                ]
+            )
         }
     }
 
@@ -74,6 +104,23 @@ enum MessageExportBundleWriter {
         guard flock(descriptor, LOCK_EX) == 0 else { throw posixError() }
         defer { _ = flock(descriptor, LOCK_UN) }
         return try operation()
+    }
+
+    private static func stagingCleanupError(
+        path: String,
+        exportError: Error,
+        cleanupFailure: Error
+    ) -> NSError {
+        NSError(
+            domain: "Phosphor.MessageExportBundleWriter",
+            code: 1,
+            userInfo: [
+                NSLocalizedDescriptionKey: "Message export failed and Phosphor could not remove its staging folder. The completed exports were not changed.",
+                NSFilePathErrorKey: path,
+                NSUnderlyingErrorKey: cleanupFailure,
+                "PhosphorExportError": exportError.localizedDescription
+            ]
+        )
     }
 
     private static func posixError() -> NSError {

--- a/Sources/Phosphor/Utilities/MessageExportBundleWriter.swift
+++ b/Sources/Phosphor/Utilities/MessageExportBundleWriter.swift
@@ -11,12 +11,17 @@ enum MessageExportBundleWriter {
 
     static func write(
         in parentDirectory: URL,
+        directoryName: String = "Messages Export",
         populate: (URL) throws -> Int
     ) throws -> Result {
         let fileManager = FileManager.default
         try fileManager.createDirectory(at: parentDirectory, withIntermediateDirectories: true)
 
-        let finalDirectory = availableDirectory(in: parentDirectory, fileManager: fileManager)
+        let finalDirectory = availableDirectory(
+            named: directoryName,
+            in: parentDirectory,
+            fileManager: fileManager
+        )
         let stagingDirectory = parentDirectory.appendingPathComponent(
             ".\(finalDirectory.lastPathComponent).staging-\(UUID().uuidString)",
             isDirectory: true
@@ -36,13 +41,14 @@ enum MessageExportBundleWriter {
     }
 
     private static func availableDirectory(
+        named directoryName: String,
         in parentDirectory: URL,
         fileManager: FileManager
     ) -> URL {
-        var name = "Messages Export"
+        var name = directoryName
         var suffix = 2
         while fileManager.fileExists(atPath: parentDirectory.appendingPathComponent(name).path) {
-            name = "Messages Export \(suffix)"
+            name = "\(directoryName) \(suffix)"
             suffix += 1
         }
         return parentDirectory.appendingPathComponent(name, isDirectory: true)

--- a/Sources/Phosphor/Utilities/MessageExportBundleWriter.swift
+++ b/Sources/Phosphor/Utilities/MessageExportBundleWriter.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+/// Builds a complete multi-conversation export out of sight, then reveals it
+/// with one final move so cancellation or writer failure cannot leave a partial
+/// `Messages Export` folder behind.
+enum MessageExportBundleWriter {
+    struct Result {
+        let count: Int
+        let directory: URL
+    }
+
+    static func write(
+        in parentDirectory: URL,
+        populate: (URL) throws -> Int
+    ) throws -> Result {
+        let fileManager = FileManager.default
+        try fileManager.createDirectory(at: parentDirectory, withIntermediateDirectories: true)
+
+        let finalDirectory = availableDirectory(in: parentDirectory, fileManager: fileManager)
+        let stagingDirectory = parentDirectory.appendingPathComponent(
+            ".\(finalDirectory.lastPathComponent).staging-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        var stagingExists = true
+        defer {
+            if stagingExists {
+                try? fileManager.removeItem(at: stagingDirectory)
+            }
+        }
+
+        try fileManager.createDirectory(at: stagingDirectory, withIntermediateDirectories: true)
+        let count = try populate(stagingDirectory)
+        try fileManager.moveItem(at: stagingDirectory, to: finalDirectory)
+        stagingExists = false
+        return Result(count: count, directory: finalDirectory)
+    }
+
+    private static func availableDirectory(
+        in parentDirectory: URL,
+        fileManager: FileManager
+    ) -> URL {
+        var name = "Messages Export"
+        var suffix = 2
+        while fileManager.fileExists(atPath: parentDirectory.appendingPathComponent(name).path) {
+            name = "Messages Export \(suffix)"
+            suffix += 1
+        }
+        return parentDirectory.appendingPathComponent(name, isDirectory: true)
+    }
+}

--- a/Sources/Phosphor/Utilities/MessageExportTransaction.swift
+++ b/Sources/Phosphor/Utilities/MessageExportTransaction.swift
@@ -1,3 +1,4 @@
+import Darwin
 import Foundation
 
 /// Publishes a staged transcript without ever moving a completed attachment
@@ -11,39 +12,69 @@ enum MessageExportTransaction {
         prepareAttachments: (() throws -> MessageAttachmentExporter.Generation)? = nil,
         populate: (URL, [String: String]) throws -> Void
     ) throws {
-        let fileManager = FileManager.default
-        let parentURL = finalTranscriptURL.deletingLastPathComponent()
-        try fileManager.createDirectory(at: parentURL, withIntermediateDirectories: true)
-
-        let stagedTranscriptURL = parentURL.appendingPathComponent(
-            ".\(finalTranscriptURL.lastPathComponent).staging-\(UUID().uuidString)"
+        // The parent must exist before the cross-process lock file can be opened.
+        // This is idempotent when another exporter is starting concurrently.
+        try FileManager.default.createDirectory(
+            at: finalTranscriptURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
         )
-        var generation: MessageAttachmentExporter.Generation?
-        var transcriptCommitted = false
+        try withDestinationLock(for: finalTranscriptURL) {
+            let fileManager = FileManager.default
+            let parentURL = finalTranscriptURL.deletingLastPathComponent()
 
-        do {
-            generation = try prepareAttachments?()
-            try populate(stagedTranscriptURL, generation?.paths ?? attachmentMap)
+            let stagedTranscriptURL = parentURL.appendingPathComponent(
+                ".\(finalTranscriptURL.lastPathComponent).staging-\(UUID().uuidString)"
+            )
+            var generation: MessageAttachmentExporter.Generation?
+            var transcriptCommitted = false
 
-            if fileManager.fileExists(atPath: finalTranscriptURL.path) {
-                _ = try fileManager.replaceItemAt(finalTranscriptURL, withItemAt: stagedTranscriptURL)
-            } else {
-                try fileManager.moveItem(at: stagedTranscriptURL, to: finalTranscriptURL)
+            do {
+                generation = try prepareAttachments?()
+                try populate(stagedTranscriptURL, generation?.paths ?? attachmentMap)
+
+                if fileManager.fileExists(atPath: finalTranscriptURL.path) {
+                    _ = try fileManager.replaceItemAt(finalTranscriptURL, withItemAt: stagedTranscriptURL)
+                } else {
+                    try fileManager.moveItem(at: stagedTranscriptURL, to: finalTranscriptURL)
+                }
+                transcriptCommitted = true
+            } catch {
+                try? fileManager.removeItem(at: stagedTranscriptURL)
+                if let generation {
+                    MessageAttachmentExporter.discard(generation)
+                }
+                throw error
             }
-            transcriptCommitted = true
-        } catch {
-            try? fileManager.removeItem(at: stagedTranscriptURL)
-            if let generation {
-                MessageAttachmentExporter.discard(generation)
-            }
-            throw error
-        }
 
-        // This is post-commit housekeeping. A crash or deletion failure here can
-        // only leave unreferenced directories behind; it cannot invalidate the
-        // just-committed transcript's generation.
-        if transcriptCommitted, let generation {
-            MessageAttachmentExporter.cleanupObsoleteGenerations(for: generation)
+            // Cleanup remains inside the destination lock: a concurrent export
+            // must never remove the sidecar referenced by the transcript that
+            // was published after this one.
+            if transcriptCommitted, let generation {
+                MessageAttachmentExporter.cleanupObsoleteGenerations(for: generation)
+            }
         }
+    }
+
+    /// Serialize complete transcript-plus-sidecar publication per destination,
+    /// including across separate Phosphor processes. The lock file deliberately
+    /// persists: deleting a lock file after unlock can split waiters between old
+    /// and new inodes, defeating mutual exclusion.
+    private static func withDestinationLock<T>(
+        for finalTranscriptURL: URL,
+        operation: () throws -> T
+    ) throws -> T {
+        let lockURL = finalTranscriptURL.deletingLastPathComponent()
+            .appendingPathComponent(".\(finalTranscriptURL.lastPathComponent).phosphor-export.lock")
+        let descriptor = open(lockURL.path, O_CREAT | O_RDWR | O_CLOEXEC | O_NOFOLLOW, S_IRUSR | S_IWUSR)
+        guard descriptor >= 0 else { throw posixError() }
+        defer { close(descriptor) }
+
+        guard flock(descriptor, LOCK_EX) == 0 else { throw posixError() }
+        defer { _ = flock(descriptor, LOCK_UN) }
+        return try operation()
+    }
+
+    private static func posixError() -> NSError {
+        NSError(domain: NSPOSIXErrorDomain, code: Int(errno))
     }
 }

--- a/Sources/Phosphor/Utilities/MessageExportTransaction.swift
+++ b/Sources/Phosphor/Utilities/MessageExportTransaction.swift
@@ -1,0 +1,49 @@
+import Foundation
+
+/// Publishes a staged transcript without ever moving a completed attachment
+/// sidecar out of the path named by that transcript. A fresh attachment
+/// generation is made visible first, its relative name is embedded in the
+/// staged transcript, and only then is the transcript atomically replaced.
+enum MessageExportTransaction {
+    static func write(
+        to finalTranscriptURL: URL,
+        attachmentMap: [String: String] = [:],
+        prepareAttachments: (() throws -> MessageAttachmentExporter.Generation)? = nil,
+        populate: (URL, [String: String]) throws -> Void
+    ) throws {
+        let fileManager = FileManager.default
+        let parentURL = finalTranscriptURL.deletingLastPathComponent()
+        try fileManager.createDirectory(at: parentURL, withIntermediateDirectories: true)
+
+        let stagedTranscriptURL = parentURL.appendingPathComponent(
+            ".\(finalTranscriptURL.lastPathComponent).staging-\(UUID().uuidString)"
+        )
+        var generation: MessageAttachmentExporter.Generation?
+        var transcriptCommitted = false
+
+        do {
+            generation = try prepareAttachments?()
+            try populate(stagedTranscriptURL, generation?.paths ?? attachmentMap)
+
+            if fileManager.fileExists(atPath: finalTranscriptURL.path) {
+                _ = try fileManager.replaceItemAt(finalTranscriptURL, withItemAt: stagedTranscriptURL)
+            } else {
+                try fileManager.moveItem(at: stagedTranscriptURL, to: finalTranscriptURL)
+            }
+            transcriptCommitted = true
+        } catch {
+            try? fileManager.removeItem(at: stagedTranscriptURL)
+            if let generation {
+                MessageAttachmentExporter.discard(generation)
+            }
+            throw error
+        }
+
+        // This is post-commit housekeeping. A crash or deletion failure here can
+        // only leave unreferenced directories behind; it cannot invalidate the
+        // just-committed transcript's generation.
+        if transcriptCommitted, let generation {
+            MessageAttachmentExporter.cleanupObsoleteGenerations(for: generation)
+        }
+    }
+}

--- a/Sources/Phosphor/Utilities/MessageTypedStream/MessageTypedStreamClass.swift
+++ b/Sources/Phosphor/Utilities/MessageTypedStream/MessageTypedStreamClass.swift
@@ -1,0 +1,20 @@
+// Adapted from Madrid TypedStream at commit 8f5f4f1.
+// Copyright 2025 Mattt. Licensed under the MIT License; see THIRD_PARTY_NOTICES.md.
+
+/// Represents a class stored in the `typedstream`
+public struct MessageTypedStreamClass: Hashable, Sendable {
+    /// The name of the class
+    public let name: String
+    /// The encoded version of the class
+    public let version: UInt64
+
+    /// Creates class metadata for a `typedstream` class entry.
+    ///
+    /// - Parameters:
+    ///   - name: The class name.
+    ///   - version: The encoded class version.
+    public init(name: String, version: UInt64) {
+        self.name = name
+        self.version = version
+    }
+}

--- a/Sources/Phosphor/Utilities/MessageTypedStream/MessageTypedStreamDecoder.swift
+++ b/Sources/Phosphor/Utilities/MessageTypedStream/MessageTypedStreamDecoder.swift
@@ -1,0 +1,594 @@
+// Adapted from Madrid TypedStream at commit 8f5f4f1.
+// Copyright 2025 Mattt. Licensed under the MIT License; see THIRD_PARTY_NOTICES.md.
+
+import Foundation
+
+/// Errors that can occur when parsing `typedstream` data.
+///
+/// This corresponds to the new `typedstream` deserializer.
+public enum MessageTypedStreamDecoderError: Error, LocalizedError {
+    /// Read or slice operation exceeded the stream bounds.
+    case outOfBounds(index: Int, length: Int)
+    /// The stream header is missing, malformed, or unsupported.
+    case invalidHeader
+    /// Failed to slice the source stream.
+    case sliceError(Swift.Error)
+    /// Failed to decode string data as UTF-8.
+    case stringParseError(Swift.Error)
+    /// Array type declaration could not be parsed.
+    case invalidArray
+    /// MessageTypedStreamType reference pointer is invalid or out of range.
+    case invalidPointer(UInt8)
+    /// Corrupt input nested objects deeply enough to risk exhausting the stack.
+    case nestingTooDeep
+    /// Parsing exceeded the bounded work or collection budget.
+    case resourceLimit
+
+    public var errorDescription: String? {
+        switch self {
+        case .outOfBounds(let index, let length):
+            return "Index \(String(index, radix: 16)) is outside of range \(String(length, radix: 16))!"
+        case .invalidHeader:
+            return "Invalid typedstream header!"
+        case .sliceError(let error):
+            return "Unable to slice source stream: \(error)"
+        case .stringParseError(let error):
+            return "Failed to parse string: \(error)"
+        case .invalidArray:
+            return "Failed to parse array data"
+        case .invalidPointer(let value):
+            return "Failed to parse pointer: \(String(value, radix: 16))"
+        case .nestingTooDeep:
+            return "Typedstream object nesting exceeds the supported limit"
+        case .resourceLimit:
+            return "Typedstream exceeds the supported parsing budget"
+        }
+    }
+}
+
+/// Deserializes data from the NeXT/Apple `typedstream` binary format.
+///
+/// `typedstream` is designed to serialize and deserialize complex object graphs
+/// and data structures in C and Objective-C. A stream begins with a header
+/// (format version and architecture), followed by typed data elements
+/// prefixed with type information.
+///
+/// Use `decode(_:)` to parse `Data` into an array of `MessageTypedStreamValue` values.
+/// `typedstream` data does not include property names;
+/// values are stored in order of appearance.
+public final class MessageTypedStreamDecoder {
+    /// Result of parsing a class: either a reference index or a new hierarchy.
+    private enum ClassResult {
+        /// A reference to an already-seen class in the `TypedStreamReader`'s object table
+        case index(Int)
+        /// A new class hierarchy to be inserted into the `TypedStreamReader`'s object table
+        case classHierarchy([MessageTypedStreamValue])
+    }
+
+    // MARK: - Constants
+
+    /// Indicates an `Int16` in the byte stream
+    private let I_16: UInt8 = 0x81
+    /// Indicates an `Int32` in the byte stream
+    private let I_32: UInt8 = 0x82
+    /// Indicates a `Float` or `Double` in the byte stream; the `MessageTypedStreamType` determines the size
+    private let DECIMAL: UInt8 = 0x83
+    /// Indicates the start of a new object
+    private let START: UInt8 = 0x84
+    /// Indicates that there is no more data to parse, for example the end of a class inheritance chain
+    private let EMPTY: UInt8 = 0x85
+    /// Indicates the last byte of an object
+    private let END: UInt8 = 0x86
+    /// Bytes equal or greater in value than the reference tag indicate an index in the table of already-seen types
+    private let REFERENCE_TAG: UInt64 = 0x92
+    /// Attributed-string type declarations are tiny; reject corrupt declarations
+    /// before they can expand into very large enum arrays.
+    private let maximumTypeDeclarationSize: UInt64 = 65_536
+
+    // MARK: - Properties
+
+    /// The `typedstream` we want to parse
+    let stream: [UInt8]
+    /// The current index we are at in the stream
+    var idx: Int
+    /// As we parse the `typedstream`, build a table of seen `MessageTypedStreamType`s to reference in the future
+    ///
+    /// The first time a `MessageTypedStreamType` is seen, it is present in the stream literally,
+    /// but afterwards are only referenced by index in order of appearance.
+    var typesTable: [[MessageTypedStreamType]]
+    /// As we parse the `typedstream`, build a table of seen archivable data to reference in the future
+    var objectTable: [MessageTypedStreamValue]
+    /// We want to copy embedded types the first time they are seen, even if the types were resolved through references
+    var seenEmbeddedTypes: Set<UInt32>
+    /// Stores the position of the current `MessageTypedStreamValue.placeholder`
+    var placeholder: Int?
+    /// Bounds recursive embedded objects in backup-controlled archives.
+    var embeddedDepth: Int
+    /// Limits parser control-flow work independently of large string payloads.
+    var remainingByteReads: Int
+    /// Limits decoded collection growth, including expansion through references.
+    var remainingDecodedValues: Int
+
+    // MARK: - Static Methods
+
+    /// Decodes `typedstream` data into an array of `MessageTypedStreamValue` values.
+    ///
+    /// - Parameter data: The `typedstream` bytes to decode.
+    /// - Returns: An array of decoded values in stream order.
+    /// - Throws: `MessageTypedStreamDecoderError` when the stream is malformed or parsing fails.
+    public static func decode(_ data: Data) throws -> [MessageTypedStreamValue] {
+        let bytes = [UInt8](data)
+        let decoder = MessageTypedStreamDecoder(stream: bytes)
+        return try decoder.parse()
+    }
+
+    // MARK: - Initialization
+
+    /// Creates a decoder for the given byte stream.
+    init(stream: [UInt8]) {
+        self.stream = stream
+        self.idx = 0
+        self.typesTable = []
+        self.objectTable = []
+        self.seenEmbeddedTypes = Set()
+        self.placeholder = nil
+        self.embeddedDepth = 0
+        self.remainingByteReads = 1_000_000
+        self.remainingDecodedValues = 131_072
+    }
+
+    // MARK: - Methods
+
+    /// Parses the stream and returns decoded `MessageTypedStreamValue` values in order.
+    ///
+    /// Does not retain object inheritance hierarchy; callers assemble the
+    /// flat result into the desired structure.
+    ///
+    /// - Returns: An array of values parsed from the stream.
+    /// - Throws: `MessageTypedStreamDecoderError` when parsing fails.
+    func parse() throws -> [MessageTypedStreamValue] {
+        var output: [MessageTypedStreamValue] = []
+
+        try validateHeader()
+
+        while idx < stream.count {
+            if try getCurrentByte() == END {
+                idx += 1
+                continue
+            }
+            // First, get the current type
+            if let foundTypes = try getType(embedded: false) {
+                if let result = try readTypes(foundTypes: foundTypes) {
+                    try consumeDecodedValues()
+                    output.append(result)
+                }
+            }
+        }
+
+        return output
+    }
+
+    /// Validates the stream header (version, signature, system version).
+    private func validateHeader() throws {
+        // Encoding type
+        let typedstreamVersion = try readUnsignedInt()
+        // Encoding signature
+        let signature = try readString()
+        // System version
+        let systemVersion = try readSignedInt()
+
+        if typedstreamVersion != 4 || signature != "streamtyped" || systemVersion != 1000 {
+            throw MessageTypedStreamDecoderError.invalidHeader
+        }
+    }
+
+    /// Reads a signed integer; size is inferred from stream type markers.
+    private func readSignedInt() throws -> Int64 {
+        while true {
+            switch try getCurrentByte() {
+            case I_16:
+                idx += 1
+                let size = 2
+                let bytes = try readExactBytes(size: size)
+                let value = Int16(littleEndian: bytes.withUnsafeBytes { $0.load(as: Int16.self) })
+                return Int64(value)
+            case I_32:
+                idx += 1
+                let size = 4
+                let bytes = try readExactBytes(size: size)
+                let value = Int32(littleEndian: bytes.withUnsafeBytes { $0.load(as: Int32.self) })
+                return Int64(value)
+            default:
+                let currentByte = try getCurrentByte()
+                if currentByte > UInt8(REFERENCE_TAG), try getNextByte() != END {
+                    // Malformed streams can contain long runs of reference-like
+                    // bytes. Skip them iteratively so backup input cannot exhaust
+                    // the process stack.
+                    idx += 1
+                    continue
+                }
+                let value = Int8(bitPattern: currentByte)
+                idx += 1
+                return Int64(value)
+            }
+        }
+    }
+
+    /// Reads an unsigned integer; size is inferred from stream type markers.
+    private func readUnsignedInt() throws -> UInt64 {
+        switch try getCurrentByte() {
+        case I_16:
+            idx += 1
+            let size = 2
+            let bytes = try readExactBytes(size: size)
+            let value = UInt16(littleEndian: bytes.withUnsafeBytes { $0.load(as: UInt16.self) })
+            return UInt64(value)
+        case I_32:
+            idx += 1
+            let size = 4
+            let bytes = try readExactBytes(size: size)
+            let value = UInt32(littleEndian: bytes.withUnsafeBytes { $0.load(as: UInt32.self) })
+            return UInt64(value)
+        default:
+            let value = try getCurrentByte()
+            idx += 1
+            return UInt64(value)
+        }
+    }
+
+    /// Reads a 32-bit float from the stream.
+    private func readFloat() throws -> Float {
+        switch try getCurrentByte() {
+        case DECIMAL:
+            idx += 1
+            let size = 4
+            let bytes = try readExactBytes(size: size)
+            let value = Float(bitPattern: bytes.withUnsafeBytes { $0.load(as: UInt32.self) })
+            return value
+        case I_16, I_32:
+            let intValue = try readSignedInt()
+            return Float(intValue)
+        default:
+            idx += 1
+            let intValue = try readSignedInt()
+            return Float(intValue)
+        }
+    }
+
+    /// Read a double-precision float from the byte stream
+    private func readDouble() throws -> Double {
+        switch try getCurrentByte() {
+        case DECIMAL:
+            idx += 1
+            let size = 8
+            let bytes = try readExactBytes(size: size)
+            let value = Double(bitPattern: bytes.withUnsafeBytes { $0.load(as: UInt64.self) })
+            return value
+        case I_16, I_32:
+            let intValue = try readSignedInt()
+            return Double(intValue)
+        default:
+            idx += 1
+            let intValue = try readSignedInt()
+            return Double(intValue)
+        }
+    }
+
+    /// Reads exactly `size` bytes and advances the index.
+    private func readExactBytes(size: Int) throws -> Data {
+        guard size >= 0, idx >= 0, idx <= stream.count, size <= stream.count - idx else {
+            throw MessageTypedStreamDecoderError.outOfBounds(index: idx, length: stream.count)
+        }
+        let end = idx + size
+        let data = Data(stream[idx ..< end])
+        idx += size
+        return data
+    }
+
+    /// Reads `length` bytes and decodes them as UTF-8.
+    private func readExactAsString(length: Int) throws -> String {
+        let bytes = try readExactBytes(size: length)
+        guard let string = String(data: bytes, encoding: .utf8) else {
+            throw MessageTypedStreamDecoderError.stringParseError(NSError(domain: "Invalid UTF-8", code: 0))
+        }
+        return string
+    }
+
+    /// Returns the byte at the given index.
+    private func getByte(at index: Int) throws -> UInt8 {
+        guard remainingByteReads > 0 else { throw MessageTypedStreamDecoderError.resourceLimit }
+        remainingByteReads -= 1
+        guard index >= 0, index < stream.count else {
+            throw MessageTypedStreamDecoderError.outOfBounds(index: index, length: stream.count)
+        }
+        return stream[index]
+    }
+
+    /// Reserves decoded collection capacity before allocating or copying it.
+    private func consumeDecodedValues(_ count: Int = 1) throws {
+        guard count >= 0, count <= remainingDecodedValues else {
+            throw MessageTypedStreamDecoderError.resourceLimit
+        }
+        remainingDecodedValues -= count
+    }
+
+    /// Returns the byte at the current stream index.
+    private func getCurrentByte() throws -> UInt8 {
+        return try getByte(at: idx)
+    }
+
+    /// Returns the byte immediately after the current index.
+    private func getNextByte() throws -> UInt8 {
+        return try getByte(at: idx + 1)
+    }
+
+    /// Reads `size` bytes as a byte array.
+    private func readArray(size: Int) throws -> [UInt8] {
+        let data = try readExactBytes(size: size)
+        return [UInt8](data)
+    }
+
+    /// Reads the type declaration for the next element.
+    private func readType() throws -> [MessageTypedStreamType] {
+        let length = try readUnsignedInt()
+        guard length <= maximumTypeDeclarationSize else {
+            throw MessageTypedStreamDecoderError.resourceLimit
+        }
+        let typesData = try readExactBytes(size: Int(length))
+        let typesBytes = [UInt8](typesData)
+
+        // Handle array size
+        if typesBytes.first == 0x5B {  // '[' character
+            if let (arrayTypes, _) = MessageTypedStreamType.getArrayLength(types: typesBytes) {
+                return arrayTypes
+            } else {
+                throw MessageTypedStreamDecoderError.invalidArray
+            }
+        }
+
+        return typesBytes.map { MessageTypedStreamType.fromByte($0) }
+    }
+
+    /// Reads a type reference pointer from the stream.
+    private func readPointer() throws -> UInt32 {
+        let pointer = try getCurrentByte()
+        idx += 1
+        let referenceTag = UInt8(REFERENCE_TAG)
+        // typedstream references are encoded in a signed byte domain:
+        // valid reference bytes are [0x92...0xFF] and [0x00...0x7F].
+        guard pointer < 0x80 || pointer >= referenceTag else {
+            throw MessageTypedStreamDecoderError.invalidPointer(pointer)
+        }
+        return UInt32(pointer &- referenceTag)
+    }
+
+    /// Parses a class declaration or reference.
+    private func readClass(depth: Int = 0) throws -> ClassResult {
+        guard depth <= 256 else { throw MessageTypedStreamDecoderError.nestingTooDeep }
+        var output: [MessageTypedStreamValue] = []
+        switch try getCurrentByte() {
+        case START:
+            // Skip some header bytes
+            while try getCurrentByte() == START {
+                idx += 1
+            }
+            let length = try readUnsignedInt()
+
+            if length >= REFERENCE_TAG {
+                let index = length - REFERENCE_TAG
+                return .index(Int(index))
+            }
+
+            let className = try readExactAsString(length: Int(length))
+            let version = try readUnsignedInt()
+
+            typesTable.append([.newString(className)])
+            try consumeDecodedValues()
+            output.append(.class(MessageTypedStreamClass(name: className, version: version)))
+
+            let parentClassResult = try readClass(depth: depth + 1)
+            if case .classHierarchy(let parent) = parentClassResult {
+                try consumeDecodedValues(parent.count)
+                output.append(contentsOf: parent)
+            }
+        case EMPTY:
+            idx += 1
+        default:
+            let index = try readPointer()
+            return .index(Int(index))
+        }
+        return .classHierarchy(output)
+    }
+
+    /// Reads an object from the stream or returns a cached reference.
+    private func readObject() throws -> MessageTypedStreamValue? {
+        switch try getCurrentByte() {
+        case START:
+            let classResult = try readClass()
+            switch classResult {
+            case .index(let idx):
+                return objectTable[safe: idx]
+            case .classHierarchy(let classes):
+                try consumeDecodedValues(classes.count)
+                objectTable.append(contentsOf: classes)
+            }
+            return nil
+        case EMPTY:
+            idx += 1
+            return nil
+        default:
+            let index = try readPointer()
+            return objectTable[safe: Int(index)]
+        }
+    }
+
+    /// Reads a length-prefixed string from the stream.
+    private func readString() throws -> String {
+        let length = try readUnsignedInt()
+        let string = try readExactAsString(length: Int(length))
+        return string
+    }
+
+    /// Reads embedded `MessageTypedStreamValue` data (e.g. from `MessageTypedStreamType.embeddedData`).
+    private func readEmbeddedData() throws -> MessageTypedStreamValue? {
+        guard embeddedDepth < 256 else { throw MessageTypedStreamDecoderError.nestingTooDeep }
+        embeddedDepth += 1
+        defer { embeddedDepth -= 1 }
+        // Skip the 0x84
+        idx += 1
+        if let types = try getType(embedded: true) {
+            return try readTypes(foundTypes: types)
+        }
+        return nil
+    }
+
+    /// Returns the current type(s), from the stream or `typesTable` by reference.
+    /// - Parameter embedded: When true, records embedded types in the object table.
+    private func getType(embedded: Bool) throws -> [MessageTypedStreamType]? {
+        switch try getCurrentByte() {
+        case START:
+            // Ignore repeated types, for example in a dict
+            idx += 1
+            let objectTypes = try readType()
+            // Embedded data is stored as a C String in the objects table
+            if embedded {
+                try consumeDecodedValues()
+                objectTable.append(.type(objectTypes))
+                seenEmbeddedTypes.insert(UInt32(typesTable.count))
+            }
+            typesTable.append(objectTypes)
+            return typesTable.last
+        case END:
+            // This indicates the end of the current object
+            return nil
+        default:
+            // Ignore repeated types, for example in a dict
+            while try getCurrentByte() == getNextByte() {
+                idx += 1
+            }
+            let refTag = try readPointer()
+            let result = typesTable[safe: Int(refTag)]
+            if embedded, let res = result {
+                // We only want to include the first embedded reference tag, not subsequent references to the same embed
+                if !seenEmbeddedTypes.contains(refTag) {
+                    try consumeDecodedValues()
+                    objectTable.append(.type(res))
+                    seenEmbeddedTypes.insert(refTag)
+                }
+            }
+            return result
+        }
+    }
+
+    /// Parses stream data according to the given types and returns an `MessageTypedStreamValue`.
+    private func readTypes(foundTypes: [MessageTypedStreamType]) throws -> MessageTypedStreamValue? {
+        // Reserve the full type expansion up front so references cannot repeatedly
+        // inflate a small declaration into an unbounded output graph.
+        try consumeDecodedValues(foundTypes.count)
+        var output: [MessageTypedStreamObject] = []
+        var isObject = false
+
+        for foundType in foundTypes {
+            switch foundType {
+            case .utf8String:
+                let string = try readString()
+                output.append(.string(string))
+            case .embeddedData:
+                if let embeddedData = try readEmbeddedData() {
+                    return embeddedData
+                }
+            case .object:
+                isObject = true
+                let length = objectTable.count
+                placeholder = length
+                try consumeDecodedValues()
+                objectTable.append(.placeholder)
+                if let object = try readObject() {
+                    switch object {
+                    case .object(_, let data):
+                        // If this is a new object, i.e. one without any data, we add the data into it later
+                        // If the object already has data in it, we just want to return that object
+                        if !data.isEmpty {
+                            placeholder = nil
+                            objectTable.removeLast()
+                            return object
+                        }
+                        try consumeDecodedValues(data.count)
+                        output.append(contentsOf: data)
+                    case .class(let cls):
+                        output.append(.class(cls))
+                    case .data(let data):
+                        try consumeDecodedValues(data.count)
+                        output.append(contentsOf: data)
+                    default:
+                        break
+                    }
+                }
+            case .signedInt:
+                let value = try readSignedInt()
+                output.append(.signedInteger(value))
+            case .unsignedInt:
+                let value = try readUnsignedInt()
+                output.append(.unsignedInteger(value))
+            case .float:
+                let value = try readFloat()
+                output.append(.float(value))
+            case .double:
+                let value = try readDouble()
+                output.append(.double(value))
+            case .unknown(let byte):
+                output.append(.byte(byte))
+            case .string(let s):
+                output.append(.string(s))
+            case .array(let size):
+                let array = try readArray(size: size)
+                output.append(.array(array))
+            }
+        }
+
+        // If we had reserved a place for an object, fill that spot
+        if let spot = placeholder {
+            if !output.isEmpty {
+                // We got a class, but do not have its respective data yet
+                if let last = output.last, case .class(let cls) = last {
+                    objectTable[spot] = .object(cls, [])
+                }
+                // The spot after the current placeholder contains the class at the top of the class hierarchy
+                else if let next = objectTable[safe: spot + 1], case .class(let cls) = next {
+                    objectTable[spot] = .object(cls, output)
+                    placeholder = nil
+                    return objectTable[spot]
+                }
+                // We got some data for a class that was already seen
+                else if case .object(let cls, var data) = objectTable[spot] {
+                    try consumeDecodedValues(output.count)
+                    data.append(contentsOf: output)
+                    objectTable[spot] = .object(cls, data)
+                    placeholder = nil
+                    return objectTable[spot]
+                }
+                // We got some data that is not part of a class
+                else {
+                    objectTable[spot] = .data(output)
+                    placeholder = nil
+                    return objectTable[spot]
+                }
+            }
+        }
+
+        if !output.isEmpty && !isObject {
+            return .data(output)
+        }
+
+        return nil
+    }
+}
+
+// MARK: -
+
+extension Array {
+    /// Returns the element at `index` if in bounds; otherwise `nil`.
+    fileprivate subscript(safe index: Int) -> Element? {
+        return indices.contains(index) ? self[index] : nil
+    }
+}

--- a/Sources/Phosphor/Utilities/MessageTypedStream/MessageTypedStreamObject.swift
+++ b/Sources/Phosphor/Utilities/MessageTypedStream/MessageTypedStreamObject.swift
@@ -1,0 +1,22 @@
+// Adapted from Madrid TypedStream at commit 8f5f4f1.
+// Copyright 2025 Mattt. Licensed under the MIT License; see THIRD_PARTY_NOTICES.md.
+
+/// Structures containing data stored in the `typedstream`
+public enum MessageTypedStreamObject: Hashable, Sendable {
+    /// Text data, denoted in the stream by `MessageTypedStreamType.utf8String`
+    case string(String)
+    /// Signed integer types, denoted in the stream by `MessageTypedStreamType.signedInt`
+    case signedInteger(Int64)
+    /// Unsigned integer types, denoted in the stream by `MessageTypedStreamType.unsignedInt`
+    case unsignedInteger(UInt64)
+    /// Floating point numbers, denoted in the stream by `MessageTypedStreamType.float`
+    case float(Float)
+    /// Double precision floats, denoted in the stream by `MessageTypedStreamType.double`
+    case double(Double)
+    /// Bytes whose type is not known, denoted in the stream by `MessageTypedStreamType.unknown`
+    case byte(UInt8)
+    /// Collection of bytes in an array, denoted in the stream by `MessageTypedStreamType.array`
+    case array([UInt8])
+    /// A found class, used by `MessageTypedStreamValue.classCase`
+    case `class`(MessageTypedStreamClass)
+}

--- a/Sources/Phosphor/Utilities/MessageTypedStream/MessageTypedStreamType.swift
+++ b/Sources/Phosphor/Utilities/MessageTypedStream/MessageTypedStreamType.swift
@@ -1,0 +1,111 @@
+// Adapted from Madrid TypedStream at commit 8f5f4f1.
+// Copyright 2025 Mattt. Licensed under the MIT License; see THIRD_PARTY_NOTICES.md.
+
+/// Represents primitive types of data that can be stored in a `typedstream`
+///
+/// These type encodings are partially documented [here](https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/ObjCRuntimeGuide/Articles/ocrtTypeEncodings.html) by Apple.
+public enum MessageTypedStreamType: Hashable, Sendable {
+    /// Encoded string data, usually embedded in an object. Denoted by:
+    ///
+    /// | Hex    | UTF-8 |
+    /// |--------|-------|
+    /// | `0x28` | `+`   |
+    case utf8String
+    /// Encoded bytes that can be parsed again as data. Denoted by:
+    ///
+    /// | Hex    | UTF-8 |
+    /// |--------|-------|
+    /// | `0x2A` | `*`   |
+    case embeddedData
+    /// An instance of a class, usually with data. Denoted by:
+    ///
+    /// | Hex    | UTF-8 |
+    /// |--------|-------|
+    /// | `0x40` | `@`   |
+    case object
+    /// A signed integer type. Denoted by:
+    ///
+    /// | Hex    | UTF-8 |
+    /// |--------|-------|
+    /// | `0x63` | `c`   |
+    /// | `0x69` | `i`   |
+    /// | `0x6C` | `l`   |
+    /// | `0x71` | `q`   |
+    /// | `0x73` | `s`   |
+    case signedInt
+    /// An unsigned integer type. Denoted by:
+    ///
+    /// | Hex    | UTF-8 |
+    /// |--------|-------|
+    /// | `0x43` | `C`   |
+    /// | `0x49` | `I`   |
+    /// | `0x4C` | `L`   |
+    /// | `0x51` | `Q`   |
+    /// | `0x53` | `S`   |
+    case unsignedInt
+    /// A `Float` value. Denoted by:
+    ///
+    /// | Hex    | UTF-8 |
+    /// |--------|-------|
+    /// | `0x66` | `f`   |
+    case float
+    /// A `Double` value. Denoted by:
+    ///
+    /// | Hex    | UTF-8 |
+    /// |--------|-------|
+    /// | `0x64` | `d`   |
+    case double
+    /// Some text we can reuse later, e.g., a class name.
+    case string(String)
+    /// An array containing some data of a given length. Denoted by braced digits: `[123]`.
+    case array(Int)
+    /// Data for which we do not know the type.
+    case unknown(UInt8)
+
+    static func fromByte(_ byte: UInt8) -> MessageTypedStreamType {
+        switch byte {
+        case 0x40:
+            return .object
+        case 0x2B:
+            return .utf8String
+        case 0x2A:
+            return .embeddedData
+        case 0x66:
+            return .float
+        case 0x64:
+            return .double
+        case 0x63, 0x69, 0x6C, 0x71, 0x73:
+            return .signedInt
+        case 0x43, 0x49, 0x4C, 0x51, 0x53:
+            return .unsignedInt
+        default:
+            return .unknown(byte)
+        }
+    }
+
+    static func newString(_ string: String) -> MessageTypedStreamType {
+        return .string(string)
+    }
+
+    static func getArrayLength(types: [UInt8]) -> ([MessageTypedStreamType], Int)? {
+        guard let first = types.first, first == 0x5B else {  // '[' character
+            return nil
+        }
+        var length = 0
+        var index = 1
+        while index < types.count,
+            let digit = UInt8(exactly: types[index]),
+            (48 ... 57).contains(digit)
+        {
+            let value = Int(digit - 48)  // ASCII '0' is 48
+            guard length <= (Int.max - value) / 10 else { return nil }
+            length = length * 10 + value
+            index += 1
+        }
+        if length > 0 {
+            return ([.array(length)], index)
+        } else {
+            return nil
+        }
+    }
+}

--- a/Sources/Phosphor/Utilities/MessageTypedStream/MessageTypedStreamValue.swift
+++ b/Sources/Phosphor/Utilities/MessageTypedStream/MessageTypedStreamValue.swift
@@ -1,0 +1,112 @@
+// Adapted from Madrid TypedStream at commit 8f5f4f1.
+// Copyright 2025 Mattt. Licensed under the MIT License; see THIRD_PARTY_NOTICES.md.
+
+/// Types of data that can be archived into the `typedstream`
+public enum MessageTypedStreamValue: Hashable, Sendable {
+    /// An instance of a class that may contain some embedded data.
+    /// `typedstream` data doesn't include property names, so data is stored in order of appearance.
+    case object(MessageTypedStreamClass, [MessageTypedStreamObject])
+    /// Data that is likely a property on the object described by the `typedstream` but not part of a class.
+    case data([MessageTypedStreamObject])
+    /// A class referenced in the `typedstream`, usually part of an inheritance hierarchy that does not contain any data itself.
+    case `class`(MessageTypedStreamClass)
+    /// A placeholder, used when reserving a spot in the objects table for a reference to be filled with class information.
+    case placeholder
+    /// A type that made it through the parsing process without getting replaced by an object.
+    case type([MessageTypedStreamType])
+
+    // MARK: - Convenience Properties
+
+    /// If this archivable represents an `NSString` or `NSMutableString` object,
+    /// returns its string value.
+    ///
+    /// ### Example
+    /// ```swift
+    /// let nsstring = MessageTypedStreamValue.object(
+    ///     MessageTypedStreamClass(name: "NSString", version: 1),
+    ///     [.string("Hello world")]
+    /// )
+    /// print(nsstring.stringValue) // Optional("Hello world")
+    ///
+    /// let notNSString = MessageTypedStreamValue.object(
+    ///     MessageTypedStreamClass(name: "NSNumber", version: 1),
+    ///     [.signedInteger(100)]
+    /// )
+    /// print(notNSString.stringValue) // nil
+    /// ```
+    public var stringValue: String? {
+        if case let .object(classInfo, value) = self,
+            classInfo.name == "NSString" || classInfo.name == "NSMutableString",
+            let first = value.first,
+            case let .string(text) = first
+        {
+            // Filter out strings that look like attribute keys or metadata
+            if text.hasPrefix("__k")  // System keys often start with __k
+                || text.contains("Attribute")  // Attribute names
+                || text.contains("NS")  // Foundation framework keys
+                || !text.contains(where: { $0.isLetter || $0.isNumber })  // Strings with no letters or numbers are likely metadata
+            {
+                return nil
+            }
+
+            return text
+        }
+        return nil
+    }
+
+    /// If this archivable represents an `NSNumber` object containing an integer,
+    /// returns its 64-bit integer value.
+    ///
+    /// ### Example
+    /// ```swift
+    /// let nsnumber = MessageTypedStreamValue.object(
+    ///     MessageTypedStreamClass(name: "NSNumber", version: 1),
+    ///     [.signedInteger(100)]
+    /// )
+    /// print(nsnumber.integerValue) // Optional(100)
+    ///
+    /// let notNSNumber = MessageTypedStreamValue.object(
+    ///     MessageTypedStreamClass(name: "NSString", version: 1),
+    ///     [.string("Hello world")]
+    /// )
+    /// print(notNSNumber.integerValue) // nil
+    /// ```
+    public var integerValue: Int64? {
+        if case let .object(classInfo, value) = self,
+            classInfo.name == "NSNumber",
+            let first = value.first,
+            case let .signedInteger(num) = first
+        {
+            return num
+        }
+        return nil
+    }
+
+    /// If this archivable represents an `NSNumber` object containing a floating-point value,
+    /// returns its double-precision value.
+    ///
+    /// ### Example
+    /// ```swift
+    /// let nsnumber = MessageTypedStreamValue.object(
+    ///     MessageTypedStreamClass(name: "NSNumber", version: 1),
+    ///     [.double(100.001)]
+    /// )
+    /// print(nsnumber.doubleValue) // Optional(100.001)
+    ///
+    /// let notNSNumber = MessageTypedStreamValue.object(
+    ///     MessageTypedStreamClass(name: "NSString", version: 1),
+    ///     [.string("Hello world")]
+    /// )
+    /// print(notNSNumber.doubleValue) // nil
+    /// ```
+    public var doubleValue: Double? {
+        if case let .object(classInfo, value) = self,
+            classInfo.name == "NSNumber",
+            let first = value.first,
+            case let .double(num) = first
+        {
+            return num
+        }
+        return nil
+    }
+}

--- a/Sources/Phosphor/Utilities/PDFTranscriptWriter.swift
+++ b/Sources/Phosphor/Utilities/PDFTranscriptWriter.swift
@@ -1,6 +1,7 @@
 import AppKit
 import CoreText
 import Foundation
+import ImageIO
 
 /// Writes paginated, iMessage-inspired transcript PDFs without loading a WebView
 /// or holding a giant rendered document in memory. The output favors a natural
@@ -8,6 +9,13 @@ import Foundation
 /// previews, media/link cards, or tapback badges instead of being rendered as a
 /// list of transcript pills after each message.
 enum PDFTranscriptWriter {
+    struct Attachment {
+        let summary: String
+        /// A resolved backup file path for image attachments. The writer creates
+        /// a bounded thumbnail; non-images and unreadable files remain text cards.
+        var imagePath: String? = nil
+    }
+
     struct Entry {
         let title: String
         let subtitle: String
@@ -15,7 +23,7 @@ enum PDFTranscriptWriter {
         let isFromMe: Bool
         var reactions: [String] = []
         var inlineReply: String? = nil
-        var attachments: [String] = []
+        var attachments: [Attachment] = []
         var linkURL: String? = nil
         var status: String? = nil
     }
@@ -57,6 +65,8 @@ enum PDFTranscriptWriter {
             let text: NSAttributedString
             let fill: CGColor
             let accent: CGColor?
+            let image: CGImage?
+            let imageHeight: CGFloat
             let height: CGFloat
         }
 
@@ -122,7 +132,37 @@ enum PDFTranscriptWriter {
                 text: text,
                 fill: isFromMe ? outgoingInlineCardColor : incomingInlineCardColor,
                 accent: accent,
+                image: nil,
+                imageHeight: 0,
                 height: height
+            )
+        }
+
+        func makeAttachmentCard(_ attachment: Attachment, width: CGFloat, isFromMe: Bool) -> BubbleCard {
+            let text = attributed("📎 \(attachment.summary)", font: .systemFont(ofSize: 9.5), color: isFromMe ? outgoingTextColor : primaryTextColor)
+            let captionHeight = measuredHeight(text, width: width - 18) + 9
+            guard let path = attachment.imagePath,
+                  let image = thumbnailImage(at: path, maxPixelSize: 1200) else {
+                return BubbleCard(
+                    text: text,
+                    fill: isFromMe ? outgoingInlineCardColor : incomingInlineCardColor,
+                    accent: nil,
+                    image: nil,
+                    imageHeight: 0,
+                    height: captionHeight
+                )
+            }
+
+            let imageWidth = max(width - 8, 1)
+            let aspectHeight = imageWidth * CGFloat(image.height) / CGFloat(max(image.width, 1))
+            let imageHeight = min(180, max(72, aspectHeight))
+            return BubbleCard(
+                text: text,
+                fill: isFromMe ? outgoingInlineCardColor : incomingInlineCardColor,
+                accent: nil,
+                image: image,
+                imageHeight: imageHeight,
+                height: imageHeight + captionHeight + 4
             )
         }
 
@@ -134,7 +174,7 @@ enum PDFTranscriptWriter {
             if let link = entry.linkURL, !link.isEmpty {
                 out.append(makeCard("🔗 \(link)", width: width, isFromMe: entry.isFromMe))
             }
-            out.append(contentsOf: entry.attachments.map { makeCard("📎 \($0)", width: width, isFromMe: entry.isFromMe) })
+            out.append(contentsOf: entry.attachments.map { makeAttachmentCard($0, width: width, isFromMe: entry.isFromMe) })
             return out
         }
 
@@ -144,7 +184,27 @@ enum PDFTranscriptWriter {
                 context.setFillColor(accent)
                 context.fill(CGRect(x: x + 7, y: pageHeight - topY - card.height + 6, width: 2, height: max(4, card.height - 12)))
             }
-            draw(card.text, in: CGRect(x: x + 12, y: topY + 4, width: width - 20, height: card.height - 8), context: context, pageHeight: pageHeight)
+            var textTopY = topY + 4
+            if let image = card.image {
+                let availableWidth = width - 8
+                let sourceWidth = CGFloat(max(image.width, 1))
+                let sourceHeight = CGFloat(max(image.height, 1))
+                let scale = min(availableWidth / sourceWidth, card.imageHeight / sourceHeight)
+                let drawWidth = sourceWidth * scale
+                let drawHeight = sourceHeight * scale
+                let imageRect = CGRect(
+                    x: x + 4 + ((availableWidth - drawWidth) / 2),
+                    y: pageHeight - topY - 4 - ((card.imageHeight + drawHeight) / 2),
+                    width: drawWidth,
+                    height: drawHeight
+                )
+                context.saveGState()
+                context.interpolationQuality = .high
+                context.draw(image, in: imageRect)
+                context.restoreGState()
+                textTopY += card.imageHeight + 4
+            }
+            draw(card.text, in: CGRect(x: x + 12, y: textTopY, width: width - 20, height: card.height - (textTopY - topY) - 4), context: context, pageHeight: pageHeight)
         }
 
         func drawReactionBadge(_ entry: Entry, bubbleX: CGFloat, bubbleTopY: CGFloat, bubbleWidth: CGFloat) {
@@ -228,13 +288,14 @@ enum PDFTranscriptWriter {
                 y += senderHeight + 2
             }
 
-            let textColor = entry.isFromMe ? outgoingTextColor : primaryTextColor
-            let text = attributed(entry.body.isEmpty ? "[Empty message]" : entry.body,
-                                  font: .systemFont(ofSize: 11.5),
-                                  color: textColor)
             let maxTextWidth = bubbleMaxWidth - (bubblePaddingX * 2)
             let cardWidthProbe = maxTextWidth
             let bubbleCards = cards(for: entry, width: cardWidthProbe)
+            let textColor = entry.isFromMe ? outgoingTextColor : primaryTextColor
+            let visibleBody = entry.body.isEmpty && bubbleCards.isEmpty ? "[Empty message]" : entry.body
+            let text = attributed(visibleBody,
+                                  font: .systemFont(ofSize: 11.5),
+                                  color: textColor)
             let preferredBodyWidth = measuredSize(text, width: maxTextWidth).width
             let preferredCardWidth = bubbleCards.reduce(CGFloat(0)) { max($0, measuredSize($1.text, width: maxTextWidth).width + 20) }
             let textWidth = min(maxTextWidth, max(86, ceil(max(preferredBodyWidth, preferredCardWidth))))
@@ -307,6 +368,21 @@ enum PDFTranscriptWriter {
     private static let reactionBadgeColor = NSColor.white.cgColor
     private static let reactionBadgeBorderColor = NSColor(calibratedWhite: 0.82, alpha: 1).cgColor
     private static let replyAccentColor = NSColor(calibratedWhite: 0.62, alpha: 1).cgColor
+
+    /// Decode a bounded first-frame thumbnail instead of materializing a full-size
+    /// backup-controlled image in memory. ImageIO also applies HEIC/JPEG orientation.
+    private static func thumbnailImage(at path: String, maxPixelSize: Int) -> CGImage? {
+        let url = URL(fileURLWithPath: path) as CFURL
+        let sourceOptions = [kCGImageSourceShouldCache: false] as CFDictionary
+        guard let source = CGImageSourceCreateWithURL(url, sourceOptions) else { return nil }
+        let thumbnailOptions = [
+            kCGImageSourceCreateThumbnailFromImageAlways: true,
+            kCGImageSourceCreateThumbnailWithTransform: true,
+            kCGImageSourceThumbnailMaxPixelSize: maxPixelSize,
+            kCGImageSourceShouldCacheImmediately: true
+        ] as CFDictionary
+        return CGImageSourceCreateThumbnailAtIndex(source, 0, thumbnailOptions)
+    }
 
     private static func attributed(_ raw: String,
                                    font: NSFont,

--- a/Sources/Phosphor/Utilities/PDFTranscriptWriter.swift
+++ b/Sources/Phosphor/Utilities/PDFTranscriptWriter.swift
@@ -19,6 +19,7 @@ enum PDFTranscriptWriter {
     struct Entry {
         let title: String
         let subtitle: String
+        var timestamp: Date = .distantPast
         let body: String
         let isFromMe: Bool
         var reactions: [String] = []
@@ -59,12 +60,14 @@ enum PDFTranscriptWriter {
         var y: CGFloat = margin
         var pageNumber = 0
         let showIncomingSenderLabels = Set(entries.filter { !$0.isFromMe && !$0.title.isEmpty }.map { $0.title }).count > 1
-        var messagesSinceTimestamp = 99
+        let calendar = Calendar.current
+        var previousMessageTimestamp: Date?
 
         struct BubbleCard {
             let text: NSAttributedString
             let fill: CGColor
             let accent: CGColor?
+            let url: URL?
             let image: CGImage?
             let imageHeight: CGFloat
             let height: CGFloat
@@ -103,18 +106,22 @@ enum PDFTranscriptWriter {
             y += metaHeight + 18
         }
 
-        func drawTimestampIfNeeded(_ value: String) {
-            guard !value.isEmpty else { return }
-            // Real Messages uses occasional centered time separators, not a log
-            // timestamp above every bubble. Keep the first timestamp, then space
-            // later separators out so the page reads like a conversation.
-            guard messagesSinceTimestamp >= 8 else { return }
-            let meta = attributed(value, font: .systemFont(ofSize: 8.5), color: secondaryTextColor, alignment: .center)
+        func drawTimestampIfNeeded(for entry: Entry) {
+            defer { previousMessageTimestamp = entry.timestamp }
+            guard !entry.subtitle.isEmpty else { return }
+            let shouldDraw: Bool
+            if let previousMessageTimestamp {
+                shouldDraw = !calendar.isDate(entry.timestamp, inSameDayAs: previousMessageTimestamp)
+                    || entry.timestamp.timeIntervalSince(previousMessageTimestamp) >= timestampSeparatorGap
+            } else {
+                shouldDraw = true
+            }
+            guard shouldDraw else { return }
+            let meta = attributed(entry.subtitle, font: .systemFont(ofSize: 8.5), color: secondaryTextColor, alignment: .center)
             let metaHeight = measuredHeight(meta, width: contentWidth)
             ensureSpace(metaHeight + 18)
             draw(meta, in: CGRect(x: margin, y: y, width: contentWidth, height: metaHeight), context: context, pageHeight: pageHeight)
             y += metaHeight + 7
-            messagesSinceTimestamp = 0
         }
 
         func drawRoundedRect(x: CGFloat, topY: CGFloat, width: CGFloat, height: CGFloat, radius: CGFloat, fill: CGColor) {
@@ -125,13 +132,14 @@ enum PDFTranscriptWriter {
             context.fillPath()
         }
 
-        func makeCard(_ raw: String, width: CGFloat, isFromMe: Bool, accent: CGColor? = nil) -> BubbleCard {
+        func makeCard(_ raw: String, width: CGFloat, isFromMe: Bool, accent: CGColor? = nil, url: URL? = nil) -> BubbleCard {
             let text = attributed(raw, font: .systemFont(ofSize: 9.5), color: isFromMe ? outgoingTextColor : primaryTextColor)
             let height = measuredHeight(text, width: width - 18) + 9
             return BubbleCard(
                 text: text,
                 fill: isFromMe ? outgoingInlineCardColor : incomingInlineCardColor,
                 accent: accent,
+                url: url,
                 image: nil,
                 imageHeight: 0,
                 height: height
@@ -147,6 +155,7 @@ enum PDFTranscriptWriter {
                     text: text,
                     fill: isFromMe ? outgoingInlineCardColor : incomingInlineCardColor,
                     accent: nil,
+                    url: nil,
                     image: nil,
                     imageHeight: 0,
                     height: captionHeight
@@ -160,6 +169,7 @@ enum PDFTranscriptWriter {
                 text: text,
                 fill: isFromMe ? outgoingInlineCardColor : incomingInlineCardColor,
                 accent: nil,
+                url: nil,
                 image: image,
                 imageHeight: imageHeight,
                 height: imageHeight + captionHeight + 4
@@ -171,8 +181,8 @@ enum PDFTranscriptWriter {
             if let inlineReply = entry.inlineReply, !inlineReply.isEmpty {
                 out.append(makeCard("↩︎ Inline reply: \(inlineReply)", width: width, isFromMe: entry.isFromMe, accent: entry.isFromMe ? outgoingTextColor.cgColor : replyAccentColor))
             }
-            if let link = entry.linkURL, !link.isEmpty {
-                out.append(makeCard("🔗 \(link)", width: width, isFromMe: entry.isFromMe))
+            if let link = entry.linkURL, let url = validHTTPURL(link) {
+                out.append(makeCard("🔗 \(link)", width: width, isFromMe: entry.isFromMe, url: url))
             }
             out.append(contentsOf: entry.attachments.map { makeAttachmentCard($0, width: width, isFromMe: entry.isFromMe) })
             return out
@@ -180,6 +190,12 @@ enum PDFTranscriptWriter {
 
         func drawCard(_ card: BubbleCard, x: CGFloat, topY: CGFloat, width: CGFloat) {
             drawRoundedRect(x: x, topY: topY, width: width, height: card.height, radius: 11, fill: card.fill)
+            if let url = card.url {
+                // CGContext uses PDF page coordinates (bottom-left origin), while
+                // rendering below accepts top-left coordinates.
+                let annotationRect = CGRect(x: x, y: pageHeight - topY - card.height, width: width, height: card.height)
+                context.setURL(url as CFURL, for: annotationRect)
+            }
             if let accent = card.accent {
                 context.setFillColor(accent)
                 context.fill(CGRect(x: x + 7, y: pageHeight - topY - card.height + 6, width: 2, height: max(4, card.height - 12)))
@@ -278,7 +294,7 @@ enum PDFTranscriptWriter {
         }
 
         func drawMessage(_ entry: Entry) throws {
-            drawTimestampIfNeeded(entry.subtitle)
+            drawTimestampIfNeeded(for: entry)
 
             if !entry.isFromMe, showIncomingSenderLabels, !entry.title.isEmpty {
                 let sender = attributed(entry.title, font: .systemFont(ofSize: 9, weight: .medium), color: secondaryTextColor)
@@ -341,7 +357,6 @@ enum PDFTranscriptWriter {
             } while offset < text.length
 
             drawStatus(entry.status, bubbleX: bubbleX, bubbleWidth: bubbleWidth, isFromMe: entry.isFromMe)
-            messagesSinceTimestamp += 1
             y += 6
         }
 
@@ -368,6 +383,17 @@ enum PDFTranscriptWriter {
     private static let reactionBadgeColor = NSColor.white.cgColor
     private static let reactionBadgeBorderColor = NSColor(calibratedWhite: 0.82, alpha: 1).cgColor
     private static let replyAccentColor = NSColor(calibratedWhite: 0.62, alpha: 1).cgColor
+    private static let timestampSeparatorGap: TimeInterval = 30 * 60
+
+    private static func validHTTPURL(_ raw: String) -> URL? {
+        guard let url = URL(string: raw),
+              let scheme = url.scheme?.lowercased(),
+              scheme == "http" || scheme == "https",
+              url.host?.isEmpty == false else {
+            return nil
+        }
+        return url
+    }
 
     /// Decode a bounded first-frame thumbnail instead of materializing a full-size
     /// backup-controlled image in memory. ImageIO also applies HEIC/JPEG orientation.

--- a/Sources/Phosphor/ViewModels/MessageViewModel.swift
+++ b/Sources/Phosphor/ViewModels/MessageViewModel.swift
@@ -112,6 +112,7 @@ final class MessageViewModel: ObservableObject {
 
     private var exporter: MessageExporter?
     private var backupPath: String?
+    private var contactDirectory: ContactDirectory = .empty
     private var exportCancelled = false
     private var exportTask: Task<Void, Never>?
     private var exportOperationID: UUID?
@@ -124,6 +125,7 @@ final class MessageViewModel: ObservableObject {
         exportOperationID = nil
         exporter = nil
         backupPath = nil
+        contactDirectory = .empty
         chats = []
         selectedChat = nil
         messages = []
@@ -154,6 +156,7 @@ final class MessageViewModel: ObservableObject {
             invalidateExportForBackupSwitch()
         }
         self.backupPath = backupPath
+        contactDirectory = .empty
         backupReadiness = Self.readiness(for: backupPath)
         backupReadinessMessage = backupReadiness.subtitle
         selectedChat = nil
@@ -178,6 +181,7 @@ final class MessageViewModel: ObservableObject {
         } else {
             directory = .empty
         }
+        self.contactDirectory = directory
 
         do {
             let exporter = try MessageExporter(backupPath: backupPath, contacts: directory)
@@ -244,6 +248,7 @@ final class MessageViewModel: ObservableObject {
         let options = MessageExportOptions(startDate: range.start, endDate: range.end, includeAttachments: includeAttachments)
         let sourceMessages = visibleMessages
         let fallbackMessages = messages
+        let contactDirectory = self.contactDirectory
         isExporting = true
         exportCancelled = false
         exportProgress = 0.1
@@ -251,9 +256,9 @@ final class MessageViewModel: ObservableObject {
         let exportID = UUID()
         exportOperationID = exportID
 
-        exportTask = Task.detached(priority: .userInitiated) { [weak self, chat, sourceMessages, fallbackMessages, backupPath, exportID] in
+        exportTask = Task.detached(priority: .userInitiated) { [weak self, chat, sourceMessages, fallbackMessages, backupPath, contactDirectory, exportID] in
             do {
-                let exporter = try MessageExporter(backupPath: backupPath, contacts: .empty)
+                let exporter = try MessageExporter(backupPath: backupPath, contacts: contactDirectory)
                 let baseMessages: [Message]
                 if let sourceMessages {
                     baseMessages = sourceMessages
@@ -298,6 +303,7 @@ final class MessageViewModel: ObservableObject {
         guard let backupPath else { return }
         let range = dateFilter.range(customStart: customStart, customEnd: customEnd)
         let options = MessageExportOptions(startDate: range.start, endDate: range.end, includeAttachments: includeAttachments)
+        let contactDirectory = self.contactDirectory
         isExporting = true
         exportCancelled = false
         exportProgress = 0
@@ -305,9 +311,9 @@ final class MessageViewModel: ObservableObject {
         let exportID = UUID()
         exportOperationID = exportID
 
-        exportTask = Task.detached(priority: .userInitiated) { [weak self, backupPath, exportID] in
+        exportTask = Task.detached(priority: .userInitiated) { [weak self, backupPath, contactDirectory, exportID] in
             do {
-                let exporter = try MessageExporter(backupPath: backupPath, contacts: .empty)
+                let exporter = try MessageExporter(backupPath: backupPath, contacts: contactDirectory)
                 let count = try exporter.exportAllChats(
                     format: format,
                     to: directory,

--- a/Sources/Phosphor/ViewModels/MessageViewModel.swift
+++ b/Sources/Phosphor/ViewModels/MessageViewModel.swift
@@ -358,6 +358,74 @@ final class MessageViewModel: ObservableObject {
         }
     }
 
+    func startExportAllChatsAllFormats(
+        to parentDirectory: String,
+        dateFilter: MessageDateFilter = .all,
+        customStart: Date = Date(),
+        customEnd: Date = Date()
+    ) {
+        guard let backupPath else { return }
+        let range = dateFilter.range(customStart: customStart, customEnd: customEnd)
+        let options = MessageExportOptions(startDate: range.start, endDate: range.end, includeAttachments: true)
+        let contactDirectory = self.contactDirectory
+        isExporting = true
+        exportCancelled = false
+        exportProgress = 0
+        exportProgressText = "Preparing complete export…"
+        let exportID = UUID()
+        exportOperationID = exportID
+
+        exportTask = Task.detached(priority: .userInitiated) { [weak self, backupPath, contactDirectory, exportID] in
+            do {
+                let exporter = try MessageExporter(backupPath: backupPath, contacts: contactDirectory)
+                let result = try exporter.exportAllChatsAllFormats(
+                    to: parentDirectory,
+                    options: options,
+                    onProgress: { completed, total, title in
+                        try Task.checkCancellation()
+                        let progress = total == 0 ? 0 : Double(completed) / Double(total)
+                        Task { @MainActor [weak self] in
+                            guard let self, self.exportOperationID == exportID, self.backupPath == backupPath else { return }
+                            self.exportProgress = progress
+                            self.exportProgressText = completed >= total
+                                ? "Export complete"
+                                : "Exporting \(completed + 1) of \(total): \(title)"
+                        }
+                    },
+                    cancellationCheck: {
+                        try Task.checkCancellation()
+                    }
+                )
+                await MainActor.run { [weak self] in
+                    guard let self, self.exportOperationID == exportID, self.backupPath == backupPath else { return }
+                    self.isExporting = false
+                    self.exportOperationID = nil
+                    self.exportProgress = 1
+                    self.exportResult = MessageExportResult(
+                        url: result.directory,
+                        summary: "Exported \(result.count) conversations in all formats with attachments"
+                    )
+                }
+            } catch is CancellationError {
+                await MainActor.run { [weak self] in
+                    guard let self, self.exportOperationID == exportID, self.backupPath == backupPath else { return }
+                    self.isExporting = false
+                    self.exportOperationID = nil
+                    self.alertMessage = "Export cancelled"
+                    self.showAlert = true
+                }
+            } catch {
+                await MainActor.run { [weak self] in
+                    guard let self, self.exportOperationID == exportID, self.backupPath == backupPath else { return }
+                    self.isExporting = false
+                    self.exportOperationID = nil
+                    self.alertMessage = "Export failed: \(error.localizedDescription)"
+                    self.showAlert = true
+                }
+            }
+        }
+    }
+
     func revealLastExport() {
         guard let url = exportResult?.url else { return }
         NSWorkspace.shared.activateFileViewerSelecting([url])

--- a/Sources/Phosphor/ViewModels/MessageViewModel.swift
+++ b/Sources/Phosphor/ViewModels/MessageViewModel.swift
@@ -241,6 +241,78 @@ final class MessageViewModel: ObservableObject {
         exportProgressText = "Cancelling…"
     }
 
+    func startExportChatPDFBundle(
+        to parentDirectory: String,
+        dateFilter: MessageDateFilter = .all,
+        customStart: Date = Date(),
+        customEnd: Date = Date(),
+        visibleMessages: [Message]? = nil
+    ) {
+        guard let chat = selectedChat, let backupPath else { return }
+        let range = dateFilter.range(customStart: customStart, customEnd: customEnd)
+        let options = MessageExportOptions(startDate: range.start, endDate: range.end, includeAttachments: true)
+        let sourceMessages = visibleMessages
+        let fallbackMessages = messages
+        let contactDirectory = self.contactDirectory
+        isExporting = true
+        exportCancelled = false
+        exportProgress = 0.1
+        exportProgressText = "Creating PDF bundle for \(chat.title)…"
+        let exportID = UUID()
+        exportOperationID = exportID
+
+        exportTask = Task.detached(priority: .userInitiated) { [weak self, chat, sourceMessages, fallbackMessages, backupPath, contactDirectory, exportID] in
+            do {
+                let exporter = try MessageExporter(backupPath: backupPath, contacts: contactDirectory)
+                let baseMessages: [Message]
+                if let sourceMessages {
+                    baseMessages = sourceMessages
+                } else if fallbackMessages.isEmpty {
+                    baseMessages = try exporter.getMessages(chatId: chat.id)
+                } else {
+                    baseMessages = fallbackMessages
+                }
+                let exportedMessageCount = options.apply(to: baseMessages).count
+                try Task.checkCancellation()
+                let result = try exporter.exportChatPDFBundle(
+                    chat: chat,
+                    messages: baseMessages,
+                    to: parentDirectory,
+                    options: options,
+                    cancellationCheck: {
+                        try Task.checkCancellation()
+                    }
+                )
+                await MainActor.run { [weak self] in
+                    guard let self, self.exportOperationID == exportID, self.backupPath == backupPath else { return }
+                    self.isExporting = false
+                    self.exportOperationID = nil
+                    self.exportProgress = 1
+                    self.exportResult = MessageExportResult(
+                        url: result.directory,
+                        summary: "Exported \(exportedMessageCount) messages as a PDF bundle with attachments"
+                    )
+                }
+            } catch is CancellationError {
+                await MainActor.run { [weak self] in
+                    guard let self, self.exportOperationID == exportID, self.backupPath == backupPath else { return }
+                    self.isExporting = false
+                    self.exportOperationID = nil
+                    self.alertMessage = "Export cancelled"
+                    self.showAlert = true
+                }
+            } catch {
+                await MainActor.run { [weak self] in
+                    guard let self, self.exportOperationID == exportID, self.backupPath == backupPath else { return }
+                    self.isExporting = false
+                    self.exportOperationID = nil
+                    self.alertMessage = "Export failed: \(error.localizedDescription)"
+                    self.showAlert = true
+                }
+            }
+        }
+    }
+
     func startExportChat(format: MessageExportFormat, to path: String, dateFilter: MessageDateFilter = .all, customStart: Date = Date(), customEnd: Date = Date(), includeAttachments: Bool = true, visibleMessages: [Message]? = nil) {
         guard let chat = selectedChat, let backupPath else { return }
         let normalisedPath = ensureExtension(path, for: format)

--- a/Sources/Phosphor/ViewModels/WhatsAppViewModel.swift
+++ b/Sources/Phosphor/ViewModels/WhatsAppViewModel.swift
@@ -1,0 +1,280 @@
+import AppKit
+import Foundation
+
+@MainActor
+final class WhatsAppViewModel: ObservableObject {
+    @Published var chats: [WhatsAppExporter.WAChat] = []
+    @Published var selectedChat: WhatsAppExporter.WAChat?
+    @Published var messages: [WhatsAppExporter.WAMessage] = []
+    @Published var isLoading = false
+    @Published var errorMessage: String?
+    @Published var isExporting = false
+    @Published var exportProgressText = ""
+    @Published var exportProgress: Double = 0
+    @Published var exportResult: MessageExportResult?
+    @Published var showAlert = false
+    @Published var alertMessage = ""
+
+    private var exporter: WhatsAppExporter?
+    private var backupPath: String?
+    private var exportTask: Task<Void, Never>?
+    private var exportOperationID: UUID?
+
+    var loadedBackupPath: String? { backupPath }
+    var totalMessages: Int { chats.reduce(0) { $0 + $1.messageCount } }
+
+    func clear() {
+        exportTask?.cancel()
+        exportTask = nil
+        exportOperationID = nil
+        exporter = nil
+        backupPath = nil
+        chats = []
+        selectedChat = nil
+        messages = []
+        isLoading = false
+        errorMessage = nil
+        isExporting = false
+        exportProgressText = ""
+        exportProgress = 0
+        exportResult = nil
+    }
+
+    func loadChats(from backupPath: String) {
+        if self.backupPath != backupPath {
+            exportTask?.cancel()
+            exportOperationID = nil
+            isExporting = false
+        }
+        self.backupPath = backupPath
+        selectedChat = nil
+        messages = []
+        chats = []
+        errorMessage = nil
+        isLoading = true
+        do {
+            let exporter = try WhatsAppExporter(backupPath: backupPath)
+            self.exporter = exporter
+            chats = try exporter.getChats()
+        } catch {
+            exporter = nil
+            errorMessage = error.localizedDescription
+        }
+        isLoading = false
+    }
+
+    func selectChat(_ chat: WhatsAppExporter.WAChat) {
+        selectedChat = chat
+        do {
+            messages = try exporter?.getMessages(chatId: chat.id) ?? []
+        } catch {
+            messages = []
+            alertMessage = "Could not load conversation: \(error.localizedDescription)"
+            showAlert = true
+        }
+    }
+
+    func filteredMessages(
+        searchText: String,
+        dateFilter: MessageDateFilter,
+        customStart: Date = Date(),
+        customEnd: Date = Date()
+    ) -> [WhatsAppExporter.WAMessage] {
+        let range = dateFilter.range(customStart: customStart, customEnd: customEnd)
+        return messages.filter { message in
+            if let start = range.start, message.date < start { return false }
+            if let end = range.end, message.date > end { return false }
+            guard !searchText.isEmpty else { return true }
+            return message.displayText.localizedCaseInsensitiveContains(searchText)
+                || (message.senderJid?.localizedCaseInsensitiveContains(searchText) ?? false)
+                || (message.mediaLocalPath?.localizedCaseInsensitiveContains(searchText) ?? false)
+        }
+    }
+
+    func cancelExport() {
+        exportTask?.cancel()
+        exportProgressText = "Cancelling…"
+    }
+
+    func startExportChatPDFBundle(
+        to parentDirectory: String,
+        dateFilter: MessageDateFilter = .all,
+        customStart: Date = Date(),
+        customEnd: Date = Date(),
+        visibleMessages: [WhatsAppExporter.WAMessage]? = nil
+    ) {
+        guard let chat = selectedChat, let backupPath else { return }
+        let range = dateFilter.range(customStart: customStart, customEnd: customEnd)
+        let options = MessageExportOptions(startDate: range.start, endDate: range.end, includeAttachments: true)
+        let sourceMessages = visibleMessages ?? messages
+        startExport(text: "Creating PDF bundle for \(chat.displayName)…", backupPath: backupPath) { exporter, _ in
+            let result = try exporter.exportChatPDFBundle(
+                chat: chat,
+                messages: sourceMessages,
+                to: parentDirectory,
+                options: options,
+                cancellationCheck: { try Task.checkCancellation() }
+            )
+            return MessageExportResult(
+                url: result.directory,
+                summary: "Exported \(sourceMessages.count) WhatsApp messages as a PDF bundle with attachments"
+            )
+        }
+    }
+
+    func startExportChat(
+        format: MessageExportFormat,
+        to path: String,
+        dateFilter: MessageDateFilter = .all,
+        customStart: Date = Date(),
+        customEnd: Date = Date(),
+        includeAttachments: Bool = true,
+        visibleMessages: [WhatsAppExporter.WAMessage]? = nil
+    ) {
+        guard let chat = selectedChat, let backupPath else { return }
+        let range = dateFilter.range(customStart: customStart, customEnd: customEnd)
+        let options = MessageExportOptions(startDate: range.start, endDate: range.end, includeAttachments: includeAttachments)
+        let sourceMessages = visibleMessages ?? messages
+        let outputPath = ensureExtension(path, for: format)
+        startExport(text: "Exporting \(chat.displayName)…", backupPath: backupPath) { exporter, _ in
+            try exporter.exportMessages(
+                sourceMessages,
+                title: chat.displayName,
+                format: format,
+                to: outputPath,
+                options: options,
+                cancellationCheck: { try Task.checkCancellation() }
+            )
+            return MessageExportResult(
+                url: URL(fileURLWithPath: outputPath),
+                summary: "Exported \(sourceMessages.count) WhatsApp messages"
+            )
+        }
+    }
+
+    func startExportAllChats(
+        format: MessageExportFormat,
+        to directory: String,
+        dateFilter: MessageDateFilter = .all,
+        customStart: Date = Date(),
+        customEnd: Date = Date(),
+        includeAttachments: Bool = true
+    ) {
+        guard let backupPath else { return }
+        let range = dateFilter.range(customStart: customStart, customEnd: customEnd)
+        let options = MessageExportOptions(startDate: range.start, endDate: range.end, includeAttachments: includeAttachments)
+        startExport(text: "Preparing WhatsApp export…", backupPath: backupPath) { exporter, progress in
+            let result = try exporter.exportAllChats(
+                format: format,
+                to: directory,
+                options: options,
+                onProgress: progress,
+                cancellationCheck: { try Task.checkCancellation() }
+            )
+            return MessageExportResult(
+                url: result.directory,
+                summary: "Exported \(result.count) WhatsApp conversations"
+            )
+        }
+    }
+
+    func startExportAllChatsAllFormats(
+        to parentDirectory: String,
+        dateFilter: MessageDateFilter = .all,
+        customStart: Date = Date(),
+        customEnd: Date = Date()
+    ) {
+        guard let backupPath else { return }
+        let range = dateFilter.range(customStart: customStart, customEnd: customEnd)
+        let options = MessageExportOptions(startDate: range.start, endDate: range.end, includeAttachments: true)
+        startExport(text: "Preparing complete WhatsApp export…", backupPath: backupPath) { exporter, progress in
+            let result = try exporter.exportAllChatsAllFormats(
+                to: parentDirectory,
+                options: options,
+                onProgress: progress,
+                cancellationCheck: { try Task.checkCancellation() }
+            )
+            return MessageExportResult(
+                url: result.directory,
+                summary: "Exported \(result.count) WhatsApp conversations in all formats with attachments"
+            )
+        }
+    }
+
+    func revealLastExport() {
+        guard let url = exportResult?.url else { return }
+        NSWorkspace.shared.activateFileViewerSelecting([url])
+    }
+
+    func openLastExport() {
+        guard let url = exportResult?.url else { return }
+        NSWorkspace.shared.open(url)
+    }
+
+    private func startExport(
+        text: String,
+        backupPath: String,
+        operation: @escaping (WhatsAppExporter, @escaping (Int, Int, String) throws -> Void) throws -> MessageExportResult
+    ) {
+        exportTask?.cancel()
+        isExporting = true
+        exportProgress = 0
+        exportProgressText = text
+        let operationID = UUID()
+        exportOperationID = operationID
+
+        exportTask = Task.detached(priority: .userInitiated) { [weak self, backupPath, operationID] in
+            do {
+                let exporter = try WhatsAppExporter(backupPath: backupPath)
+                let result = try operation(exporter) { completed, total, title in
+                    try Task.checkCancellation()
+                    let progress = total == 0 ? 0 : Double(completed) / Double(total)
+                    Task { @MainActor [weak self] in
+                        guard let self,
+                              self.exportOperationID == operationID,
+                              self.backupPath == backupPath else { return }
+                        self.exportProgress = progress
+                        self.exportProgressText = completed >= total
+                            ? "Export complete"
+                            : "Exporting \(completed + 1) of \(total): \(title)"
+                    }
+                }
+                await MainActor.run { [weak self] in
+                    guard let self,
+                          self.exportOperationID == operationID,
+                          self.backupPath == backupPath else { return }
+                    self.isExporting = false
+                    self.exportOperationID = nil
+                    self.exportProgress = 1
+                    self.exportResult = result
+                }
+            } catch is CancellationError {
+                await MainActor.run { [weak self] in
+                    guard let self,
+                          self.exportOperationID == operationID,
+                          self.backupPath == backupPath else { return }
+                    self.isExporting = false
+                    self.exportOperationID = nil
+                    self.alertMessage = "Export cancelled"
+                    self.showAlert = true
+                }
+            } catch {
+                await MainActor.run { [weak self] in
+                    guard let self,
+                          self.exportOperationID == operationID,
+                          self.backupPath == backupPath else { return }
+                    self.isExporting = false
+                    self.exportOperationID = nil
+                    self.alertMessage = "Export failed: \(error.localizedDescription)"
+                    self.showAlert = true
+                }
+            }
+        }
+    }
+
+    private func ensureExtension(_ path: String, for format: MessageExportFormat) -> String {
+        let nsPath = path as NSString
+        if nsPath.pathExtension.lowercased() == format.fileExtension.lowercased() { return path }
+        return "\(nsPath.deletingPathExtension).\(format.fileExtension)"
+    }
+}

--- a/Sources/Phosphor/Views/ContentView.swift
+++ b/Sources/Phosphor/Views/ContentView.swift
@@ -6,6 +6,7 @@ struct ContentView: View {
     @EnvironmentObject var deviceVM: DeviceViewModel
     @EnvironmentObject var backupVM: BackupViewModel
     @EnvironmentObject var messageVM: MessageViewModel
+    @EnvironmentObject var whatsAppVM: WhatsAppViewModel
     @Binding var selectedSection: SidebarSection?
 
     @State private var columnVisibility: NavigationSplitViewVisibility = .all
@@ -25,6 +26,7 @@ struct ContentView: View {
                 detailView
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
                 if messageVM.isExporting { messageExportProgressView }
+                if whatsAppVM.isExporting { whatsAppExportProgressView }
             }
         }
         .navigationTitle("Phosphor")
@@ -127,6 +129,26 @@ struct ContentView: View {
         .padding(.horizontal, 20)
         .padding(.vertical, 12)
         .background(Color.brandAccent.opacity(0.06))
+    }
+
+    private var whatsAppExportProgressView: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text(whatsAppVM.exportProgressText)
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                Spacer()
+                Button("Cancel") { whatsAppVM.cancelExport() }
+                    .controlSize(.small)
+            }
+            ProgressView(value: whatsAppVM.exportProgress, total: 1.0)
+                .progressViewStyle(.linear)
+                .tint(.green)
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 12)
+        .background(Color.green.opacity(0.06))
     }
 
     private func checkTunnel() async {

--- a/Sources/Phosphor/Views/ContentView.swift
+++ b/Sources/Phosphor/Views/ContentView.swift
@@ -6,8 +6,8 @@ struct ContentView: View {
     @EnvironmentObject var deviceVM: DeviceViewModel
     @EnvironmentObject var backupVM: BackupViewModel
     @EnvironmentObject var messageVM: MessageViewModel
+    @Binding var selectedSection: SidebarSection?
 
-    @State private var selectedSection: SidebarSection? = .devices
     @State private var columnVisibility: NavigationSplitViewVisibility = .all
     @State private var tunnelRunning = true
     @State private var tunnelStarting = false
@@ -326,7 +326,7 @@ struct WelcomeView: View {
 
 #if canImport(PreviewsMacros)
 #Preview {
-    ContentView()
+    ContentView(selectedSection: .constant(.devices))
         .environmentObject(DeviceViewModel())
         .environmentObject(BackupViewModel())
         .environmentObject(MessageViewModel())

--- a/Sources/Phosphor/Views/ContentView.swift
+++ b/Sources/Phosphor/Views/ContentView.swift
@@ -5,6 +5,7 @@ struct ContentView: View {
 
     @EnvironmentObject var deviceVM: DeviceViewModel
     @EnvironmentObject var backupVM: BackupViewModel
+    @EnvironmentObject var messageVM: MessageViewModel
 
     @State private var selectedSection: SidebarSection? = .devices
     @State private var columnVisibility: NavigationSplitViewVisibility = .all
@@ -23,6 +24,7 @@ struct ContentView: View {
                 }
                 detailView
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
+                if messageVM.isExporting { messageExportProgressView }
             }
         }
         .navigationTitle("Phosphor")
@@ -105,6 +107,26 @@ struct ContentView: View {
         .padding(.horizontal, 16)
         .padding(.top, 12)
         .padding(.bottom, 4)
+    }
+
+    private var messageExportProgressView: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text(messageVM.exportProgressText)
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+                Spacer()
+                Button("Cancel") { messageVM.cancelExport() }
+                    .controlSize(.small)
+            }
+            ProgressView(value: messageVM.exportProgress, total: 1.0)
+                .progressViewStyle(.linear)
+                .tint(.brandAccent)
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 12)
+        .background(Color.brandAccent.opacity(0.06))
     }
 
     private func checkTunnel() async {
@@ -307,5 +329,6 @@ struct WelcomeView: View {
     ContentView()
         .environmentObject(DeviceViewModel())
         .environmentObject(BackupViewModel())
+        .environmentObject(MessageViewModel())
 }
 #endif

--- a/Sources/Phosphor/Views/Messages/MessageListView.swift
+++ b/Sources/Phosphor/Views/Messages/MessageListView.swift
@@ -487,8 +487,32 @@ struct MessageListView: View {
     /// extension (HTML/JSON/MBOX). SwiftUI's `.fileExporter` hard-codes a
     /// single `UTType` per modifier and was rewriting `.html` to `.txt`
     /// (issue #17).
+    private func exportSingleChatPDFBundle() {
+        guard loadedBackupIsCurrent else { return }
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = false
+        panel.canChooseDirectories = true
+        panel.canCreateDirectories = true
+        panel.prompt = "Create PDF Bundle"
+        panel.message = "Choose where Phosphor should create a folder containing this conversation PDF and its original attachments."
+
+        if panel.runModal() == .OK, let url = panel.url {
+            messageVM.startExportChatPDFBundle(
+                to: url.path,
+                dateFilter: dateFilter,
+                customStart: customStartDate,
+                customEnd: customEndDate,
+                visibleMessages: displayedMessages
+            )
+        }
+    }
+
     private func exportSingleChat(format: MessageExportFormat) {
         guard loadedBackupIsCurrent, let chat = messageVM.selectedChat else { return }
+        if format == .pdf {
+            exportSingleChatPDFBundle()
+            return
+        }
         let panel = NSSavePanel()
         panel.title = "Export Conversation"
         panel.nameFieldStringValue = chat.exportFilename(format: format, includeChatID: false)

--- a/Sources/Phosphor/Views/Messages/MessageListView.swift
+++ b/Sources/Phosphor/Views/Messages/MessageListView.swift
@@ -200,6 +200,10 @@ struct MessageListView: View {
                     exportAllConversations(format: format)
                 }
             }
+            Divider()
+            Button("All Formats + Attachments") {
+                exportAllConversationsAllFormats()
+            }
         }
         .menuStyle(.borderlessButton)
         .font(.system(size: 11, weight: .medium))
@@ -521,6 +525,25 @@ struct MessageListView: View {
                 customStart: customStartDate,
                 customEnd: customEndDate,
                 includeAttachments: includeAttachments
+            )
+        }
+    }
+
+    private func exportAllConversationsAllFormats() {
+        guard loadedBackupIsCurrent else { return }
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = false
+        panel.canChooseDirectories = true
+        panel.canCreateDirectories = true
+        panel.prompt = "Create Export"
+        panel.message = "Choose where Phosphor should create a Messages Export folder containing every conversation, all supported formats, and original attachments."
+
+        if panel.runModal() == .OK, let url = panel.url {
+            messageVM.startExportAllChatsAllFormats(
+                to: url.path,
+                dateFilter: dateFilter,
+                customStart: customStartDate,
+                customEnd: customEndDate
             )
         }
     }

--- a/Sources/Phosphor/Views/Messages/MessageListView.swift
+++ b/Sources/Phosphor/Views/Messages/MessageListView.swift
@@ -7,7 +7,7 @@ import UniformTypeIdentifiers
 struct MessageListView: View {
 
     @EnvironmentObject var backupVM: BackupViewModel
-    @StateObject private var messageVM = MessageViewModel()
+    @EnvironmentObject var messageVM: MessageViewModel
     @State private var showExportSheet = false
     @State private var exportFormat: MessageExportFormat = .html
     @State private var searchText = ""
@@ -32,9 +32,6 @@ struct MessageListView: View {
         }
         .onChange(of: backupVM.backups.map(\.path)) { _, _ in
             reconcileLoadedBackupWithAvailableBackups()
-        }
-        .overlay(alignment: .bottom) {
-            if messageVM.isExporting { exportProgressBar }
         }
         .alert("Messages", isPresented: $messageVM.showAlert) {
             Button("OK") {}
@@ -315,22 +312,6 @@ struct MessageListView: View {
         .background(Color(.controlBackgroundColor).opacity(0.35))
     }
 
-    private var exportProgressBar: some View {
-        HStack(spacing: 12) {
-            ProgressView(value: messageVM.exportProgress)
-                .frame(width: 180)
-            Text(messageVM.exportProgressText)
-                .font(.system(size: 12))
-                .lineLimit(1)
-            Spacer()
-            Button("Cancel") { messageVM.cancelExport() }
-                .controlSize(.small)
-        }
-        .padding(12)
-        .background(.ultraThinMaterial)
-        .clipShape(RoundedRectangle(cornerRadius: 12))
-        .padding()
-    }
 
     // MARK: - Message Detail
 

--- a/Sources/Phosphor/Views/Messages/MessageListView.swift
+++ b/Sources/Phosphor/Views/Messages/MessageListView.swift
@@ -486,7 +486,7 @@ struct MessageListView: View {
         guard loadedBackupIsCurrent, let chat = messageVM.selectedChat else { return }
         let panel = NSSavePanel()
         panel.title = "Export Conversation"
-        panel.nameFieldStringValue = "\(safeFileName(chat.title)).\(format.fileExtension)"
+        panel.nameFieldStringValue = chat.exportFilename(format: format, includeChatID: false)
         if let type = format.contentType { panel.allowedContentTypes = [type] }
         panel.canCreateDirectories = true
 
@@ -524,12 +524,6 @@ struct MessageListView: View {
         }
     }
 
-    private func safeFileName(_ raw: String) -> String {
-        let stripped = raw
-            .replacingOccurrences(of: "/", with: "-")
-            .replacingOccurrences(of: ":", with: "-")
-        return String(stripped.prefix(80))
-    }
 }
 
 private extension MessageExportFormat {

--- a/Sources/Phosphor/Views/Messages/MessageListView.swift
+++ b/Sources/Phosphor/Views/Messages/MessageListView.swift
@@ -266,9 +266,10 @@ struct MessageListView: View {
                 .labelsHidden()
                 .frame(width: 130)
 
-                Toggle("Attachments", isOn: $includeAttachments)
+                Toggle("Export Attachments", isOn: $includeAttachments)
                     .toggleStyle(.checkbox)
                     .font(.system(size: 11))
+                    .help("Copies original photos, videos, audio, and files into an attachments folder beside the transcript.")
             }
             .padding(.horizontal, 16)
 

--- a/Sources/Phosphor/Views/WhatsApp/WhatsAppView.swift
+++ b/Sources/Phosphor/Views/WhatsApp/WhatsAppView.swift
@@ -1,18 +1,18 @@
+import AppKit
 import SwiftUI
+import UniformTypeIdentifiers
 
 /// Browse and export WhatsApp conversations from backup ChatStorage.sqlite.
 struct WhatsAppView: View {
-
     @EnvironmentObject var backupVM: BackupViewModel
-    @State private var chats: [WhatsAppExporter.WAChat] = []
-    @State private var selectedChat: WhatsAppExporter.WAChat?
-    @State private var messages: [WhatsAppExporter.WAMessage] = []
-    @State private var isLoading = false
-    @State private var errorMessage: String?
-    @State private var searchText = ""
+    @EnvironmentObject var whatsAppVM: WhatsAppViewModel
 
-    /// Cached exporter - avoid recreating on every access
-    @State private var cachedExporter: WhatsAppExporter?
+    @State private var chatSearchText = ""
+    @State private var messageSearchText = ""
+    @State private var dateFilter: MessageDateFilter = .all
+    @State private var customStartDate = Calendar.current.date(byAdding: .month, value: -1, to: Date()) ?? Date()
+    @State private var customEndDate = Date()
+    @State private var includeAttachments = true
 
     var body: some View {
         HSplitView {
@@ -20,17 +20,23 @@ struct WhatsAppView: View {
                 .frame(minWidth: 260, idealWidth: 300, maxWidth: 380)
             messagePane
         }
-        .onAppear(perform: loadChats)
-        .onChange(of: selectedChat) { _, newChat in
-            guard let chat = newChat, let exp = cachedExporter else {
-                messages = []
-                return
-            }
-            messages = (try? exp.getMessages(chatId: chat.id)) ?? []
+        .onAppear(perform: loadIfNeeded)
+        .onChange(of: backupVM.selectedBackup?.id) { _, _ in handleSelectedBackupChange() }
+        .onChange(of: backupVM.backups.map(\.path)) { _, _ in reconcileLoadedBackup() }
+        .alert("WhatsApp", isPresented: $whatsAppVM.showAlert) {
+            Button("OK") {}
+        } message: {
+            Text(whatsAppVM.alertMessage)
+        }
+        .alert(item: $whatsAppVM.exportResult) { result in
+            Alert(
+                title: Text("Export Complete"),
+                message: Text(result.summary),
+                primaryButton: .default(Text("Reveal in Finder")) { whatsAppVM.revealLastExport() },
+                secondaryButton: .default(Text("Open")) { whatsAppVM.openLastExport() }
+            )
         }
     }
-
-    // MARK: - Chat List
 
     private var chatListPane: some View {
         VStack(spacing: 0) {
@@ -42,11 +48,11 @@ struct WhatsAppView: View {
                     iconSize: 14,
                     cornerRadius: 8
                 )
-                Text("WhatsApp")
-                    .font(.headline)
+                Text("WhatsApp").font(.headline)
                 Spacer()
-                if !chats.isEmpty {
-                    Text("\(chats.count) chats")
+                if loadedBackupIsCurrent && !whatsAppVM.chats.isEmpty { exportAllMenu }
+                if loadedBackupIsCurrent && !whatsAppVM.chats.isEmpty {
+                    Text("\(whatsAppVM.totalMessages) messages")
                         .font(.system(size: 11))
                         .foregroundStyle(.tertiary)
                 }
@@ -54,10 +60,15 @@ struct WhatsAppView: View {
             .padding(.horizontal, 16)
             .padding(.vertical, 12)
 
+            if !backupVM.backups.isEmpty {
+                backupPicker
+                    .padding(.horizontal, 16)
+                    .padding(.bottom, 8)
+            }
+
             HStack {
-                Image(systemName: "magnifyingglass")
-                    .foregroundStyle(.tertiary)
-                TextField("Search...", text: $searchText)
+                Image(systemName: "magnifyingglass").foregroundStyle(.tertiary)
+                TextField("Search conversations...", text: $chatSearchText)
                     .textFieldStyle(.plain)
             }
             .padding(.horizontal, 10)
@@ -69,18 +80,45 @@ struct WhatsAppView: View {
 
             Divider()
 
-            if isLoading {
+            if whatsAppVM.isLoading {
                 LoadingOverlay(message: "Loading WhatsApp data...")
-            } else if let error = errorMessage {
+            } else if let error = whatsAppVM.errorMessage, loadedBackupIsCurrent {
+                EmptyStateView(
+                    icon: "exclamationmark.bubble",
+                    title: "WhatsApp Not Found",
+                    subtitle: error,
+                    action: chooseBackupFolder,
+                    actionLabel: "Choose Different Backup"
+                )
+            } else if backupVM.selectedBackup == nil && backupVM.backups.isEmpty {
                 EmptyStateView(
                     icon: "bubble.left.and.text.bubble.right",
-                    title: "WhatsApp Not Found",
-                    subtitle: error
+                    title: "No Backup Available",
+                    subtitle: "Create a backup first, or choose an existing backup folder. WhatsApp is read from local device backups.",
+                    action: chooseBackupFolder,
+                    actionLabel: "Choose Backup Folder"
                 )
-            } else if chats.isEmpty {
-                noBackupView
+            } else if backupVM.selectedBackup == nil {
+                EmptyStateView(
+                    icon: "bubble.left.and.text.bubble.right",
+                    title: "No Backup Selected",
+                    subtitle: "Choose a backup below, or use the latest one to browse and export WhatsApp conversations.",
+                    action: useLatestBackup,
+                    actionLabel: "Use Latest Backup"
+                )
+            } else if loadedBackupIsCurrent && whatsAppVM.chats.isEmpty {
+                EmptyStateView(
+                    icon: "bubble.left.and.text.bubble.right",
+                    title: "No WhatsApp Data",
+                    subtitle: "WhatsApp data was not found in this backup.",
+                    action: chooseBackupFolder,
+                    actionLabel: "Choose Different Backup"
+                )
             } else {
-                List(filteredChats, selection: $selectedChat) { chat in
+                List(filteredChats, selection: Binding<WhatsAppExporter.WAChat?>(
+                    get: { whatsAppVM.selectedChat },
+                    set: { if let chat = $0 { whatsAppVM.selectChat(chat) } }
+                )) { chat in
                     waChatRow(chat).tag(chat)
                 }
                 .listStyle(.inset)
@@ -88,19 +126,54 @@ struct WhatsAppView: View {
         }
     }
 
-    private var noBackupView: some View {
-        EmptyStateView(
-            icon: "bubble.left.and.text.bubble.right",
-            title: backupVM.selectedBackup == nil ? "No Backup Selected" : "No WhatsApp Data",
-            subtitle: backupVM.selectedBackup == nil
-                ? "Select a backup from the Backups section first."
-                : "WhatsApp data was not found in this backup."
-        )
+    private var backupPicker: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "externaldrive.fill").foregroundStyle(.secondary)
+            Menu {
+                ForEach(backupVM.backups) { backup in
+                    Button("\(backup.displayName) • iOS \(backup.iosVersion) • \(backup.relativeDate)\(backup.isEncrypted ? " • Encrypted" : "")") {
+                        selectBackup(backup)
+                    }
+                }
+                Divider()
+                Button("Choose Backup Folder…", action: chooseBackupFolder)
+            } label: {
+                HStack {
+                    Text(backupVM.selectedBackup.map {
+                        "\($0.displayName) • iOS \($0.iosVersion) • \($0.relativeDate)\($0.isEncrypted ? " • Encrypted" : "")"
+                    } ?? "Choose Backup")
+                    .lineLimit(1)
+                    Image(systemName: "chevron.down").font(.system(size: 9, weight: .semibold))
+                }
+                .font(.system(size: 11))
+            }
+            .menuStyle(.borderlessButton)
+            Spacer()
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+        .background(.quaternary)
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+    }
+
+    private var exportAllMenu: some View {
+        Menu("Export All") {
+            ForEach(MessageExportFormat.allCases, id: \.self) { format in
+                Button(format.rawValue) { exportAllConversations(format: format) }
+            }
+            Divider()
+            Button("All Formats + Attachments") { exportAllConversationsAllFormats() }
+        }
+        .menuStyle(.borderlessButton)
+        .font(.system(size: 11, weight: .medium))
     }
 
     private var filteredChats: [WhatsAppExporter.WAChat] {
-        guard !searchText.isEmpty else { return chats }
-        return chats.filter { $0.displayName.localizedCaseInsensitiveContains(searchText) }
+        guard !chatSearchText.isEmpty else { return whatsAppVM.chats }
+        return whatsAppVM.chats.filter {
+            $0.displayName.localizedCaseInsensitiveContains(chatSearchText)
+                || $0.contactJid.localizedCaseInsensitiveContains(chatSearchText)
+        }
     }
 
     private func waChatRow(_ chat: WhatsAppExporter.WAChat) -> some View {
@@ -113,16 +186,11 @@ struct WhatsAppView: View {
                     .font(.system(size: 14))
                     .foregroundStyle(.green)
             }
-
             VStack(alignment: .leading, spacing: 2) {
-                Text(chat.displayName)
-                    .font(.system(size: 13, weight: .medium))
-                    .lineLimit(1)
+                Text(chat.displayName).font(.system(size: 13, weight: .medium)).lineLimit(1)
                 HStack {
                     Text("\(chat.messageCount) messages")
-                    if let date = chat.lastMessageDate {
-                        Text(date.relativeString)
-                    }
+                    if let date = chat.lastMessageDate { Text(date.relativeString) }
                 }
                 .font(.system(size: 11))
                 .foregroundStyle(.secondary)
@@ -133,18 +201,79 @@ struct WhatsAppView: View {
         .contentShape(Rectangle())
     }
 
-    // MARK: - Messages
+    private var displayedMessages: [WhatsAppExporter.WAMessage] {
+        whatsAppVM.filteredMessages(
+            searchText: messageSearchText,
+            dateFilter: dateFilter,
+            customStart: customStartDate,
+            customEnd: customEndDate
+        )
+    }
+
+    private var exportOptionsBar: some View {
+        VStack(spacing: 8) {
+            HStack(spacing: 8) {
+                Image(systemName: "magnifyingglass").foregroundStyle(.tertiary)
+                TextField("Search this conversation…", text: $messageSearchText)
+                    .textFieldStyle(.plain)
+                Picker("Date", selection: $dateFilter) {
+                    ForEach(MessageDateFilter.allCases) { filter in
+                        Text(filter.rawValue).tag(filter)
+                    }
+                }
+                .labelsHidden()
+                .frame(width: 130)
+                Toggle("Export Attachments", isOn: $includeAttachments)
+                    .toggleStyle(.checkbox)
+                    .font(.system(size: 11))
+            }
+            .padding(.horizontal, 16)
+
+            if dateFilter == .custom {
+                HStack(spacing: 8) {
+                    Text("From").font(.system(size: 11)).foregroundStyle(.secondary)
+                    DatePicker("Start", selection: $customStartDate, displayedComponents: [.date]).labelsHidden()
+                    Text("to").font(.system(size: 11)).foregroundStyle(.secondary)
+                    DatePicker("End", selection: $customEndDate, displayedComponents: [.date]).labelsHidden()
+                    Spacer()
+                }
+                .padding(.horizontal, 16)
+            }
+
+            if !messageSearchText.isEmpty || dateFilter != .all {
+                HStack {
+                    Text("Showing \(displayedMessages.count) of \(whatsAppVM.messages.count) messages")
+                        .font(.system(size: 11))
+                        .foregroundStyle(.secondary)
+                    Spacer()
+                    Button("Clear Filters") {
+                        messageSearchText = ""
+                        dateFilter = .all
+                    }
+                    .font(.system(size: 11))
+                }
+                .padding(.horizontal, 16)
+            }
+        }
+        .padding(.vertical, 8)
+        .background(Color(.controlBackgroundColor).opacity(0.35))
+    }
 
     private var messagePane: some View {
         VStack(spacing: 0) {
-            if let chat = selectedChat {
+            if let chat = whatsAppVM.selectedChat, loadedBackupIsCurrent {
                 HStack {
-                    Text(chat.displayName)
-                        .font(.headline)
+                    Text(chat.displayName).font(.headline)
                     Spacer()
                     Menu("Export") {
-                        ForEach(MessageExportFormat.allCases, id: \.self) { fmt in
-                            Button(fmt.rawValue) { exportChat(chat, format: fmt) }
+                        ForEach(MessageExportFormat.allCases, id: \.self) { format in
+                            Button(format.rawValue) { exportSingleChat(format: format) }
+                        }
+                        Divider()
+                        Menu("Export All Conversations As...") {
+                            ForEach(MessageExportFormat.allCases, id: \.self) { format in
+                                Button(format.rawValue) { exportAllConversations(format: format) }
+                            }
                         }
                     }
                     .menuStyle(.borderlessButton)
@@ -153,12 +282,11 @@ struct WhatsAppView: View {
                 .padding(.horizontal, 16)
                 .padding(.vertical, 10)
                 Divider()
-
+                exportOptionsBar
+                Divider()
                 ScrollView {
                     LazyVStack(spacing: 4) {
-                        ForEach(messages) { msg in
-                            waMessageBubble(msg)
-                        }
+                        ForEach(displayedMessages) { msg in waMessageBubble(msg) }
                     }
                     .padding(16)
                 }
@@ -166,7 +294,13 @@ struct WhatsAppView: View {
                 EmptyStateView(
                     icon: "bubble.left.and.bubble.right",
                     title: "Select a Conversation",
-                    subtitle: "Choose a WhatsApp conversation from the list."
+                    subtitle: loadedBackupIsCurrent && !whatsAppVM.chats.isEmpty
+                        ? "Choose a WhatsApp conversation from the list, or export every conversation at once."
+                        : "Choose a backup to load WhatsApp conversations.",
+                    action: loadedBackupIsCurrent && !whatsAppVM.chats.isEmpty
+                        ? { exportAllConversations(format: .html) }
+                        : nil,
+                    actionLabel: loadedBackupIsCurrent && !whatsAppVM.chats.isEmpty ? "Export All as HTML…" : nil
                 )
             }
         }
@@ -184,40 +318,159 @@ struct WhatsAppView: View {
                 Text(msg.displayText)
                     .font(.system(size: 14))
                     .foregroundStyle(msg.isFromMe ? .white : .primary)
+                    .textSelection(.enabled)
                     .padding(.horizontal, 12)
                     .padding(.vertical, 8)
                     .background(msg.isFromMe ? Color.green : Color(.controlBackgroundColor))
                     .clipShape(RoundedRectangle(cornerRadius: 16))
-                Text(msg.formattedDate)
-                    .font(.system(size: 9))
-                    .foregroundStyle(.tertiary)
+                Text(msg.formattedDate).font(.system(size: 9)).foregroundStyle(.tertiary)
             }
             if !msg.isFromMe { Spacer(minLength: 60) }
         }
     }
 
-    // MARK: - Actions
+    private var loadedBackupIsCurrent: Bool {
+        guard let path = whatsAppVM.loadedBackupPath,
+              backupVM.backups.contains(where: { $0.path == path }) else { return false }
+        return backupVM.selectedBackup?.path == path
+    }
 
-    private func loadChats() {
-        guard let backup = backupVM.selectedBackup else { return }
-        isLoading = true
-        errorMessage = nil
-
-        do {
-            let wa = try WhatsAppExporter(backupPath: backup.path)
-            cachedExporter = wa
-            chats = try wa.getChats()
-        } catch {
-            errorMessage = error.localizedDescription
+    private func loadIfNeeded() {
+        if backupVM.backups.isEmpty { backupVM.loadBackups() }
+        if let selected = backupVM.selectedBackup {
+            loadWhatsApp(from: selected)
+        } else {
+            useLatestBackup()
         }
-        isLoading = false
     }
 
-    private func exportChat(_ chat: WhatsAppExporter.WAChat, format: MessageExportFormat) {
+    private func useLatestBackup() {
+        if let latest = backupVM.backups.first { selectBackup(latest) }
+    }
+
+    private func selectBackup(_ backup: BackupInfo) {
+        guard backupVM.openBackupBrowser(backup) else { return }
+        loadWhatsApp(from: backup)
+    }
+
+    private func loadWhatsApp(from backup: BackupInfo) {
+        chatSearchText = ""
+        messageSearchText = ""
+        whatsAppVM.loadChats(from: backup.path)
+        if let first = whatsAppVM.chats.first { whatsAppVM.selectChat(first) }
+    }
+
+    private func chooseBackupFolder() {
+        let previousPaths = backupVM.backups.map(\.path)
+        backupVM.openExistingBackupFolder()
+        guard backupVM.backups.map(\.path) != previousPaths else { return }
+        if let latest = backupVM.backups.first { selectBackup(latest) } else { whatsAppVM.clear() }
+    }
+
+    private func handleSelectedBackupChange() {
+        if let backup = backupVM.selectedBackup, whatsAppVM.loadedBackupPath != backup.path {
+            loadWhatsApp(from: backup)
+        } else if backupVM.selectedBackup == nil {
+            reconcileLoadedBackup()
+        }
+    }
+
+    private func reconcileLoadedBackup() {
+        guard let path = whatsAppVM.loadedBackupPath else { return }
+        guard backupVM.backups.contains(where: { $0.path == path }) else {
+            whatsAppVM.clear()
+            return
+        }
+        if let selected = backupVM.selectedBackup, selected.path != path { loadWhatsApp(from: selected) }
+    }
+
+    private func exportSingleChat(format: MessageExportFormat) {
+        guard loadedBackupIsCurrent, let chat = whatsAppVM.selectedChat else { return }
+        if format == .pdf {
+            let panel = NSOpenPanel()
+            panel.canChooseFiles = false
+            panel.canChooseDirectories = true
+            panel.canCreateDirectories = true
+            panel.prompt = "Create PDF Bundle"
+            panel.message = "Choose where Phosphor should create a folder containing this WhatsApp PDF and its original attachments."
+            if panel.runModal() == .OK, let url = panel.url {
+                whatsAppVM.startExportChatPDFBundle(
+                    to: url.path,
+                    dateFilter: dateFilter,
+                    customStart: customStartDate,
+                    customEnd: customEndDate,
+                    visibleMessages: displayedMessages
+                )
+            }
+            return
+        }
+
         let panel = NSSavePanel()
-        panel.nameFieldStringValue = "\(chat.displayName).\(format.fileExtension)"
-        guard panel.runModal() == .OK, let url = panel.url else { return }
-        try? cachedExporter?.exportChat(chatId: chat.id, format: format, to: url.path)
+        panel.title = "Export WhatsApp Conversation"
+        panel.nameFieldStringValue = chat.exportFilename(format: format, includeChatID: false)
+        if let type = format.whatsAppContentType { panel.allowedContentTypes = [type] }
+        panel.canCreateDirectories = true
+        if panel.runModal() == .OK, let url = panel.url {
+            whatsAppVM.startExportChat(
+                format: format,
+                to: url.path,
+                dateFilter: dateFilter,
+                customStart: customStartDate,
+                customEnd: customEndDate,
+                includeAttachments: includeAttachments,
+                visibleMessages: displayedMessages
+            )
+        }
     }
 
+    private func exportAllConversations(format: MessageExportFormat) {
+        guard loadedBackupIsCurrent else { return }
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = false
+        panel.canChooseDirectories = true
+        panel.canCreateDirectories = true
+        panel.prompt = "Export Here"
+        panel.message = "Choose a folder to export all WhatsApp conversations"
+        if panel.runModal() == .OK, let url = panel.url {
+            whatsAppVM.startExportAllChats(
+                format: format,
+                to: url.path,
+                dateFilter: dateFilter,
+                customStart: customStartDate,
+                customEnd: customEndDate,
+                includeAttachments: includeAttachments
+            )
+        }
+    }
+
+    private func exportAllConversationsAllFormats() {
+        guard loadedBackupIsCurrent else { return }
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = false
+        panel.canChooseDirectories = true
+        panel.canCreateDirectories = true
+        panel.prompt = "Create Export"
+        panel.message = "Choose where Phosphor should create a WhatsApp Export folder containing every conversation, all supported formats, and original attachments."
+        if panel.runModal() == .OK, let url = panel.url {
+            whatsAppVM.startExportAllChatsAllFormats(
+                to: url.path,
+                dateFilter: dateFilter,
+                customStart: customStartDate,
+                customEnd: customEndDate
+            )
+        }
+    }
+}
+
+private extension MessageExportFormat {
+    var whatsAppContentType: UTType? {
+        switch self {
+        case .csv: return .commaSeparatedText
+        case .txt: return .plainText
+        case .pdf: return .pdf
+        case .html: return .html
+        case .json: return .json
+        case .mbox: return UTType(filenameExtension: "mbox") ?? .data
+        }
+    }
 }

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,15 @@
+# Third-Party Notices
+
+## Madrid TypedStream
+
+Phosphor includes an adapted, namespaced copy of Madrid's `TypedStream` decoder from commit `8f5f4f1`:
+
+- Project: https://github.com/mattt/Madrid
+- Copyright 2025 Mattt (https://mat.tt)
+- License: MIT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
## Summary
- recover visible iMessage text from `message.attributedBody` when `message.text` is empty, including inline replies
- route recovered content through the shared message model so CSV, JSON, text, HTML, MBOX, and PDF exports benefit
- preserve the selected backup's contact directory in detached single-chat and bulk exports so contact/group names and sender labels survive background export
- render readable image attachments as bounded inline previews in message PDFs while retaining metadata cards for other files
- expose an **Export Attachments** option that copies original photos, videos, audio, and files beside single-chat and bulk transcripts for every supported format
- add **Export All → All Formats + Attachments**, which creates a complete conversation archive with every supported transcript format and one original-attachment folder per chat
- stage attachment sidecars before atomically replacing prior output, preserve completed output on cancellation/failure, collision-rename duplicate display names, and isolate sidecars by transcript format
- URL-encode HTML attachment paths and migrate stale pre-format-isolation HTML attachment folders
- skip internal rich-link plugin payloads and include the vendored Madrid TypedStream MIT notice in source and packaged app bundles

## Attachment export behavior
- enabled exports create a sibling folder such as `Jane Doe-pdf_attachments`
- HTML exports link to `Jane Doe-html_attachments` using URL-safe relative paths
- PDF exports retain inline image previews and also preserve downloadable originals in the sidecar
- CSV, text, JSON, and MBOX exports receive the same original-attachment sidecar behavior
- disabling the option removes only the matching format-specific stale sidecar
- bulk filenames and sidecars retain the collision-safe chat-ID suffix

## Complete export bundle
- creates a collision-safe `Messages Export` folder inside the user-selected parent directory
- creates one `<resolved title>-chat-<id>` folder per conversation
- writes CSV, plain text, PDF, HTML, JSON, and MBOX transcripts inside every conversation folder
- copies originals once into a shared `Attachments` folder and links the HTML transcript to those files
- builds the complete root in a hidden staging directory, then moves it into place only after every conversation succeeds
- repeated exports preserve older bundles as `Messages Export 2`, `Messages Export 3`, and so on
- cancellation/failure removes partial staging output and never exposes an incomplete export folder

## Verification
- `python3 Scripts/regression/run.py` — 73/73 checks pass
- `swift build`
- `swift build -c release`
- `bash Scripts/build.sh`
- behavioral Swift probe covers duplicate filenames, stale replacement, cancellation, format isolation, legacy cleanup, and reserved-character URL encoding
- behavioral bundle probe covers atomic publication, collision-safe repeated exports, and cancellation cleanup
- packaged Messages UI exposes an enabled attachment checkbox with help text explaining that originals are copied beside the transcript
- packaged Messages UI exposes the **All Formats + Attachments** item under **Export All**
- generated PDF rasterization regression confirms attachment image pixels render visibly
- 203 malformed/truncated typedstream subprocess cases fail closed without crashes
- validated 14,370 nonempty attributed bodies and 1,869 inline replies against a real backup corpus

## Security and reliability
- no Foundation object unarchiving is used for backup-controlled typedstreams
- parser work, nesting, decoded-value expansion, type declarations, archive size, single-row BLOB loading, and aggregate recovered text are bounded
- attachment destination names use only the source display name's final path component
- rich-link / Apple Pay / Memoji plugin payloads are not exported as user files
- attachment copying checks cancellation between files and does not replace a prior completed sidecar until staging succeeds

## Filename behavior
- single-conversation PDFs default to the resolved contact/group name, for example `Jane Doe.pdf`
- bulk PDFs preserve that name and add the chat ID for collision safety, for example `Jane Doe-chat-42.pdf`
- background exports reuse the contact directory loaded for the selected backup instead of falling back to raw handles

<!-- Follow-up: crash-safe export generations -->
### Follow-up: crash-safe export generations

This follow-up makes individual message exports crash-safe. Each export writes attachments into a unique immutable generation directory, renders the transcript against that generation, and atomically publishes only the completed transcript. Cancellation or a process crash can leave an unreferenced generation for later cleanup, but cannot expose a partial transcript or pair an old transcript with new attachments.

Verification:
- 73 regression checks passed
- `swift build -c release` passed
- executable generation-publication probes cover cancellation/failure and successful replacement\n\n### Latest update\n- Single-conversation **PDF** exports now create one collision-safe folder containing the transcript PDF and an `Attachments/` folder of original files.\n- PDF links are clickable; timestamp dividers follow day boundaries and 30-minute conversation gaps.\n- Same-destination attachment/transcript exports are serialized across processes, preventing sidecar cleanup races.\n- Added deterministic cross-process publication coverage plus PDF-bundle and timeline regressions.

### Staging cleanup safety
- treats the successful same-parent move as the publication commit point
- explicitly removes and verifies the active staging directory on handled cancellation or failure
- surfaces cleanup failures instead of silently ignoring them
- preserves ambiguous pre-existing staging lookalikes rather than recursively deleting user-controlled data
