### PR TITLE
feat: support safe concurrent multi-device backups

### DIFF
--- a/Scripts/regression/checks/device_backup.py
+++ b/Scripts/regression/checks/device_backup.py
@@ -398,8 +398,27 @@ struct BackupRequestTrackerProbe {
 
         tracker.registerOwner(owner, udid: "phone")
         tracker.registerWaiter(waiter, udid: "phone")
-        precondition(tracker.cancel(owner, udid: "phone") == .detachRequest)
+        var ownerCompletions: [String: UUID] = ["phone": owner]
+        var ownerResumeCount = 0
+        var jobCancelCount = 0
+        for _ in 0..<2 {
+            switch tracker.cancel(owner, udid: "phone") {
+            case .detachRequest:
+                if ownerCompletions["phone"] == owner {
+                    ownerCompletions.removeValue(forKey: "phone")
+                    ownerResumeCount += 1
+                }
+            case .cancelJob:
+                jobCancelCount += 1
+            case .notFound:
+                break
+            }
+        }
+        precondition(ownerResumeCount == 1, "a detached owner continuation must resume exactly once")
+        precondition(jobCancelCount == 0, "the shared job must continue while a waiter authorizes it")
         precondition(tracker.cancel(waiter, udid: "phone") == .cancelJob)
+        jobCancelCount += 1
+        precondition(jobCancelCount == 1)
         tracker.finish(udid: "phone")
 
         tracker.registerOwner(owner, udid: "phone")
@@ -775,6 +794,14 @@ def test_scheduled_work_is_tracked_cancelled_and_revalidated_before_starting_bac
     assert_contains(scheduler, "isScheduledRunStillValid", "scheduled work must revalidate persisted state after async discovery")
     assert_contains(view_model, "cancelBackupRequest(udid: udid, requestID: request.id)", "task cancellation must remove the exact scheduled queue request")
     assert_contains(view_model, "requestTracker.cancel(requestID", "scheduled cancellation must not bluntly cancel a manual caller sharing the same UDID")
+    started_owner = view_model.split("case .started:", 1)[1].split("} onCancel:", 1)[0]
+    continuation_index = started_owner.index("backupCompletionContinuations[udid] = continuation")
+    task_index = started_owner.index("let task = Task")
+    assert continuation_index < task_index, "the started owner must install its detachable completion before launching shared work"
+    assert_contains(started_owner, "backupJobTasks[udid] = task", "the independently running shared job must remain tracked for cancellation")
+    assert_not_contains(started_owner, "await runBackupJob(udid: udid)", "the started request must not remain structurally attached to a manual-backed shared job")
+    detach_path = view_model.split("case .detachRequest:", 1)[1].split("case .notFound:", 1)[0]
+    assert_contains(detach_path, "backupCompletionContinuations.removeValue(forKey: udid)?.resume()", "owner detachment must remove and resume its continuation exactly once")
     cancel_work = scheduler.split("private func cancelScheduledWork", 1)[1].split("private func cancelInvalidScheduledWork", 1)[0]
     invalid_work = scheduler.split("private func cancelInvalidScheduledWork", 1)[1].split("private func finishScheduledRunTask", 1)[0]
     assert_not_contains(cancel_work, "scheduledRunOwnership.removeAll()", "stop-monitoring cancellation must retain ownership until queue cancellation is terminal")

--- a/Scripts/regression/checks/device_backup.py
+++ b/Scripts/regression/checks/device_backup.py
@@ -192,8 +192,8 @@ def test_wifi_schedules_use_network_discovery_and_network_backup_flag(root: Path
     assert_contains(scheduler, "components.minute = schedule.preferredMinute", "Scheduler should use preferred minute even after a previous run exists")
     assert_contains(scheduler, "while next <= now", "Scheduler should advance preferred-time candidates until they are in the future")
     assert_not_contains(scheduler, "next = lastRun.addingTimeInterval(schedule.frequency.interval)", "Scheduler should not drift nextRunDate to the last completion time")
-    run_body = scheduler.split("private func run(schedule runSchedule:", 1)[1].split("// MARK: - Backup Execution", 1)[0]
-    assert run_body.index("runningScheduledUDIDs.insert(scheduleIdentity)") < run_body.index("findTargetDevice(for: runSchedule)"), "Run Now should claim its device schedule before async discovery"
+    run_now = scheduler.split("func runNow() async", 1)[1].split("private func run(", 1)[0]
+    assert run_now.index("scheduledRunOwnership.claim(identity: scheduleIdentity, runID: runID)") < run_now.index("await run("), "Run Now should claim its device schedule before async discovery"
 
     view = read(root, "Sources/Phosphor/Views/Backup/BackupListView.swift")
     assert_contains(view, "Wi-Fi only (skip if Wi-Fi is not available)", "Wi-Fi-only schedule copy should not say USB is required")
@@ -674,3 +674,130 @@ def test_live_photo_exports_use_path_based_names(root: Path) -> None:
     assert_contains(live, "photo.path", "Live photo export naming should use the full device path, not only the basename")
     assert_contains(live, "replacingOccurrences(of: \"/\", with: \"_\")", "Live photo export should preserve DCIM folder identity in local filenames")
     assert_contains(live, "appendingPathComponent(uniqueLocalName(for: photo))", "Live photo temp cache and export should use duplicate-safe names")
+
+
+def test_clearing_a_schedule_target_persists_a_disabled_clear_state(root: Path) -> None:
+    scheduler = read(root, "Sources/Phosphor/Services/BackupScheduler.swift")
+    selection = scheduler.split("func selectSchedule(targetUDID:", 1)[1].split("// MARK: - Timer Control", 1)[0]
+
+    assert_contains(selection, "if targetUDID == nil", "choosing the empty device picker option needs an explicit clear path")
+    assert_contains(selection, "let previousTargetUDID = schedule.targetUDID", "clearing must identify the currently edited device schedule")
+    assert_contains(selection, "schedules.removeAll", "clearing a target must remove the old per-device schedule from persisted schedules")
+    assert_contains(selection, "schedule = Schedule()", "clearing a target must persist a disabled, targetless editor state")
+    assert_contains(selection, "saveSchedules()", "clearing a target must write through to UserDefaults before reload")
+
+    # Behavioral model of the persistence contract: after a user clears Device,
+    # reloading must not rediscover the formerly enabled target schedule.
+    schedules = [{"target": "phone", "enabled": True}]
+    previous_target = "phone"
+    schedules = [entry for entry in schedules if entry["target"] != previous_target]
+    editor = {"target": None, "enabled": False}
+    reloaded = schedules
+    assert editor == {"target": None, "enabled": False}
+    assert not any(entry["target"] == "phone" and entry["enabled"] for entry in reloaded)
+
+
+def test_scheduled_work_is_tracked_cancelled_and_revalidated_before_starting_backup(root: Path) -> None:
+    scheduler = read(root, "Sources/Phosphor/Services/BackupScheduler.swift")
+
+    assert_contains(scheduler, "private var scheduledCheckTask: Task<Void, Never>?", "scheduled monitor checks need a retained task handle")
+    assert_contains(scheduler, "private var scheduledRunTasks: [String: Task<Void, Never>]", "each delayed scheduled discovery/run needs a retained task handle")
+    assert_contains(scheduler, "scheduledCheckTask?.cancel()", "stopping or replacing monitoring must cancel an outstanding check")
+    assert_contains(scheduler, "scheduledRunTasks.values.forEach { $0.cancel() }", "stopping monitoring must cancel delayed per-device scheduled work")
+    assert_contains(scheduler, "guard !Task.isCancelled", "scheduled work must observe cancellation after suspension")
+    assert_contains(scheduler, "isScheduledRunStillValid", "scheduled work must revalidate persisted state after async discovery")
+
+    run_body = scheduler.split("private func run(", 1)[1].split("private func isScheduledRunStillValid", 1)[0]
+    discovery_index = run_body.index("findTargetDevice(for: runSchedule)")
+    validation_index = run_body.rindex("isScheduledRunStillValid")
+    backup_index = run_body.index("runScheduledBackup(")
+    assert discovery_index < validation_index < backup_index, "a stale schedule must be revalidated after discovery and before it can enqueue a backup"
+
+    # Focused race model: discovery can finish after the app suspends/returns and
+    # the user disables, retargets, or stops monitoring. None may start a backup.
+    def may_start_after_discovery(*, monitoring: bool, enabled: bool, stored_target: str | None, run_target: str | None, cancelled: bool) -> bool:
+        return monitoring and enabled and stored_target == run_target and not cancelled
+
+    assert not may_start_after_discovery(monitoring=False, enabled=True, stored_target="phone", run_target="phone", cancelled=True)
+    assert not may_start_after_discovery(monitoring=True, enabled=False, stored_target="phone", run_target="phone", cancelled=True)
+    assert not may_start_after_discovery(monitoring=True, enabled=True, stored_target="tablet", run_target="phone", cancelled=True)
+    assert may_start_after_discovery(monitoring=True, enabled=True, stored_target="phone", run_target="phone", cancelled=False)
+
+
+def test_schedule_completion_requires_current_persisted_schedule_and_run_ownership(root: Path) -> None:
+    scheduler = read(root, "Sources/Phosphor/Services/BackupScheduler.swift")
+    ownership = root / "Sources/Phosphor/Services/ScheduledRunOwnership.swift"
+
+    assert ownership.exists(), "scheduled work needs a production run-ownership type that can be behaviorally exercised"
+    assert_contains(scheduler, "private var scheduledRunOwnership = ScheduledRunOwnership()", "the scheduler must track each in-flight run by a unique ownership token")
+    assert_contains(scheduler, "private var scheduledRunIDs: [String: UUID] = [:]", "task tracking must retain the matching run token")
+    assert_contains(scheduler, "currentScheduleForCompletion", "completion writes must explicitly revalidate the persisted schedule")
+    assert_not_contains(scheduler, "latestSchedule(matching: runSchedule.targetUDID) ?? runSchedule", "no post-await path may recreate a stale schedule from its run snapshot")
+
+    task_cleanup = scheduler.split("private func finishScheduledRunTask", 1)[1].split("private func finishScheduledBackupRun", 1)[0]
+    assert_contains(task_cleanup, "guard scheduledRunIDs[identity] == runID else { return }", "stale task A must not erase task B's tracking")
+
+    completion = scheduler.split("private func runScheduledBackup", 1)[1].split("// MARK: - Device Discovery", 1)[0]
+    assert_not_contains(completion, "?? runSchedule", "completion must never recreate a cleared or retargeted schedule from the stale run snapshot")
+
+    # Model the post-await persistence contract with controllable snapshots. A
+    # cleared/disabled/retargeted schedule must be a no-op, never a recreation.
+    run_snapshot = {"target": "phone", "enabled": True, "generation": 1}
+
+    def completion_write(persisted: dict[str, object] | None) -> dict[str, object] | None:
+        return persisted if persisted == run_snapshot else None
+
+    assert completion_write(None) is None
+    assert completion_write({"target": "phone", "enabled": False, "generation": 1}) is None
+    assert completion_write({"target": "tablet", "enabled": True, "generation": 1}) is None
+    assert completion_write(run_snapshot) == run_snapshot
+
+    # Compile and run the actual production ownership model. In particular,
+    # stale task A cannot finish task B after a clear/retarget made B current.
+    probe = r'''
+import Foundation
+
+@main
+struct ScheduledRunOwnershipProbe {
+    static func main() {
+        var ownership = ScheduledRunOwnership()
+        let runA = UUID()
+        let runB = UUID()
+
+        precondition(ownership.claim(identity: "phone", runID: runA))
+        precondition(ownership.owns(identity: "phone", runID: runA))
+        precondition(ownership.finish(identity: "phone", runID: runA))
+        precondition(ownership.claim(identity: "phone", runID: runB))
+        precondition(!ownership.finish(identity: "phone", runID: runA), "stale A must not clear B")
+        precondition(ownership.owns(identity: "phone", runID: runB), "B must remain tracked after stale A cleanup")
+        precondition(ownership.finish(identity: "phone", runID: runB))
+        precondition(!ownership.isOwned(identity: "phone"))
+        print("PASS")
+    }
+}
+'''
+    with tempfile.TemporaryDirectory(prefix="phosphor-scheduled-run-ownership-") as temp_dir:
+        temp = Path(temp_dir)
+        probe_path = temp / "Probe.swift"
+        binary_path = temp / "scheduled-run-ownership-probe"
+        probe_path.write_text(probe)
+        result = subprocess.run(
+            ["swiftc", "-parse-as-library", str(ownership), str(probe_path), "-o", str(binary_path)],
+            cwd=root,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        assert result.returncode == 0, result.stderr
+        result = subprocess.run([str(binary_path)], capture_output=True, text=True, timeout=30)
+        assert result.returncode == 0, result.stderr
+        assert result.stdout.strip() == "PASS"
+
+
+def test_global_concurrent_backup_accessibility_names_each_device_and_progress(root: Path) -> None:
+    backup_list = read(root, "Sources/Phosphor/Views/Backup/BackupListView.swift")
+    activity_list = backup_list.split("private var backupActivityList", 1)[1].split("private func deviceIdentity", 1)[0]
+
+    assert_contains(activity_list, ".accessibilityElement(children: .combine)", "each global backup status container should be one VoiceOver element")
+    assert_contains(activity_list, ".accessibilityLabel(\"\\(deviceIdentity(for: activity.udid)), \\(activity.displayProgressText)\")", "global status must announce the device identity and current progress")
+    assert_contains(activity_list, ".accessibilityLabel(\"Cancel backup for \\(deviceIdentity(for: activity.udid))\")", "same-name concurrent backups need device-specific cancel labels")

--- a/Scripts/regression/checks/device_backup.py
+++ b/Scripts/regression/checks/device_backup.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import re
+import subprocess
+import tempfile
 from pathlib import Path
 
 
@@ -92,8 +94,8 @@ def test_finder_wifi_sync_can_be_enabled_from_usb_device(root: Path) -> None:
     assert_contains(view, "Start a backup for this device", "Device overview should surface a backup action")
     assert_contains(view, "Full Wi-Fi Backup?", "Device overview Wi-Fi full backups should use the same safety confirmation pattern")
     assert_contains(view, "BackupManager.hasExistingBackup(for: device.id) && backupVM.backups.contains", "Device overview should only run incremental Wi-Fi backups when complete metadata exists")
-    assert_contains(view, "ProgressView(value: backupVM.displayProgressFraction", "Device overview backup progress should use a linear loading bar")
-    assert_contains(view, "backupVM.displayProgressText", "Device overview should show sanitized backup progress copy")
+    assert_contains(view, "value: activity.displayProgressFraction", "Device overview backup progress should use a device-scoped linear loading bar")
+    assert_contains(view, "activity.displayProgressText", "Device overview should show sanitized device-scoped backup progress copy")
 
 
 def test_backup_progress_ui_uses_sanitized_loading_bar(root: Path) -> None:
@@ -103,8 +105,8 @@ def test_backup_progress_ui_uses_sanitized_loading_bar(root: Path) -> None:
     assert_contains(backup_vm, "var displayProgressText", "BackupViewModel should expose user-facing progress copy")
     assert_contains(backup_vm, "return \"Backing up", "Backup progress copy should say Backing up, not the backend/protocol name")
     assert_contains(backup_vm, "var displayProgressFraction", "BackupViewModel should expose progress for a loading bar")
-    assert_contains(backup_view, "ProgressView(value: backupVM.displayProgressFraction", "Backup list should show a linear loading bar while backing up")
-    assert_contains(backup_view, "backupVM.displayProgressText", "Backup list should not show raw backend/protocol progress text")
+    assert_contains(backup_view, "value: activity.displayProgressFraction", "Backup list should show a linear loading bar for every active device")
+    assert_contains(backup_view, "activity.displayProgressText", "Backup list should not show raw backend/protocol progress text")
     assert_contains(manager, "onProgress(\"Backing up", "pymobiledevice3 stderr percentage updates should reach the user-facing progress bar")
 
 
@@ -178,19 +180,20 @@ def test_wifi_schedules_use_network_discovery_and_network_backup_flag(root: Path
     scheduler = read(root, "Sources/Phosphor/Services/BackupScheduler.swift")
     assert_contains(scheduler, "pyEntries.filter { $0.connectionType != \"USB\" }", "Wi-Fi-only schedules should filter out USB pymobiledevice entries")
     assert_contains(scheduler, "PyMobileDevice.listNetworkDevices()", "Wi-Fi-only schedules should probe network devices explicitly")
-    assert_contains(scheduler, 'let fallbackArgs = schedule.wifiOnly ? ["-n"] : ["-l"]', "Wi-Fi-only fallback should use idevice_id -n")
-    assert_contains(scheduler, "createIncrementalBackup(udid: udid, preferNetwork: preferNetwork)", "scheduled incremental backups should preserve network preference")
-    assert_contains(scheduler, "createBackup(udid: udid, preferNetwork: preferNetwork)", "scheduled full backups should preserve network preference")
-    assert_contains(scheduler, "schedule.incrementalOnly && BackupManager.hasExistingBackup(for: udid)", "Scheduled incremental mode should run the required first full backup when metadata is missing")
+    assert_contains(scheduler, 'let fallbackArgs = runSchedule.wifiOnly ? ["-n"] : ["-l"]', "Wi-Fi-only fallback should use idevice_id -n")
+    assert_contains(scheduler, "createBackup(udid: udid, incremental: incremental, preferNetwork: preferNetwork)", "all scheduled backups should preserve incremental and network preferences through the shared queue")
+    assert_contains(scheduler, "runSchedule.incrementalOnly && BackupManager.hasExistingBackup(for: udid)", "Scheduled incremental mode should run the required first full backup when metadata is missing")
     assert_contains(scheduler, "running required first full backup", "Scheduled first-full fallback should be logged clearly")
-    assert_contains(scheduler, "able to notice a schedule that is enabled after launch", "App-level scheduler should keep monitoring so schedules enabled after launch can run")
-    assert_contains(scheduler, "if schedule.nextRunDate == nil { updateNextRunDate() }", "Scheduler should initialize next run when a separate UI instance enables the schedule")
+    assert_contains(scheduler, "scheduleDidChangeNotification", "App-level scheduler should react when another window enables a schedule after launch")
+    assert_contains(scheduler, "self.configureMonitoring()", "schedule changes should reconfigure monitoring without an idle disabled timer")
+    assert_contains(scheduler, "if candidate.nextRunDate == nil", "Scheduler should initialize every enabled device schedule after a separate UI instance changes it")
     assert_contains(scheduler, "func scheduledTime(on date: Date) -> Date", "Scheduler should align non-hourly next runs to preferred wall-clock time")
     assert_contains(scheduler, "components.hour = schedule.preferredHour", "Scheduler should use preferred hour even after a previous run exists")
     assert_contains(scheduler, "components.minute = schedule.preferredMinute", "Scheduler should use preferred minute even after a previous run exists")
     assert_contains(scheduler, "while next <= now", "Scheduler should advance preferred-time candidates until they are in the future")
     assert_not_contains(scheduler, "next = lastRun.addingTimeInterval(schedule.frequency.interval)", "Scheduler should not drift nextRunDate to the last completion time")
-    assert_contains(scheduler, "func runNow() async {\n        guard !isRunningScheduledBackup else { return }\n        isRunningScheduledBackup = true", "Run Now should set the running guard before async device discovery")
+    run_body = scheduler.split("private func run(schedule runSchedule:", 1)[1].split("// MARK: - Backup Execution", 1)[0]
+    assert run_body.index("runningScheduledUDIDs.insert(scheduleIdentity)") < run_body.index("findTargetDevice(for: runSchedule)"), "Run Now should claim its device schedule before async discovery"
 
     view = read(root, "Sources/Phosphor/Views/Backup/BackupListView.swift")
     assert_contains(view, "Wi-Fi only (skip if Wi-Fi is not available)", "Wi-Fi-only schedule copy should not say USB is required")
@@ -203,6 +206,329 @@ def test_wifi_schedules_use_network_discovery_and_network_backup_flag(root: Path
     assert_contains(settings, "Wi-Fi only (skip if Wi-Fi is not available)", "Settings schedule copy should match the safer schedule sheet copy")
     assert_contains(settings, "Incremental when possible (faster)", "Settings should not promise incremental-only behavior when first run may be full")
     assert_contains(settings, ".onChange(of: scheduler.schedule.preferredHour)", "Settings should refresh next-run timing when preferred time changes")
+
+
+def test_scheduled_backups_never_choose_between_multiple_devices(root: Path) -> None:
+    resolver = root / "Sources/Phosphor/Utilities/ScheduledBackupTargetResolver.swift"
+    scheduler = read(root, "Sources/Phosphor/Services/BackupScheduler.swift")
+    schedule_sheet = read(root, "Sources/Phosphor/Views/Backup/BackupListView.swift")
+    settings = read(root, "Sources/Phosphor/Views/Settings/SettingsView.swift")
+
+    assert_contains(scheduler, "ScheduledBackupTargetResolver.resolve", "scheduled backup discovery must use the fail-closed target resolver")
+    assert_contains(scheduler, "Multiple devices are available. Choose a device", "ambiguous discovery should explain why no backup started")
+    assert_not_contains(scheduler, "if let first = eligiblePyEntries.first", "scheduled backups must not pick the first enumerated device")
+    assert_not_contains(scheduler, "if let first = devices.first", "libimobiledevice fallback must not pick the first enumerated device")
+    assert_contains(schedule_sheet, "ScheduledBackupDevicePicker", "the backup schedule sheet should expose an explicit device picker")
+    assert_contains(settings, "ScheduledBackupDevicePicker", "Settings should expose the same explicit device picker")
+
+    probe = r'''
+import Foundation
+
+typealias Resolver = ScheduledBackupTargetResolver
+
+func require(_ condition: @autoclosure () -> Bool, _ message: String) {
+    guard condition() else {
+        FileHandle.standardError.write(Data((message + "\n").utf8))
+        exit(1)
+    }
+}
+
+let phone = Resolver.Candidate(udid: "phone", preferNetwork: true)
+let tablet = Resolver.Candidate(udid: "tablet", preferNetwork: false)
+
+require(Resolver.resolve(candidates: [], targetUDID: nil) == .noneAvailable, "zero devices must remain unavailable")
+require(Resolver.resolve(candidates: [phone], targetUDID: nil) == .target(phone), "one legacy device may remain automatic")
+require(Resolver.resolve(candidates: [phone, tablet], targetUDID: nil) == .selectionRequired, "multiple devices must require selection")
+require(Resolver.resolve(candidates: [tablet, phone], targetUDID: nil) == .selectionRequired, "discovery order must not select a target")
+require(Resolver.resolve(candidates: [phone, tablet], targetUDID: "tablet") == .target(tablet), "an explicit target must win")
+require(Resolver.resolve(candidates: [phone], targetUDID: "tablet") == .noneAvailable, "a missing target must not fall back to another device")
+
+let phoneUSB = Resolver.Candidate(udid: "phone", preferNetwork: false)
+require(Resolver.resolve(candidates: [phone, phoneUSB], targetUDID: nil) == .target(phoneUSB), "duplicate transports are one device and USB should win")
+'''
+
+    with tempfile.TemporaryDirectory(prefix="phosphor-schedule-target-") as temp_dir:
+        temp = Path(temp_dir)
+        main = temp / "main.swift"
+        binary = temp / "target-resolver-probe"
+        main.write_text(probe)
+        compile_result = subprocess.run(
+            ["swiftc", str(resolver), str(main), "-o", str(binary)],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        assert compile_result.returncode == 0, f"target resolver probe should compile: {compile_result.stderr}"
+        run_result = subprocess.run([str(binary)], capture_output=True, text=True, timeout=10)
+        assert run_result.returncode == 0, f"target resolver behavior failed: {run_result.stderr}"
+
+
+def test_legacy_schedule_resolves_the_complete_discovery_union(root: Path) -> None:
+    scheduler = read(root, "Sources/Phosphor/Services/BackupScheduler.swift")
+    no_target = scheduler.split("// Legacy schedules may not have a target yet.", 1)[1]
+    discovery = no_target.split("// MARK: - Scheduling Math", 1)[0]
+
+    assert_contains(discovery, "var discoveredCandidates", "legacy target discovery should accumulate candidates across backends")
+    assert_contains(discovery, "discoveredCandidates.append(contentsOf:", "every applicable discovery backend should contribute to one candidate union")
+    assert_contains(discovery, "resolveTarget(from: discoveredCandidates, targetUDID: runSchedule.targetUDID)", "legacy target resolution must happen once against the complete candidate union")
+    resolve_call = "resolveTarget(from: discoveredCandidates, targetUDID: runSchedule.targetUDID)"
+    assert discovery.rindex(resolve_call) > discovery.index("PyMobileDevice.listNetworkDevices()"), "network discovery must finish before resolving a legacy target"
+    assert discovery.rindex(resolve_call) > discovery.index('Shell.runAsync("idevice_id"'), "libimobiledevice fallback must finish before resolving a legacy target"
+
+    # A single primary candidate plus a distinct fallback candidate is ambiguous.
+    # This is the cross-backend scenario that previously selected the primary early.
+    resolver = root / "Sources/Phosphor/Utilities/ScheduledBackupTargetResolver.swift"
+    probe = r'''
+import Foundation
+
+let primary = ScheduledBackupTargetResolver.Candidate(udid: "phone", preferNetwork: true)
+let fallback = ScheduledBackupTargetResolver.Candidate(udid: "tablet", preferNetwork: true)
+precondition(
+    ScheduledBackupTargetResolver.resolve(
+        candidates: [primary, fallback],
+        targetUDID: nil
+    ) == .selectionRequired
+)
+'''
+    with tempfile.TemporaryDirectory(prefix="phosphor-schedule-union-") as temp_dir:
+        temp = Path(temp_dir)
+        main = temp / "main.swift"
+        binary = temp / "schedule-union-probe"
+        main.write_text(probe)
+        result = subprocess.run(["swiftc", str(resolver), str(main), "-o", str(binary)], capture_output=True, text=True, timeout=60)
+        assert result.returncode == 0, result.stderr
+        result = subprocess.run([str(binary)], capture_output=True, text=True, timeout=10)
+        assert result.returncode == 0, result.stderr
+
+
+def test_multi_device_backup_queue_limits_concurrency_and_deduplicates_devices(root: Path) -> None:
+    queue_source = root / "Sources/Phosphor/Utilities/BackupJobQueue.swift"
+    assert queue_source.exists(), "multi-device backups need a behaviorally testable queue"
+    probe = r'''
+import Foundation
+
+@main
+struct BackupQueueProbe {
+    static func main() {
+        var queue = BackupJobQueue(maxConcurrent: 2)
+
+        precondition(queue.enqueue(udid: "phone") == .started)
+        precondition(queue.enqueue(udid: "tablet") == .started)
+        precondition(queue.enqueue(udid: "spare") == .queued(position: 1))
+        precondition(queue.enqueue(udid: "phone") == .duplicate)
+        precondition(queue.runningUDIDs == Set(["phone", "tablet"]))
+        precondition(queue.queuedUDIDs == ["spare"])
+
+        precondition(queue.finish(udid: "phone") == "spare")
+        precondition(queue.runningUDIDs == Set(["tablet", "spare"]))
+        precondition(queue.finish(udid: "missing") == nil)
+
+        precondition(queue.enqueue(udid: "fourth") == .queued(position: 1))
+        precondition(queue.cancel(udid: "fourth") == .removedQueued)
+        precondition(queue.cancel(udid: "tablet") == .cancelRunning)
+        precondition(queue.cancel(udid: "missing") == .notFound)
+        print("PASS")
+    }
+}
+'''
+    with tempfile.TemporaryDirectory(prefix="phosphor-backup-queue-") as temp_dir:
+        temp = Path(temp_dir)
+        probe_path = temp / "Probe.swift"
+        binary_path = temp / "backup-queue-probe"
+        probe_path.write_text(probe)
+        result = subprocess.run(
+            ["swiftc", "-parse-as-library", str(queue_source), str(probe_path), "-o", str(binary_path)],
+            cwd=root,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        assert result.returncode == 0, result.stderr
+        result = subprocess.run([str(binary_path)], capture_output=True, text=True, timeout=30)
+        assert result.returncode == 0, result.stderr
+        assert result.stdout.strip() == "PASS"
+
+
+def test_backup_view_model_tracks_and_cancels_jobs_per_device(root: Path) -> None:
+    view_model = read(root, "Sources/Phosphor/ViewModels/BackupViewModel.swift")
+    assert_contains(view_model, "@Published private(set) var backupActivities: [String: BackupActivity]", "backup activity must be keyed by device")
+    assert_contains(view_model, "private var backupManagers: [String: BackupManager]", "each running device needs an independent process owner")
+    assert_contains(view_model, "BackupJobQueue(maxConcurrent: 2)", "the app should run at most two device backups concurrently")
+    assert_contains(view_model, "func cancelBackup(udid: String)", "each device needs its own cancellation entry point")
+    assert_contains(view_model, "manager.cancelBackup()", "cancelling one device must not terminate another device's process")
+    assert_contains(view_model, "backupJobTasks[udid]?.cancel()", "a promoted job must remain cancellable before its BackupManager exists")
+    assert_contains(view_model, "backupJobTasks[nextUDID] = task", "promotion must register task ownership before the job can start")
+    assert_contains(view_model, "let encrypted: Bool", "queued backup requests must retain encryption intent")
+    assert_contains(view_model, "func activity(for udid: String)", "device views need device-scoped progress")
+    create = view_model.split("func createBackup(udid: String", 1)[1].split("private func", 1)[0]
+    assert "guard !isCreating" not in create, "a global creation guard would block a second device"
+    assert_contains(create, "jobQueue.enqueue(udid: udid)", "backup requests should enter the bounded per-device queue")
+
+
+def test_backup_surfaces_show_stable_device_identity(root: Path) -> None:
+    model = read(root, "Sources/Phosphor/Models/BackupInfo.swift")
+    backup_list = read(root, "Sources/Phosphor/Views/Backup/BackupListView.swift")
+    browser = read(root, "Sources/Phosphor/Views/Backup/BackupBrowserView.swift")
+    time_machine = read(root, "Sources/Phosphor/Views/Backup/BackupTimeMachineView.swift")
+    unlock = read(root, "Sources/Phosphor/Views/Backup/BackupUnlockSheet.swift")
+    archiver = read(root, "Sources/Phosphor/Services/BackupArchiver.swift")
+    apps = read(root, "Sources/Phosphor/Views/Apps/AppManagerView.swift")
+    messages = read(root, "Sources/Phosphor/Views/Messages/MessageListView.swift")
+
+    assert_contains(model, "var shortUDID", "backup metadata should expose a stable physical-device discriminator")
+    assert_contains(model, "let source = !udid.isEmpty ? udid", "the visible discriminator should prefer the authoritative backup UDID")
+    assert_contains(model, "var deviceIdentityLabel", "all backup pickers should share one device identity label")
+    assert_contains(model, "deviceName", "the identity label should retain the friendly device name")
+    assert_contains(model, "modelName", "the identity label should distinguish devices by model when possible")
+    assert_contains(model, "shortUDID", "same-name and same-model devices still need a unique visible suffix")
+
+    for source, surface in [
+        (backup_list, "backup list"),
+        (browser, "backup browser"),
+        (time_machine, "backup history"),
+        (unlock, "encrypted-backup prompt"),
+        (apps, "Apps backup picker"),
+        (messages, "Messages backup picker"),
+    ]:
+        assert_contains(source, "backup.deviceIdentityLabel", f"{surface} should identify which physical device owns the backup")
+    assert_contains(apps, "$0.deviceIdentityLabel", "the closed Apps picker must retain the selected device discriminator")
+    assert_contains(messages, "$0.deviceIdentityLabel", "the closed Messages picker must retain the selected device discriminator")
+    assert_contains(backup_list, "backedUpDeviceCount", "the backup list should report how many distinct devices it contains")
+    assert_contains(archiver, "backup.shortUDID", "portable archive filenames should remain attributable when two devices share a name")
+    assert_contains(time_machine, "request.targetUDID.suffix(8)", "restore confirmation must identify the exact destination device")
+    assert_contains(time_machine, "request.backup.deviceIdentityLabel", "restore confirmation must identify the exact source backup")
+
+    probe = r'''
+import Foundation
+
+struct BackupInfoPlist {
+    let deviceName: String
+    let displayName: String
+    let productType: String
+    let productVersion: String
+    let buildVersion: String
+    let serialNumber: String
+    let udid: String
+    let iccid: String?
+    let imei: String?
+    let meid: String?
+    let phoneNumber: String?
+    let lastBackupDate: Date?
+    let isEncrypted: Bool
+    var modelName: String { productType }
+}
+struct BackupStatusProbe { let date: Date?; let isFullBackup: Bool }
+struct BackupManifestProbe { let isEncrypted: Bool; let applicationBundleIds: [String] }
+enum PlistParser {
+    static func parseBackupInfo(_ path: String) -> BackupInfoPlist? { nil }
+    static func parseBackupStatus(_ path: String) -> BackupStatusProbe? { nil }
+    static func parseManifest(_ path: String) -> BackupManifestProbe? { nil }
+}
+extension FileManager { func directorySize(at path: String) -> UInt64 { 0 } }
+extension UInt64 { var formattedFileSize: String { "0 B" } }
+extension Date {
+    var shortString: String { "date" }
+    var relativeString: String { "relative" }
+}
+
+@main
+struct Probe {
+    static func backup(id: String? = nil, udid: String, serial: String = "serial") -> BackupInfo {
+        BackupInfo(
+            id: id ?? udid,
+            path: "/tmp/\(udid)",
+            deviceName: "My iPhone",
+            displayName: "My iPhone",
+            productType: "iPhone17,1",
+            iosVersion: "18.0",
+            serialNumber: serial,
+            udid: udid,
+            lastBackupDate: nil,
+            isEncrypted: false,
+            isFullBackup: true,
+            size: 0,
+            sizeResolved: true,
+            appCount: 0
+        )
+    }
+
+    static func main() {
+        let phone = backup(udid: "00000000AAAAAAAA")
+        let tablet = backup(udid: "00000000BBBBBBBB")
+        precondition(phone.deviceIdentityLabel != tablet.deviceIdentityLabel)
+        precondition(phone.deviceIdentityLabel.contains("AAAAAAAA"))
+        precondition(tablet.deviceIdentityLabel.contains("BBBBBBBB"))
+        precondition(phone.shortUDID == "AAAAAAAA")
+        let legacyPhone = backup(id: "folder-11111111", udid: "", serial: "serial-11111111")
+        let legacyTablet = backup(id: "folder-22222222", udid: "", serial: "serial-22222222")
+        precondition(legacyPhone.deviceIdentityLabel != legacyTablet.deviceIdentityLabel)
+        precondition(legacyPhone.deviceIdentityLabel.contains("11111111"))
+        precondition(legacyTablet.deviceIdentityLabel.contains("22222222"))
+        print("PASS")
+    }
+}
+'''
+    with tempfile.TemporaryDirectory(prefix="phosphor-backup-identity-") as temp_dir:
+        temp = Path(temp_dir)
+        probe_path = temp / "Probe.swift"
+        binary_path = temp / "backup-identity-probe"
+        probe_path.write_text(probe)
+        result = subprocess.run(
+            ["swiftc", str(root / "Sources/Phosphor/Models/BackupInfo.swift"), str(probe_path), "-o", str(binary_path)],
+            cwd=root,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        assert result.returncode == 0, result.stderr
+        result = subprocess.run([str(binary_path)], capture_output=True, text=True, timeout=30)
+        assert result.returncode == 0, result.stderr
+        assert result.stdout.strip() == "PASS"
+
+
+def test_multi_device_backup_activity_is_visible_and_device_scoped(root: Path) -> None:
+    view_model = read(root, "Sources/Phosphor/ViewModels/BackupViewModel.swift")
+    backup_list = read(root, "Sources/Phosphor/Views/Backup/BackupListView.swift")
+    overview = read(root, "Sources/Phosphor/Views/Device/DeviceOverviewView.swift")
+    app = read(root, "Sources/Phosphor/App/PhosphorApp.swift")
+
+    assert_contains(view_model, "func isBackupActive(for udid: String)", "action gating should be scoped to one device")
+    assert_contains(backup_list, "activeBackupActivities", "the Backups screen should render all active and queued devices")
+    assert_contains(backup_list, "deviceIdentity(for: activity.udid)", "same-name devices need a visible UDID discriminator while backing up")
+    assert_contains(backup_list, "backupVM.cancelBackup(udid: activity.udid)", "each activity row needs its own cancel action")
+    assert_contains(overview, "backupVM.activity(for: device.id)", "a device card must not show another device's progress")
+    assert_contains(overview, ".disabled(backupVM.isBackupActive(for: device.id))", "only the busy device's backup button should be disabled")
+    assert "backupVM.isCreating" not in app.split('Button("New Backup")', 1)[1].split('Button("Refresh Backups")', 1)[0], "Cmd-B should remain available when another device is backing up"
+
+
+def test_schedules_are_persisted_and_executed_per_device(root: Path) -> None:
+    scheduler = read(root, "Sources/Phosphor/Services/BackupScheduler.swift")
+    app = read(root, "Sources/Phosphor/App/PhosphorApp.swift")
+    settings = read(root, "Sources/Phosphor/Views/Settings/SettingsView.swift")
+    backup_list = read(root, "Sources/Phosphor/Views/Backup/BackupListView.swift")
+
+    assert_contains(scheduler, "@Published private(set) var schedules: [Schedule]", "scheduler should retain independent per-device schedules")
+    assert_contains(scheduler, 'schedulesKey = "phosphor.backup.schedules"', "multiple schedules need a new persistence key")
+    assert_contains(scheduler, "JSONDecoder().decode([Schedule].self", "new installs should restore all device schedules")
+    assert_contains(scheduler, "JSONDecoder().decode(Schedule.self", "the previous single schedule must migrate without data loss")
+    assert_contains(scheduler, "func selectSchedule(targetUDID:", "schedule surfaces need to switch between device configurations")
+    assert_contains(scheduler, "for dueSchedule in dueSchedules", "all due device schedules should be considered in one monitor tick")
+    assert_contains(scheduler, "withTaskGroup", "different due devices should be allowed to enter the bounded shared queue together")
+    assert_not_contains(scheduler, "targetDiscoveryFailure", "concurrent device discovery must not share one mutable failure message")
+    assert_contains(scheduler, "backupViewModel.createBackup", "scheduled jobs must share the app-wide two-device queue")
+    assert_contains(scheduler, "guard let backupViewModel else", "scheduled jobs must fail closed if the shared queue is unavailable")
+    assert_not_contains(scheduler, "let manager = BackupManager()", "scheduled jobs must never bypass the shared bounded queue")
+    assert_contains(scheduler, "latestPersistedSchedules()", "separate schedule windows must merge instead of overwriting another device's saved schedule")
+    assert_contains(scheduler, "scheduleDidChangeNotification", "all open schedule editors must refresh after another instance saves")
+    assert_contains(scheduler, "mergeEditedFields", "stale editors must apply only fields the user actually changed")
+    assert_contains(scheduler, "guard schedules.contains(where: \\.enabled)", "disabled schedules must not keep an idle polling timer alive")
+    assert_contains(scheduler, "latestSchedule(matching: runSchedule.targetUDID)", "a completed run must preserve edits made while that device backup was active")
+    assert_contains(app, "scheduler.attachBackupViewModel(backupVM)", "the app monitor must use the shared backup activity center")
+    assert_contains(settings, "scheduler.selectSchedule", "Settings should load the selected device's independent schedule")
+    assert_contains(backup_list, "scheduler.selectSchedule", "the schedule sheet should load the selected device's independent schedule")
+    assert_contains(backup_list, "ScheduledBackupDevicePicker", "the backup schedule sheet should share the identity-safe device picker")
+    picker = read(root, "Sources/Phosphor/Views/Backup/ScheduledBackupDevicePicker.swift")
+    assert_contains(picker, "device.id.suffix(8)", "same-name devices must be distinguishable in schedule target selection")
 
 
 def test_incremental_backups_require_existing_metadata(root: Path) -> None:

--- a/Scripts/regression/checks/device_backup.py
+++ b/Scripts/regression/checks/device_backup.py
@@ -180,7 +180,9 @@ def test_wifi_schedules_use_network_discovery_and_network_backup_flag(root: Path
     scheduler = read(root, "Sources/Phosphor/Services/BackupScheduler.swift")
     assert_contains(scheduler, "pyEntries.filter { $0.connectionType != \"USB\" }", "Wi-Fi-only schedules should filter out USB pymobiledevice entries")
     assert_contains(scheduler, "PyMobileDevice.listNetworkDevices()", "Wi-Fi-only schedules should probe network devices explicitly")
-    assert_contains(scheduler, 'let fallbackArgs = runSchedule.wifiOnly ? ["-n"] : ["-l"]', "Wi-Fi-only fallback should use idevice_id -n")
+    assert_contains(scheduler, "libimobiledeviceCandidates(wifiOnly:", "scheduled fallback should classify both USB and network candidates")
+    assert_contains(scheduler, 'arguments: ["-n"], timeout: 5', "scheduled fallback should query timeout-bounded network discovery")
+    assert_contains(scheduler, 'arguments: ["-l"], timeout: 5', "any-transport schedules should still prefer an available USB route")
     assert_contains(scheduler, "createBackup(udid: udid, incremental: incremental, preferNetwork: preferNetwork)", "all scheduled backups should preserve incremental and network preferences through the shared queue")
     assert_contains(scheduler, "runSchedule.incrementalOnly && BackupManager.hasExistingBackup(for: udid)", "Scheduled incremental mode should run the required first full backup when metadata is missing")
     assert_contains(scheduler, "running required first full backup", "Scheduled first-full fallback should be logged clearly")
@@ -265,15 +267,14 @@ require(Resolver.resolve(candidates: [phone, phoneUSB], targetUDID: nil) == .tar
 
 def test_legacy_schedule_resolves_the_complete_discovery_union(root: Path) -> None:
     scheduler = read(root, "Sources/Phosphor/Services/BackupScheduler.swift")
-    no_target = scheduler.split("// Legacy schedules may not have a target yet.", 1)[1]
-    discovery = no_target.split("// MARK: - Scheduling Math", 1)[0]
+    discovery = "var discoveredCandidates" + scheduler.split("var discoveredCandidates", 1)[1].split("// MARK: - Scheduling Math", 1)[0]
 
     assert_contains(discovery, "var discoveredCandidates", "legacy target discovery should accumulate candidates across backends")
     assert_contains(discovery, "discoveredCandidates.append(contentsOf:", "every applicable discovery backend should contribute to one candidate union")
     assert_contains(discovery, "resolveTarget(from: discoveredCandidates, targetUDID: runSchedule.targetUDID)", "legacy target resolution must happen once against the complete candidate union")
     resolve_call = "resolveTarget(from: discoveredCandidates, targetUDID: runSchedule.targetUDID)"
     assert discovery.rindex(resolve_call) > discovery.index("PyMobileDevice.listNetworkDevices()"), "network discovery must finish before resolving a legacy target"
-    assert discovery.rindex(resolve_call) > discovery.index('Shell.runAsync("idevice_id"'), "libimobiledevice fallback must finish before resolving a legacy target"
+    assert discovery.rindex(resolve_call) > discovery.index("await libimobiledeviceCandidates"), "libimobiledevice fallback must finish before resolving a legacy target"
 
     # A single primary candidate plus a distinct fallback candidate is ambiguous.
     # This is the cross-backend scenario that previously selected the primary early.
@@ -289,6 +290,17 @@ precondition(
         targetUDID: nil
     ) == .selectionRequired
 )
+
+let single = ScheduledBackupTargetResolver.resolve(candidates: [
+    .init(udid: "phone-a", preferNetwork: true)
+], targetUDID: nil)
+precondition(single == .target(.init(udid: "phone-a", preferNetwork: true)))
+
+let usbPreferred = ScheduledBackupTargetResolver.resolve(candidates: [
+    .init(udid: "phone-a", preferNetwork: true),
+    .init(udid: "phone-a", preferNetwork: false)
+], targetUDID: "phone-a")
+precondition(usbPreferred == .target(.init(udid: "phone-a", preferNetwork: false)))
 '''
     with tempfile.TemporaryDirectory(prefix="phosphor-schedule-union-") as temp_dir:
         temp = Path(temp_dir)
@@ -358,11 +370,63 @@ def test_backup_view_model_tracks_and_cancels_jobs_per_device(root: Path) -> Non
     assert_contains(view_model, "manager.cancelBackup()", "cancelling one device must not terminate another device's process")
     assert_contains(view_model, "backupJobTasks[udid]?.cancel()", "a promoted job must remain cancellable before its BackupManager exists")
     assert_contains(view_model, "backupJobTasks[nextUDID] = task", "promotion must register task ownership before the job can start")
+    assert_contains(view_model, "withTaskCancellationHandler", "cancelling a scheduled task must propagate into its queue request")
+    assert_contains(view_model, "BackupRequestTracker", "deduplicated callers need request ownership before cancellation can affect a shared job")
     assert_contains(view_model, "let encrypted: Bool", "queued backup requests must retain encryption intent")
     assert_contains(view_model, "func activity(for udid: String)", "device views need device-scoped progress")
     create = view_model.split("func createBackup(udid: String", 1)[1].split("private func", 1)[0]
     assert "guard !isCreating" not in create, "a global creation guard would block a second device"
     assert_contains(create, "jobQueue.enqueue(udid: udid)", "backup requests should enter the bounded per-device queue")
+
+
+def test_backup_request_cancellation_respects_deduplicated_callers(root: Path) -> None:
+    tracker_source = root / "Sources/Phosphor/Utilities/BackupRequestTracker.swift"
+    assert tracker_source.exists(), "queue cancellation needs a behaviorally testable request-ownership model"
+    probe = r'''
+import Foundation
+
+@main
+struct BackupRequestTrackerProbe {
+    static func main() {
+        var tracker = BackupRequestTracker()
+        let owner = UUID()
+        let waiter = UUID()
+
+        tracker.registerOwner(owner, udid: "phone")
+        precondition(tracker.cancel(owner, udid: "phone") == .cancelJob)
+        tracker.finish(udid: "phone")
+
+        tracker.registerOwner(owner, udid: "phone")
+        tracker.registerWaiter(waiter, udid: "phone")
+        precondition(tracker.cancel(owner, udid: "phone") == .detachRequest)
+        precondition(tracker.cancel(waiter, udid: "phone") == .cancelJob)
+        tracker.finish(udid: "phone")
+
+        tracker.registerOwner(owner, udid: "phone")
+        tracker.registerWaiter(waiter, udid: "phone")
+        precondition(tracker.cancel(waiter, udid: "phone") == .detachRequest)
+        precondition(tracker.cancel(owner, udid: "phone") == .cancelJob)
+        precondition(tracker.cancel(UUID(), udid: "phone") == .notFound)
+        print("PASS")
+    }
+}
+'''
+    with tempfile.TemporaryDirectory(prefix="phosphor-backup-request-tracker-") as temp_dir:
+        temp = Path(temp_dir)
+        probe_path = temp / "Probe.swift"
+        binary_path = temp / "backup-request-tracker-probe"
+        probe_path.write_text(probe)
+        result = subprocess.run(
+            ["swiftc", "-parse-as-library", str(tracker_source), str(probe_path), "-o", str(binary_path)],
+            cwd=root,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        assert result.returncode == 0, result.stderr
+        result = subprocess.run([str(binary_path)], capture_output=True, text=True, timeout=30)
+        assert result.returncode == 0, result.stderr
+        assert result.stdout.strip() == "PASS"
 
 
 def test_backup_surfaces_show_stable_device_identity(root: Path) -> None:
@@ -497,6 +561,7 @@ def test_multi_device_backup_activity_is_visible_and_device_scoped(root: Path) -
     assert_contains(backup_list, "deviceIdentity(for: activity.udid)", "same-name devices need a visible UDID discriminator while backing up")
     assert_contains(backup_list, "backupVM.cancelBackup(udid: activity.udid)", "each activity row needs its own cancel action")
     assert_contains(overview, "backupVM.activity(for: device.id)", "a device card must not show another device's progress")
+    assert_contains(overview, 'backupVM.isBackupActive(for: device.id) ? "Backing Up..."', "a device card must not show another device's global backup label")
     assert_contains(overview, ".disabled(backupVM.isBackupActive(for: device.id))", "only the busy device's backup button should be disabled")
     assert "backupVM.isCreating" not in app.split('Button("New Backup")', 1)[1].split('Button("Refresh Backups")', 1)[0], "Cmd-B should remain available when another device is backing up"
 
@@ -571,7 +636,8 @@ def test_backup_failures_have_recovery_actions_and_collapsed_details(root: Path)
 
     vm = read(root, "Sources/Phosphor/ViewModels/BackupViewModel.swift")
     assert_contains(vm, "backupIssue", "BackupViewModel should surface structured backup issues separately from success alerts")
-    assert_contains(vm, "retryLastBackup", "BackupViewModel should support recommended retry action")
+    assert_contains(vm, "retryBackup(for issue", "BackupViewModel should retry the device captured by the failed issue")
+    assert_contains(vm, "failedBackupRequests[failure.id] = request", "concurrent failures must retain each device's exact transport/encryption request")
     assert_contains(vm, "deleteIncompleteBackupAndRunFull", "BackupViewModel should implement incomplete-backup recovery")
     assert_contains(vm, "runFullBackup(for issue", "Recovery actions should use the failed issue context, not the currently selected device")
     assert_contains(vm, "expectedPath: path", "Recovery deletion should use the exact path from the failed issue")
@@ -699,6 +765,7 @@ def test_clearing_a_schedule_target_persists_a_disabled_clear_state(root: Path) 
 
 def test_scheduled_work_is_tracked_cancelled_and_revalidated_before_starting_backup(root: Path) -> None:
     scheduler = read(root, "Sources/Phosphor/Services/BackupScheduler.swift")
+    view_model = read(root, "Sources/Phosphor/ViewModels/BackupViewModel.swift")
 
     assert_contains(scheduler, "private var scheduledCheckTask: Task<Void, Never>?", "scheduled monitor checks need a retained task handle")
     assert_contains(scheduler, "private var scheduledRunTasks: [String: Task<Void, Never>]", "each delayed scheduled discovery/run needs a retained task handle")
@@ -706,6 +773,12 @@ def test_scheduled_work_is_tracked_cancelled_and_revalidated_before_starting_bac
     assert_contains(scheduler, "scheduledRunTasks.values.forEach { $0.cancel() }", "stopping monitoring must cancel delayed per-device scheduled work")
     assert_contains(scheduler, "guard !Task.isCancelled", "scheduled work must observe cancellation after suspension")
     assert_contains(scheduler, "isScheduledRunStillValid", "scheduled work must revalidate persisted state after async discovery")
+    assert_contains(view_model, "cancelBackupRequest(udid: udid, requestID: request.id)", "task cancellation must remove the exact scheduled queue request")
+    assert_contains(view_model, "requestTracker.cancel(requestID", "scheduled cancellation must not bluntly cancel a manual caller sharing the same UDID")
+    cancel_work = scheduler.split("private func cancelScheduledWork", 1)[1].split("private func cancelInvalidScheduledWork", 1)[0]
+    invalid_work = scheduler.split("private func cancelInvalidScheduledWork", 1)[1].split("private func finishScheduledRunTask", 1)[0]
+    assert_not_contains(cancel_work, "scheduledRunOwnership.removeAll()", "stop-monitoring cancellation must retain ownership until queue cancellation is terminal")
+    assert_not_contains(invalid_work, "finishScheduledBackupRun", "retargeting must not release run ownership before the exact queue request is cancelled")
 
     run_body = scheduler.split("private func run(", 1)[1].split("private func isScheduledRunStillValid", 1)[0]
     discovery_index = run_body.index("findTargetDevice(for: runSchedule)")
@@ -722,6 +795,17 @@ def test_scheduled_work_is_tracked_cancelled_and_revalidated_before_starting_bac
     assert not may_start_after_discovery(monitoring=True, enabled=False, stored_target="phone", run_target="phone", cancelled=True)
     assert not may_start_after_discovery(monitoring=True, enabled=True, stored_target="tablet", run_target="phone", cancelled=True)
     assert may_start_after_discovery(monitoring=True, enabled=True, stored_target="phone", run_target="phone", cancelled=False)
+
+
+def test_due_schedule_retries_after_transient_device_discovery_miss(root: Path) -> None:
+    scheduler = read(root, "Sources/Phosphor/Services/BackupScheduler.swift")
+    run_body = scheduler.split("private func run(", 1)[1].split("private func isScheduledRunStillValid", 1)[0]
+    missing_target = run_body.split("guard let target = discovery.target else", 1)[1].split("await runScheduledBackup", 1)[0]
+
+    assert_contains(missing_target, "Waiting to retry:", "a transient Wi-Fi miss should remain visibly pending")
+    assert_not_contains(missing_target, "lastRunDate =", "a discovery miss is not a completed scheduled attempt")
+    assert_not_contains(missing_target, "nextRunDate =", "a discovery miss must remain due for the next monitor tick")
+    assert_not_contains(scheduler, "advanceAfterDiscoveryFailure", "automatic and Run Now discovery misses should share retry-safe semantics")
 
 
 def test_schedule_completion_requires_current_persisted_schedule_and_run_ownership(root: Path) -> None:

--- a/Scripts/regression/checks/shell_safety.py
+++ b/Scripts/regression/checks/shell_safety.py
@@ -168,19 +168,19 @@ def test_backup_streaming_callers_are_timeout_bounded_and_cancelable(root: Path)
     assert "timeout: Self.streamingBackupTimeout" in backup, "backup subprocess streams must pass the backup timeout"
     assert "timeout: Self.streamingRestoreTimeout" in backup, "restore subprocess streams must pass the restore timeout"
     assert "activeProcess = Shell.runStreaming" in backup, "fallback streaming processes should be cancelable via activeProcess"
-    assert "beginCancellableOperation()" in backup, "backup/restore operations should use operation IDs rather than one shared cancellation boolean"
+    assert "beginCancellableOperation(udid:" in backup, "backup/restore operations should use per-device operation IDs rather than one shared cancellation boolean"
     assert "cancelledOperationIDs.insert(activeOperationID)" in backup, "cancelBackup should mark the active operation canceled before killing the child"
     assert "operationWasCancelled(operationID)" in backup, "cancelled primary streams should not fall through into fallback backups"
     assert "lastOperationWasCancelled" in backup, "cancellation should be exposed separately from lastError/backup failures"
-    assert "if activeOperationID == id" in swift_block_after(backup, "private func markOperationCancelled"), "stale cancelled operations should not overwrite current operation UI state"
+    assert "if operationCoordinator.activeOperationID == id" in swift_block_after(backup, "private func markOperationCancelled"), "stale cancelled operations should not overwrite current operation UI state"
     assert "backupCancelled" not in backup, "backup/restore cancellation must not use one shared mutable boolean"
     assert "lastError = nil" in swift_block_after(backup, "func cancelBackup()"), "cancelBackup should not report user cancellation as an error"
     assert "Shell.terminate(activeProcess)" in backup, "cancelBackup should escalate termination for stuck subprocesses"
 
     backup_vm = read(root, "Sources/Phosphor/ViewModels/BackupViewModel.swift")
-    assert "backupManager.lastOperationWasCancelled" in backup_vm, "backup UI should not show failure alerts after user cancellation"
-    assert "backupOperationID" in backup_vm, "BackupViewModel should ignore stale backup task progress/completions"
-    assert "guard backupOperationID == operationID else { return }" in backup_vm, "stale backup completions should not update alerts or progress"
+    assert "manager.lastOperationWasCancelled" in backup_vm, "each device activity should treat its own cancellation separately from failure"
+    assert "private var backupManagers: [String: BackupManager]" in backup_vm, "concurrent devices need independent process and completion owners"
+    assert "updateBackupProgress(udid: udid" in backup_vm, "backup progress updates must remain scoped to the originating device"
 
     time_machine = read(root, "Sources/Phosphor/Views/Backup/BackupTimeMachineView.swift")
     assert "lastOperationWasCancelled" in time_machine, "restore UI should not show a generic failure alert after cancellation"
@@ -197,6 +197,74 @@ def test_backup_streaming_callers_are_timeout_bounded_and_cancelable(root: Path)
     assert "syslogStreamID = nil" in swift_block_after(diagnostics, "func stopSyslog()"), "stopSyslog should invalidate stream identity before termination completions fire"
     assert "syslogProcess = Shell.runStreaming" in diagnostics, "syslog fallback should be stoppable via syslogProcess"
     assert "Shell.terminate(syslogProcess)" in diagnostics, "stopSyslog should escalate termination for stuck syslog children"
+
+
+def test_backup_ownership_blocks_same_device_but_allows_different_devices(root: Path) -> None:
+    manager = read(root, "Sources/Phosphor/Services/BackupManager.swift")
+    coordinator_path = root / "Sources/Phosphor/Services/BackupOperationCoordinator.swift"
+    assert coordinator_path.exists(), "backup ownership should be extracted for behavioral testing"
+    coordinator = coordinator_path.read_text()
+    assert "struct BackupOperationRegistry" in coordinator
+    assert "struct BackupOperationCoordinator" in coordinator
+    assert "private static var operationRegistry" in manager, "all manager instances must share per-device ownership"
+    assert manager.count("beginCancellableOperation(udid:") >= 4, "full, incremental, restore, and the helper must use device ownership"
+
+    probe = r'''
+import Foundation
+
+@main
+struct OperationOwnershipProbe {
+    static func main() {
+        var registry = BackupOperationRegistry()
+        var phoneManager = BackupOperationCoordinator()
+        var duplicatePhoneManager = BackupOperationCoordinator()
+        var tabletManager = BackupOperationCoordinator()
+        var thirdDeviceManager = BackupOperationCoordinator()
+
+        let phoneID = UUID()
+        let duplicateID = UUID()
+        let tabletID = UUID()
+        let replacementID = UUID()
+        let thirdDeviceID = UUID()
+
+        precondition(phoneManager.begin(udid: "phone", operationID: phoneID, registry: &registry) == phoneID)
+        precondition(duplicatePhoneManager.begin(udid: "phone", operationID: duplicateID, registry: &registry) == nil)
+        precondition(tabletManager.begin(udid: "tablet", operationID: tabletID, registry: &registry) == tabletID)
+        precondition(thirdDeviceManager.begin(udid: "watch", operationID: thirdDeviceID, registry: &registry) == nil)
+
+        // Cancellation does not release ownership until the subprocess completion
+        // finishes with the matching operation identity.
+        precondition(duplicatePhoneManager.begin(udid: "phone", operationID: replacementID, registry: &registry) == nil)
+        precondition(phoneManager.finish(operationID: phoneID, registry: &registry))
+        precondition(thirdDeviceManager.begin(udid: "watch", operationID: thirdDeviceID, registry: &registry) == thirdDeviceID)
+        precondition(thirdDeviceManager.finish(operationID: thirdDeviceID, registry: &registry))
+        precondition(phoneManager.begin(udid: "phone", operationID: replacementID, registry: &registry) == replacementID)
+
+        // A stale completion cannot release the replacement operation.
+        precondition(!phoneManager.finish(operationID: phoneID, registry: &registry))
+        precondition(duplicatePhoneManager.begin(udid: "phone", operationID: duplicateID, registry: &registry) == nil)
+        precondition(phoneManager.finish(operationID: replacementID, registry: &registry))
+        precondition(tabletManager.finish(operationID: tabletID, registry: &registry))
+        print("PASS")
+    }
+}
+'''
+    with tempfile.TemporaryDirectory(prefix="phosphor-device-ownership-") as temp_dir:
+        temp = Path(temp_dir)
+        probe_path = temp / "Probe.swift"
+        binary_path = temp / "operation-ownership-probe"
+        probe_path.write_text(probe)
+        result = subprocess.run(
+            ["swiftc", "-parse-as-library", str(coordinator_path), str(probe_path), "-o", str(binary_path)],
+            cwd=root,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        assert result.returncode == 0, result.stderr
+        result = subprocess.run([str(binary_path)], capture_output=True, text=True, timeout=30)
+        assert result.returncode == 0, result.stderr
+        assert result.stdout.strip() == "PASS"
 
 
 def test_restore_captures_target_and_uses_backup_parent_with_source_udid(root: Path) -> None:

--- a/Scripts/regression/checks/shell_safety.py
+++ b/Scripts/regression/checks/shell_safety.py
@@ -297,6 +297,9 @@ def test_restore_captures_target_and_uses_backup_parent_with_source_udid(root: P
 
     clone = read(root, "Sources/Phosphor/Services/DeviceCloneService.swift")
     assert "backup: latestBackup" in clone and "targetUDID: destinationUDID" in clone, "clone restore must keep source backup and destination device distinct"
+    assert "previousFingerprints" in clone, "clone must capture a pre-backup snapshot before choosing restore input"
+    assert "freshSourceBackups" in clone, "clone must reject unchanged stale backups even when their directory is canonical"
+    assert "backupFreshnessDate" in clone, "clone must select the freshest verified changed backup when multiple source snapshots exist"
 
 
 def test_cancellation_token_model_prevents_cancelled_primary_from_starting_fallback(root: Path) -> None:

--- a/Sources/Phosphor/App/PhosphorApp.swift
+++ b/Sources/Phosphor/App/PhosphorApp.swift
@@ -59,6 +59,7 @@ struct PhosphorApp: App {
                         try? await Task.sleep(for: .milliseconds(750))
                         deviceVM.deviceManager.startPolling(interval: 4.0)
                         backupVM.loadBackups()
+                        scheduler.attachBackupViewModel(backupVM)
                         scheduler.startMonitoring()
                     }
                 }
@@ -105,7 +106,10 @@ struct PhosphorApp: App {
                     }
                 }
                 .keyboardShortcut("b", modifiers: .command)
-                .disabled(deviceVM.selectedDevice == nil)
+                .disabled(
+                    deviceVM.selectedDevice == nil ||
+                    deviceVM.selectedDevice.map { backupVM.isBackupActive(for: $0.id) } == true
+                )
 
                 Button("Refresh Backups") {
                     backupVM.loadBackups()
@@ -116,6 +120,8 @@ struct PhosphorApp: App {
 
         Settings {
             SettingsView()
+                .environmentObject(deviceVM)
+                .environmentObject(backupVM)
         }
     }
 

--- a/Sources/Phosphor/Models/BackupInfo.swift
+++ b/Sources/Phosphor/Models/BackupInfo.swift
@@ -32,6 +32,31 @@ struct BackupInfo: Identifiable, Hashable {
         ).modelName
     }
 
+    /// Short, stable discriminator. Prefer the authoritative backup UDID, then
+    /// fall back to its serial or backup-folder identity for incomplete metadata.
+    var shortUDID: String {
+        let source = !udid.isEmpty ? udid : (!serialNumber.isEmpty ? serialNumber : id)
+        guard !source.isEmpty else { return "Unknown" }
+        return String(source.suffix(8))
+    }
+
+    /// Shared user-facing identity for backup lists and pickers. The identifier
+    /// suffix keeps same-name, same-model backups visibly distinct without
+    /// exposing a complete hardware identifier throughout the UI.
+    var deviceIdentityLabel: String {
+        let identifier: String
+        if !udid.isEmpty {
+            identifier = "ID …\(shortUDID)"
+        } else if !serialNumber.isEmpty {
+            identifier = "Serial …\(shortUDID)"
+        } else if !id.isEmpty {
+            identifier = "Backup …\(shortUDID)"
+        } else {
+            identifier = "Unknown device ID"
+        }
+        return "\(deviceName) • \(modelName) • \(identifier)"
+    }
+
     var dateString: String {
         lastBackupDate?.shortString ?? "Unknown"
     }

--- a/Sources/Phosphor/Services/BackupArchiver.swift
+++ b/Sources/Phosphor/Services/BackupArchiver.swift
@@ -98,7 +98,9 @@ enum BackupArchiver {
         dateFormatter.dateFormat = "yyyy-MM-dd_HHmmss"
         let dateStr = dateFormatter.string(from: backup.lastBackupDate ?? Date())
 
-        let archiveName = "\(safeName)_\(dateStr).\(fileExtension)"
+        // Keep portable archives attributable when same-name devices create
+        // backups at similar times.
+        let archiveName = "\(safeName)_\(backup.shortUDID)_\(dateStr).\(fileExtension)"
         let archivePath = (destinationDir as NSString).appendingPathComponent(archiveName)
 
         // Remove existing file

--- a/Sources/Phosphor/Services/BackupManager.swift
+++ b/Sources/Phosphor/Services/BackupManager.swift
@@ -53,16 +53,29 @@ final class BackupManager: ObservableObject {
         case incomplete(path: String)
     }
 
-    /// Active backup process for cancellation.
+    /// Active backup process for cancellation. Ownership is shared across manager
+    /// instances by device UDID, allowing different devices to run concurrently
+    /// without permitting two writers to operate on the same physical device.
+    private static var operationRegistry = BackupOperationRegistry()
     private var activeProcess: Process?
-    private var activeOperationID: UUID?
+    private var operationCoordinator = BackupOperationCoordinator()
     private var cancelledOperationIDs: Set<UUID> = []
 
-    private func beginCancellableOperation() -> UUID {
-        let id = UUID()
-        activeOperationID = id
+    private func beginCancellableOperation(udid: String) -> UUID? {
+        guard operationCoordinator.activeOperationID == nil else {
+            lastError = "Another backup or restore operation is already running."
+            return nil
+        }
         lastOperationWasCancelled = false
-        return id
+        lastBackupFailure = nil
+        guard let operationID = operationCoordinator.begin(
+            udid: udid,
+            registry: &Self.operationRegistry
+        ) else {
+            lastError = "Another backup or restore operation is already running for this device."
+            return nil
+        }
+        return operationID
     }
 
     private func operationWasCancelled(_ id: UUID) -> Bool {
@@ -70,8 +83,7 @@ final class BackupManager: ObservableObject {
     }
 
     private func finishOperation(_ id: UUID) {
-        if activeOperationID == id {
-            activeOperationID = nil
+        if operationCoordinator.finish(operationID: id, registry: &Self.operationRegistry) {
             activeProcess = nil
             isCreatingBackup = false
         }
@@ -79,7 +91,7 @@ final class BackupManager: ObservableObject {
     }
 
     private func markOperationCancelled(_ id: UUID, progress: String = "Cancelled") {
-        if activeOperationID == id {
+        if operationCoordinator.activeOperationID == id {
             lastOperationWasCancelled = true
             backupProgress = progress
             lastError = nil
@@ -481,8 +493,8 @@ final class BackupManager: ObservableObject {
         preferNetwork: Bool = false,
         onProgress: @escaping (String) -> Void
     ) async -> Bool {
+        guard let operationID = beginCancellableOperation(udid: udid) else { return false }
         isCreatingBackup = true
-        let operationID = beginCancellableOperation()
         backupProgress = "Starting backup..."
         backupPercent = 0
         lastError = nil
@@ -676,7 +688,7 @@ final class BackupManager: ObservableObject {
                             continuation.resume(returning: false)
                             return
                         }
-                        if self.activeOperationID == operationID {
+                        if self.operationCoordinator.activeOperationID == operationID {
                             self.activeProcess = nil
                         }
                         if self.operationWasCancelled(operationID) {
@@ -696,8 +708,8 @@ final class BackupManager: ObservableObject {
         preferNetwork: Bool = false,
         onProgress: @escaping (String) -> Void
     ) async -> Bool {
+        guard let operationID = beginCancellableOperation(udid: udid) else { return false }
         isCreatingBackup = true
-        let operationID = beginCancellableOperation()
         backupProgress = "Starting incremental backup..."
         backupPercent = 0
         lastError = nil
@@ -852,7 +864,7 @@ final class BackupManager: ObservableObject {
             return false
         }
 
-        let operationID = beginCancellableOperation()
+        guard let operationID = beginCancellableOperation(udid: targetUDID) else { return false }
         // Primary: pymobiledevice3
         if PyMobileDevice.available() {
             return await withCheckedContinuation { continuation in
@@ -913,7 +925,7 @@ final class BackupManager: ObservableObject {
 
     /// Cancel an active backup/restore.
     func cancelBackup() {
-        if let activeOperationID {
+        if let activeOperationID = operationCoordinator.activeOperationID {
             cancelledOperationIDs.insert(activeOperationID)
         }
         lastOperationWasCancelled = true

--- a/Sources/Phosphor/Services/BackupOperationCoordinator.swift
+++ b/Sources/Phosphor/Services/BackupOperationCoordinator.swift
@@ -1,0 +1,53 @@
+import Foundation
+
+/// Process-wide ownership for destructive backup/restore operations. Different
+/// devices may run concurrently, but one physical device can have only one owner.
+struct BackupOperationRegistry {
+    private let maxConcurrentOperations = 2
+    private var operationByDevice: [String: UUID] = [:]
+
+    mutating func acquire(udid: String, operationID: UUID) -> Bool {
+        guard operationByDevice[udid] == nil else { return false }
+        guard operationByDevice.count < maxConcurrentOperations else { return false }
+        operationByDevice[udid] = operationID
+        return true
+    }
+
+    mutating func release(udid: String, operationID: UUID) -> Bool {
+        guard operationByDevice[udid] == operationID else { return false }
+        operationByDevice.removeValue(forKey: udid)
+        return true
+    }
+}
+
+/// Per-BackupManager identity paired with the shared per-device registry.
+struct BackupOperationCoordinator {
+    private(set) var activeOperationID: UUID?
+    private var activeUDID: String?
+
+    mutating func begin(
+        udid: String,
+        operationID: UUID = UUID(),
+        registry: inout BackupOperationRegistry
+    ) -> UUID? {
+        guard activeOperationID == nil else { return nil }
+        guard registry.acquire(udid: udid, operationID: operationID) else { return nil }
+
+        activeOperationID = operationID
+        activeUDID = udid
+        return operationID
+    }
+
+    @discardableResult
+    mutating func finish(
+        operationID: UUID,
+        registry: inout BackupOperationRegistry
+    ) -> Bool {
+        guard activeOperationID == operationID, let activeUDID else { return false }
+        guard registry.release(udid: activeUDID, operationID: operationID) else { return false }
+
+        self.activeOperationID = nil
+        self.activeUDID = nil
+        return true
+    }
+}

--- a/Sources/Phosphor/Services/BackupScheduler.swift
+++ b/Sources/Phosphor/Services/BackupScheduler.swift
@@ -31,6 +31,7 @@ final class BackupScheduler: ObservableObject {
         var preferredHour: Int = 2
         var preferredMinute: Int = 0
         var targetUDID: String?
+        var targetName: String?
         var lastRunDate: Date?
         var nextRunDate: Date?
         var lastResult: String?
@@ -38,8 +39,9 @@ final class BackupScheduler: ObservableObject {
     }
 
     @Published var schedule: Schedule {
-        didSet { saveSchedule() }
+        didSet { synchronizeEditedSchedule(previous: oldValue) }
     }
+    @Published private(set) var schedules: [Schedule]
     @Published var isRunningScheduledBackup = false
     @Published var scheduledBackupProgress = ""
     @Published var recentLogs: [LogEntry] = []
@@ -52,108 +54,213 @@ final class BackupScheduler: ObservableObject {
     }
 
     private var timer: Timer?
+    private var scheduleChangeCancellable: AnyCancellable?
+    private var isMonitoring = false
+    private var isSynchronizingSchedule = false
+    private var runningScheduledUDIDs: Set<String> = []
+    private weak var backupViewModel: BackupViewModel?
     private let defaults = UserDefaults.standard
     private let scheduleKey = "phosphor.backup.schedule"
+    private let schedulesKey = "phosphor.backup.schedules"
     private let logsKey = "phosphor.backup.schedule.logs"
+    private static let scheduleDidChangeNotification = Notification.Name("phosphor.backup.schedule.did-change")
 
     init() {
-        if let data = defaults.data(forKey: scheduleKey),
-           let saved = try? JSONDecoder().decode(Schedule.self, from: data) {
+        if let data = defaults.data(forKey: schedulesKey),
+           let saved = try? JSONDecoder().decode([Schedule].self, from: data) {
+            self.schedules = saved
+            self.schedule = saved.first ?? Schedule()
+        } else if let data = defaults.data(forKey: scheduleKey),
+                  let saved = try? JSONDecoder().decode(Schedule.self, from: data) {
+            self.schedules = [saved]
             self.schedule = saved
         } else {
+            self.schedules = []
             self.schedule = Schedule()
         }
         loadLogs()
+        scheduleChangeCancellable = NotificationCenter.default.publisher(
+            for: Self.scheduleDidChangeNotification
+        ).sink { [weak self] _ in
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                self.reloadFromDefaults()
+                self.configureMonitoring()
+            }
+        }
+        saveSchedules()
+    }
+
+    func attachBackupViewModel(_ backupViewModel: BackupViewModel) {
+        self.backupViewModel = backupViewModel
+    }
+
+    func selectSchedule(targetUDID: String?, targetName: String?) {
+        isSynchronizingSchedule = true
+        schedules = latestPersistedSchedules()
+        if let existing = schedules.first(where: { $0.targetUDID == targetUDID }) {
+            schedule = existing
+        } else if let targetUDID,
+                  let legacyIndex = schedules.firstIndex(where: { $0.targetUDID == nil }) {
+            var migrated = schedules[legacyIndex]
+            migrated.targetUDID = targetUDID
+            migrated.targetName = targetName
+            schedules[legacyIndex] = migrated
+            schedule = migrated
+            saveSchedules()
+        } else {
+            schedule = Schedule(targetUDID: targetUDID, targetName: targetName)
+            if targetUDID != nil {
+                schedules.append(schedule)
+                saveSchedules()
+            }
+        }
+        isSynchronizingSchedule = false
     }
 
     // MARK: - Timer Control
 
     func startMonitoring() {
         stopMonitoring()
-        // Keep a lightweight timer alive even when the saved schedule is disabled.
-        // Settings and schedule sheets use separate BackupScheduler instances that
-        // persist changes through UserDefaults; this app-level scheduler must be
-        // able to notice a schedule that is enabled after launch.
+        isMonitoring = true
+        reloadFromDefaults()
+        configureMonitoring()
+        if schedules.contains(where: \.enabled) {
+            Task { await checkAndRun() }
+            updateNextRunDate()
+        }
+    }
+
+    private func configureMonitoring() {
+        timer?.invalidate()
+        timer = nil
+        guard isMonitoring else { return }
+        guard schedules.contains(where: \.enabled) else { return }
         timer = Timer.scheduledTimer(withTimeInterval: 300, repeats: true) { [weak self] _ in
             Task { @MainActor [weak self] in
                 await self?.checkAndRun()
             }
         }
-        Task { await checkAndRun() }
-        updateNextRunDate()
     }
 
     func stopMonitoring() {
+        isMonitoring = false
         timer?.invalidate()
         timer = nil
     }
 
     func reloadFromDefaults() {
-        if let data = defaults.data(forKey: scheduleKey),
-           let saved = try? JSONDecoder().decode(Schedule.self, from: data) {
-            if saved != schedule { schedule = saved }
+        let savedSchedules: [Schedule]
+        if let data = defaults.data(forKey: schedulesKey),
+           let saved = try? JSONDecoder().decode([Schedule].self, from: data) {
+            savedSchedules = saved
+        } else if let data = defaults.data(forKey: scheduleKey),
+                  let legacy = try? JSONDecoder().decode(Schedule.self, from: data) {
+            savedSchedules = [legacy]
+        } else {
+            return
+        }
+
+        if savedSchedules != schedules {
+            schedules = savedSchedules
+            let selectedTarget = schedule.targetUDID
+            if let refreshed = savedSchedules.first(where: { $0.targetUDID == selectedTarget }) ?? savedSchedules.first {
+                isSynchronizingSchedule = true
+                schedule = refreshed
+                isSynchronizingSchedule = false
+            }
         }
     }
 
     func checkAndRun() async {
         reloadFromDefaults()
-        guard schedule.enabled, !isRunningScheduledBackup else { return }
-        if schedule.nextRunDate == nil { updateNextRunDate() }
-        guard let nextRun = schedule.nextRunDate, Date() >= nextRun else { return }
-
-        isRunningScheduledBackup = true
-
-        let target = await findTargetDevice()
-        guard let target else {
-            addLog("No device found for scheduled backup", success: false)
-            isRunningScheduledBackup = false
-            return
+        var dueSchedules: [Schedule] = []
+        for stored in schedules where stored.enabled {
+            var candidate = stored
+            if candidate.nextRunDate == nil {
+                candidate.nextRunDate = nextRunDate(for: candidate)
+                storeSchedule(candidate, replacingTargetUDID: stored.targetUDID)
+            }
+            if let nextRun = candidate.nextRunDate,
+               Date() >= nextRun,
+               !runningScheduledUDIDs.contains(candidate.targetUDID ?? "legacy") {
+                dueSchedules.append(candidate)
+            }
         }
 
-        await runScheduledBackup(udid: target.udid, preferNetwork: target.preferNetwork)
+        await withTaskGroup(of: Void.self) { group in
+            for dueSchedule in dueSchedules {
+                group.addTask { @MainActor [weak self] in
+                    await self?.run(schedule: dueSchedule, advanceAfterDiscoveryFailure: true)
+                }
+            }
+        }
     }
 
     func runNow() async {
-        guard !isRunningScheduledBackup else { return }
+        await run(schedule: schedule, advanceAfterDiscoveryFailure: false)
+    }
+
+    private func run(schedule runSchedule: Schedule, advanceAfterDiscoveryFailure: Bool) async {
+        let scheduleIdentity = runSchedule.targetUDID ?? "legacy"
+        guard !runningScheduledUDIDs.contains(scheduleIdentity) else { return }
+        runningScheduledUDIDs.insert(scheduleIdentity)
         isRunningScheduledBackup = true
-        let target = await findTargetDevice()
-        guard let target else {
-            addLog("No device available for backup", success: false)
-            isRunningScheduledBackup = false
+
+        let discovery = await findTargetDevice(for: runSchedule)
+        guard let target = discovery.target else {
+            let failure = discovery.failure ?? "No device available for backup"
+            var updated = latestSchedule(matching: runSchedule.targetUDID) ?? runSchedule
+            updated.lastResult = failure
+            if advanceAfterDiscoveryFailure {
+                updated.lastRunDate = Date()
+                updated.nextRunDate = nextRunDate(for: updated)
+            }
+            storeSchedule(updated, replacingTargetUDID: runSchedule.targetUDID)
+            addLog(failure, success: false)
+            runningScheduledUDIDs.remove(scheduleIdentity)
+            isRunningScheduledBackup = !runningScheduledUDIDs.isEmpty
             return
         }
-        await runScheduledBackup(udid: target.udid, preferNetwork: target.preferNetwork)
+        await runScheduledBackup(schedule: runSchedule, udid: target.udid, preferNetwork: target.preferNetwork)
+        runningScheduledUDIDs.remove(scheduleIdentity)
+        isRunningScheduledBackup = !runningScheduledUDIDs.isEmpty
     }
 
     // MARK: - Backup Execution
 
-    private func runScheduledBackup(udid: String, preferNetwork: Bool) async {
-        isRunningScheduledBackup = true
+    private func runScheduledBackup(schedule runSchedule: Schedule, udid: String, preferNetwork: Bool) async {
         scheduledBackupProgress = "Starting scheduled backup..."
-        addLog("Scheduled backup started for device \(udid.prefix(8))...", success: true)
+        addLog("Scheduled backup started for \(runSchedule.targetName ?? "device \(udid.prefix(8))...")", success: true)
 
-        let manager = BackupManager()
-        let success: Bool
-
-        if schedule.incrementalOnly && BackupManager.hasExistingBackup(for: udid) {
-            success = await manager.createIncrementalBackup(udid: udid, preferNetwork: preferNetwork) { [weak self] text in
-                self?.scheduledBackupProgress = text
-            }
-        } else {
-            if schedule.incrementalOnly {
-                addLog("No complete backup exists yet; running required first full backup", success: true)
-            }
-            success = await manager.createBackup(udid: udid, preferNetwork: preferNetwork) { [weak self] text in
-                self?.scheduledBackupProgress = text
-            }
+        let incremental = runSchedule.incrementalOnly && BackupManager.hasExistingBackup(for: udid)
+        if runSchedule.incrementalOnly && !incremental {
+            addLog("No complete backup exists yet; running required first full backup", success: true)
         }
 
-        isRunningScheduledBackup = false
-        schedule.lastRunDate = Date()
-        schedule.lastResult = success ? "Completed" : (manager.lastError ?? "Failed")
-        updateNextRunDate()
+        guard let backupViewModel else {
+            let failure = "The shared backup queue is unavailable"
+            var updated = latestSchedule(matching: runSchedule.targetUDID) ?? runSchedule
+            updated.lastRunDate = Date()
+            updated.lastResult = failure
+            updated.nextRunDate = nextRunDate(for: updated)
+            storeSchedule(updated, replacingTargetUDID: runSchedule.targetUDID)
+            addLog(failure, success: false)
+            return
+        }
+
+        await backupViewModel.createBackup(udid: udid, incremental: incremental, preferNetwork: preferNetwork)
+        let activity = backupViewModel.activity(for: udid)
+        let success = activity?.state == .completed
+        let resultMessage = activity?.errorMessage ?? activity?.progressText ?? "Failed"
+
+        var updated = latestSchedule(matching: runSchedule.targetUDID) ?? runSchedule
+        updated.lastRunDate = Date()
+        updated.lastResult = success ? "Completed" : resultMessage
+        updated.nextRunDate = nextRunDate(for: updated)
+        storeSchedule(updated, replacingTargetUDID: runSchedule.targetUDID)
         addLog(
-            success ? "Backup completed" : "Backup failed: \(manager.lastError ?? "unknown error")",
+            success ? "Backup completed" : "Backup failed: \(resultMessage)",
             success: success
         )
     }
@@ -165,63 +272,103 @@ final class BackupScheduler: ObservableObject {
         let preferNetwork: Bool
     }
 
-    private func findTargetDevice() async -> TargetDevice? {
+    private func findTargetDevice(for runSchedule: Schedule) async -> (target: TargetDevice?, failure: String?) {
         let pyEntries = await PyMobileDevice.listDevicesWithType()
-        let eligiblePyEntries = schedule.wifiOnly
+        let eligiblePyEntries = runSchedule.wifiOnly
             ? pyEntries.filter { $0.connectionType != "USB" }
             : pyEntries
 
         // Check specific target first.
-        if let target = schedule.targetUDID {
+        if let target = runSchedule.targetUDID {
             if let entry = eligiblePyEntries.first(where: { $0.udid == target }) {
-                return TargetDevice(udid: target, preferNetwork: entry.connectionType != "USB")
+                return (TargetDevice(udid: target, preferNetwork: entry.connectionType != "USB"), nil)
             }
 
-            if schedule.wifiOnly {
+            if runSchedule.wifiOnly {
                 let networkDevices = await PyMobileDevice.listNetworkDevices()
-                if networkDevices.contains(target) { return TargetDevice(udid: target, preferNetwork: true) }
+                if networkDevices.contains(target) { return (TargetDevice(udid: target, preferNetwork: true), nil) }
             }
 
             // Fallback: libimobiledevice. Use the network-only query when the schedule
             // explicitly requests Wi-Fi backups so USB devices do not accidentally match.
-            let fallbackArgs = schedule.wifiOnly ? ["-n"] : ["-l"]
+            let fallbackArgs = runSchedule.wifiOnly ? ["-n"] : ["-l"]
             let result = await Shell.runAsync("idevice_id", arguments: fallbackArgs)
             if result.succeeded {
                 let devices = result.output.components(separatedBy: "\n").filter { !$0.isEmpty }
-                if devices.contains(target) { return TargetDevice(udid: target, preferNetwork: schedule.wifiOnly) }
+                if devices.contains(target) { return (TargetDevice(udid: target, preferNetwork: runSchedule.wifiOnly), nil) }
             }
-            return nil
+            let failure = runSchedule.wifiOnly
+                ? "The scheduled device is not available over Wi-Fi"
+                : "The scheduled device is not connected"
+            return (nil, failure)
         }
 
-        // No specific target: use the first eligible pymobiledevice3 result, preferring
-        // the single `usbmux list` snapshot over separate USB and network probes.
-        if let first = eligiblePyEntries.first {
-            return TargetDevice(udid: first.udid, preferNetwork: first.connectionType != "USB")
+        // Legacy schedules may not have a target yet. Preserve the convenient
+        // single-device behavior, but collect every applicable backend first so
+        // a partial primary result cannot hide a second phone or tablet that is
+        // visible only through a fallback.
+        var discoveredCandidates = eligiblePyEntries.map {
+            ScheduledBackupTargetResolver.Candidate(
+                udid: $0.udid,
+                preferNetwork: $0.connectionType != "USB"
+            )
         }
 
-        if schedule.wifiOnly {
+        if runSchedule.wifiOnly {
             let networkDevices = await PyMobileDevice.listNetworkDevices()
-            if let first = networkDevices.first { return TargetDevice(udid: first, preferNetwork: true) }
+            discoveredCandidates.append(contentsOf: networkDevices.map {
+                ScheduledBackupTargetResolver.Candidate(udid: $0, preferNetwork: true)
+            })
         }
 
         // Fallback: libimobiledevice.
-        let fallbackArgs = schedule.wifiOnly ? ["-n"] : ["-l"]
+        let fallbackArgs = runSchedule.wifiOnly ? ["-n"] : ["-l"]
         let result = await Shell.runAsync("idevice_id", arguments: fallbackArgs)
         if result.succeeded {
             let devices = result.output.components(separatedBy: "\n").filter { !$0.isEmpty }
-            if let first = devices.first { return TargetDevice(udid: first, preferNetwork: schedule.wifiOnly) }
+            discoveredCandidates.append(contentsOf: devices.map {
+                ScheduledBackupTargetResolver.Candidate(udid: $0, preferNetwork: runSchedule.wifiOnly)
+            })
         }
 
-        return nil
+        switch resolveTarget(from: discoveredCandidates, targetUDID: runSchedule.targetUDID) {
+        case .target(let target):
+            return (TargetDevice(udid: target.udid, preferNetwork: target.preferNetwork), nil)
+        case .selectionRequired:
+            let failure = runSchedule.wifiOnly
+                ? "Multiple Wi-Fi devices are available. Choose a device in Backup Schedule."
+                : "Multiple devices are available. Choose a device in Backup Schedule."
+            return (nil, failure)
+        case .noneAvailable:
+            break
+        }
+
+        let failure = runSchedule.wifiOnly
+            ? "The scheduled device is not available over Wi-Fi"
+            : "The scheduled device is not connected"
+        return (nil, failure)
+    }
+
+    private func resolveTarget(
+        from candidates: [ScheduledBackupTargetResolver.Candidate],
+        targetUDID: String?
+    ) -> ScheduledBackupTargetResolver.Resolution {
+        ScheduledBackupTargetResolver.resolve(
+            candidates: candidates,
+            targetUDID: targetUDID
+        )
     }
 
     // MARK: - Scheduling Math
 
     func updateNextRunDate() {
-        guard schedule.enabled else {
-            schedule.nextRunDate = nil
-            return
-        }
+        var updated = schedule
+        updated.nextRunDate = nextRunDate(for: updated)
+        schedule = updated
+    }
+
+    private func nextRunDate(for schedule: Schedule) -> Date? {
+        guard schedule.enabled else { return nil }
 
         let calendar = Calendar.current
         let now = Date()
@@ -267,15 +414,75 @@ final class BackupScheduler: ObservableObject {
             next = schedule.frequency == .hourly ? advance(next) : scheduledTime(on: advance(next))
         }
 
-        schedule.nextRunDate = next
+        return next
     }
 
     // MARK: - Persistence
 
-    private func saveSchedule() {
+    private func synchronizeEditedSchedule(previous: Schedule) {
+        guard !isSynchronizingSchedule else { return }
+        let latest = latestSchedule(matching: previous.targetUDID) ?? previous
+        let merged = mergeEditedFields(previous: previous, edited: schedule, into: latest)
+        storeSchedule(merged, replacingTargetUDID: previous.targetUDID)
+    }
+
+    /// Apply only fields changed by this editor onto the latest persisted value.
+    /// This prevents a stale Settings window from reverting another window's edit.
+    private func mergeEditedFields(previous: Schedule, edited: Schedule, into latest: Schedule) -> Schedule {
+        var merged = latest
+        if edited.enabled != previous.enabled { merged.enabled = edited.enabled }
+        if edited.frequency != previous.frequency { merged.frequency = edited.frequency }
+        if edited.wifiOnly != previous.wifiOnly { merged.wifiOnly = edited.wifiOnly }
+        if edited.preferredHour != previous.preferredHour { merged.preferredHour = edited.preferredHour }
+        if edited.preferredMinute != previous.preferredMinute { merged.preferredMinute = edited.preferredMinute }
+        if edited.targetUDID != previous.targetUDID { merged.targetUDID = edited.targetUDID }
+        if edited.targetName != previous.targetName { merged.targetName = edited.targetName }
+        if edited.lastRunDate != previous.lastRunDate { merged.lastRunDate = edited.lastRunDate }
+        if edited.nextRunDate != previous.nextRunDate { merged.nextRunDate = edited.nextRunDate }
+        if edited.lastResult != previous.lastResult { merged.lastResult = edited.lastResult }
+        if edited.incrementalOnly != previous.incrementalOnly { merged.incrementalOnly = edited.incrementalOnly }
+        return merged
+    }
+
+    private func storeSchedule(_ updated: Schedule, replacingTargetUDID oldTargetUDID: String?) {
+        var mergedSchedules = latestPersistedSchedules()
+        if let index = mergedSchedules.firstIndex(where: { $0.targetUDID == oldTargetUDID }) ??
+            mergedSchedules.firstIndex(where: { $0.targetUDID == updated.targetUDID }) {
+            mergedSchedules[index] = updated
+        } else {
+            mergedSchedules.append(updated)
+        }
+        schedules = mergedSchedules
+
+        if schedule.targetUDID == oldTargetUDID || schedule.targetUDID == updated.targetUDID {
+            isSynchronizingSchedule = true
+            schedule = updated
+            isSynchronizingSchedule = false
+        }
+        saveSchedules()
+    }
+
+    private func latestPersistedSchedules() -> [Schedule] {
+        guard let data = defaults.data(forKey: schedulesKey),
+              let persisted = try? JSONDecoder().decode([Schedule].self, from: data) else {
+            return schedules
+        }
+        return persisted
+    }
+
+    private func latestSchedule(matching targetUDID: String?) -> Schedule? {
+        latestPersistedSchedules().first(where: { $0.targetUDID == targetUDID })
+    }
+
+    private func saveSchedules() {
+        if let data = try? JSONEncoder().encode(schedules) {
+            defaults.set(data, forKey: schedulesKey)
+        }
+        // Keep the previous key current for downgrade compatibility.
         if let data = try? JSONEncoder().encode(schedule) {
             defaults.set(data, forKey: scheduleKey)
         }
+        NotificationCenter.default.post(name: Self.scheduleDidChangeNotification, object: nil)
     }
 
     private func addLog(_ message: String, success: Bool) {

--- a/Sources/Phosphor/Services/BackupScheduler.swift
+++ b/Sources/Phosphor/Services/BackupScheduler.swift
@@ -54,10 +54,14 @@ final class BackupScheduler: ObservableObject {
     }
 
     private var timer: Timer?
+    private var scheduledCheckTask: Task<Void, Never>?
+    private var scheduledRunTasks: [String: Task<Void, Never>] = [:]
+    private var scheduledRunSchedules: [String: Schedule] = [:]
+    private var scheduledRunIDs: [String: UUID] = [:]
+    private var scheduledRunOwnership = ScheduledRunOwnership()
     private var scheduleChangeCancellable: AnyCancellable?
     private var isMonitoring = false
     private var isSynchronizingSchedule = false
-    private var runningScheduledUDIDs: Set<String> = []
     private weak var backupViewModel: BackupViewModel?
     private let defaults = UserDefaults.standard
     private let scheduleKey = "phosphor.backup.schedule"
@@ -97,7 +101,18 @@ final class BackupScheduler: ObservableObject {
 
     func selectSchedule(targetUDID: String?, targetName: String?) {
         isSynchronizingSchedule = true
+        defer { isSynchronizingSchedule = false }
         schedules = latestPersistedSchedules()
+
+        if targetUDID == nil {
+            let previousTargetUDID = schedule.targetUDID
+            schedules.removeAll { $0.targetUDID == previousTargetUDID }
+            schedule = Schedule()
+            saveSchedules()
+            cancelInvalidScheduledWork()
+            return
+        }
+
         if let existing = schedules.first(where: { $0.targetUDID == targetUDID }) {
             schedule = existing
         } else if let targetUDID,
@@ -110,12 +125,10 @@ final class BackupScheduler: ObservableObject {
             saveSchedules()
         } else {
             schedule = Schedule(targetUDID: targetUDID, targetName: targetName)
-            if targetUDID != nil {
-                schedules.append(schedule)
-                saveSchedules()
-            }
+            schedules.append(schedule)
+            saveSchedules()
         }
-        isSynchronizingSchedule = false
+        cancelInvalidScheduledWork()
     }
 
     // MARK: - Timer Control
@@ -126,7 +139,7 @@ final class BackupScheduler: ObservableObject {
         reloadFromDefaults()
         configureMonitoring()
         if schedules.contains(where: \.enabled) {
-            Task { await checkAndRun() }
+            startScheduledCheck()
             updateNextRunDate()
         }
     }
@@ -134,11 +147,20 @@ final class BackupScheduler: ObservableObject {
     private func configureMonitoring() {
         timer?.invalidate()
         timer = nil
-        guard isMonitoring else { return }
-        guard schedules.contains(where: \.enabled) else { return }
+        scheduledCheckTask?.cancel()
+        scheduledCheckTask = nil
+        guard isMonitoring else {
+            cancelScheduledWork()
+            return
+        }
+        cancelInvalidScheduledWork()
+        guard schedules.contains(where: \.enabled) else {
+            cancelScheduledWork()
+            return
+        }
         timer = Timer.scheduledTimer(withTimeInterval: 300, repeats: true) { [weak self] _ in
             Task { @MainActor [weak self] in
-                await self?.checkAndRun()
+                self?.startScheduledCheck()
             }
         }
     }
@@ -147,6 +169,72 @@ final class BackupScheduler: ObservableObject {
         isMonitoring = false
         timer?.invalidate()
         timer = nil
+        cancelScheduledWork()
+    }
+
+    private func startScheduledCheck() {
+        scheduledCheckTask?.cancel()
+        scheduledCheckTask = Task { @MainActor [weak self] in
+            await self?.checkAndRun()
+        }
+    }
+
+    private func startScheduledRun(_ dueSchedule: Schedule) {
+        let scheduleIdentity = dueSchedule.targetUDID ?? "legacy"
+        guard scheduledRunTasks[scheduleIdentity] == nil,
+              isScheduleCurrent(dueSchedule, requiresActiveMonitoring: true) else { return }
+
+        let runID = UUID()
+        guard scheduledRunOwnership.claim(identity: scheduleIdentity, runID: runID) else { return }
+
+        scheduledRunSchedules[scheduleIdentity] = dueSchedule
+        scheduledRunIDs[scheduleIdentity] = runID
+        scheduledRunTasks[scheduleIdentity] = Task { @MainActor [weak self] in
+            guard let self else { return }
+            await self.run(
+                schedule: dueSchedule,
+                advanceAfterDiscoveryFailure: true,
+                requiresActiveMonitoring: true,
+                runID: runID
+            )
+            self.finishScheduledRunTask(identity: scheduleIdentity, runID: runID)
+        }
+    }
+
+    private func cancelScheduledWork() {
+        scheduledCheckTask?.cancel()
+        scheduledCheckTask = nil
+        scheduledRunTasks.values.forEach { $0.cancel() }
+        scheduledRunTasks.removeAll()
+        scheduledRunSchedules.removeAll()
+        scheduledRunIDs.removeAll()
+        scheduledRunOwnership.removeAll()
+        isRunningScheduledBackup = false
+    }
+
+    private func cancelInvalidScheduledWork() {
+        let invalidScheduleIdentities = scheduledRunSchedules.compactMap { scheduleIdentity, scheduledRun in
+            isScheduleCurrent(scheduledRun, requiresActiveMonitoring: true) ? nil : scheduleIdentity
+        }
+        for scheduleIdentity in invalidScheduleIdentities {
+            guard let runID = scheduledRunIDs[scheduleIdentity] else { continue }
+            scheduledRunTasks[scheduleIdentity]?.cancel()
+            finishScheduledRunTask(identity: scheduleIdentity, runID: runID)
+            finishScheduledBackupRun(identity: scheduleIdentity, runID: runID)
+        }
+        isRunningScheduledBackup = !scheduledRunOwnership.isEmpty
+    }
+
+    private func finishScheduledRunTask(identity: String, runID: UUID) {
+        guard scheduledRunIDs[identity] == runID else { return }
+        scheduledRunTasks.removeValue(forKey: identity)
+        scheduledRunSchedules.removeValue(forKey: identity)
+        scheduledRunIDs.removeValue(forKey: identity)
+    }
+
+    private func finishScheduledBackupRun(identity: String, runID: UUID) {
+        guard scheduledRunOwnership.finish(identity: identity, runID: runID) else { return }
+        isRunningScheduledBackup = !scheduledRunOwnership.isEmpty
     }
 
     func reloadFromDefaults() {
@@ -169,11 +257,14 @@ final class BackupScheduler: ObservableObject {
                 schedule = refreshed
                 isSynchronizingSchedule = false
             }
+            cancelInvalidScheduledWork()
         }
     }
 
     func checkAndRun() async {
+        guard isMonitoring, !Task.isCancelled else { return }
         reloadFromDefaults()
+        guard isMonitoring, !Task.isCancelled else { return }
         var dueSchedules: [Schedule] = []
         for stored in schedules where stored.enabled {
             var candidate = stored
@@ -183,7 +274,7 @@ final class BackupScheduler: ObservableObject {
             }
             if let nextRun = candidate.nextRunDate,
                Date() >= nextRun,
-               !runningScheduledUDIDs.contains(candidate.targetUDID ?? "legacy") {
+               !scheduledRunOwnership.isOwned(identity: candidate.targetUDID ?? "legacy") {
                 dueSchedules.append(candidate)
             }
         }
@@ -191,26 +282,52 @@ final class BackupScheduler: ObservableObject {
         await withTaskGroup(of: Void.self) { group in
             for dueSchedule in dueSchedules {
                 group.addTask { @MainActor [weak self] in
-                    await self?.run(schedule: dueSchedule, advanceAfterDiscoveryFailure: true)
+                    self?.startScheduledRun(dueSchedule)
                 }
             }
         }
     }
 
     func runNow() async {
-        await run(schedule: schedule, advanceAfterDiscoveryFailure: false)
+        let scheduleIdentity = schedule.targetUDID ?? "legacy"
+        let runID = UUID()
+        guard scheduledRunOwnership.claim(identity: scheduleIdentity, runID: runID) else { return }
+        await run(
+            schedule: schedule,
+            advanceAfterDiscoveryFailure: false,
+            requiresActiveMonitoring: false,
+            runID: runID
+        )
     }
 
-    private func run(schedule runSchedule: Schedule, advanceAfterDiscoveryFailure: Bool) async {
+    private func run(
+        schedule runSchedule: Schedule,
+        advanceAfterDiscoveryFailure: Bool,
+        requiresActiveMonitoring: Bool,
+        runID: UUID
+    ) async {
         let scheduleIdentity = runSchedule.targetUDID ?? "legacy"
-        guard !runningScheduledUDIDs.contains(scheduleIdentity) else { return }
-        runningScheduledUDIDs.insert(scheduleIdentity)
+        defer { finishScheduledBackupRun(identity: scheduleIdentity, runID: runID) }
+        guard isScheduledRunStillValid(
+            runSchedule,
+            requiresActiveMonitoring: requiresActiveMonitoring,
+            runID: runID
+        ) else { return }
         isRunningScheduledBackup = true
 
         let discovery = await findTargetDevice(for: runSchedule)
+        guard isScheduledRunStillValid(
+            runSchedule,
+            requiresActiveMonitoring: requiresActiveMonitoring,
+            runID: runID
+        ) else { return }
         guard let target = discovery.target else {
             let failure = discovery.failure ?? "No device available for backup"
-            var updated = latestSchedule(matching: runSchedule.targetUDID) ?? runSchedule
+            guard var updated = currentScheduleForCompletion(
+                runSchedule,
+                requiresActiveMonitoring: requiresActiveMonitoring,
+                runID: runID
+            ) else { return }
             updated.lastResult = failure
             if advanceAfterDiscoveryFailure {
                 updated.lastRunDate = Date()
@@ -218,18 +335,62 @@ final class BackupScheduler: ObservableObject {
             }
             storeSchedule(updated, replacingTargetUDID: runSchedule.targetUDID)
             addLog(failure, success: false)
-            runningScheduledUDIDs.remove(scheduleIdentity)
-            isRunningScheduledBackup = !runningScheduledUDIDs.isEmpty
             return
         }
-        await runScheduledBackup(schedule: runSchedule, udid: target.udid, preferNetwork: target.preferNetwork)
-        runningScheduledUDIDs.remove(scheduleIdentity)
-        isRunningScheduledBackup = !runningScheduledUDIDs.isEmpty
+        await runScheduledBackup(
+            schedule: runSchedule,
+            udid: target.udid,
+            preferNetwork: target.preferNetwork,
+            requiresActiveMonitoring: requiresActiveMonitoring,
+            runID: runID
+        )
+    }
+
+    private func isScheduledRunStillValid(
+        _ runSchedule: Schedule,
+        requiresActiveMonitoring: Bool,
+        runID: UUID
+    ) -> Bool {
+        let scheduleIdentity = runSchedule.targetUDID ?? "legacy"
+        guard !Task.isCancelled,
+              scheduledRunOwnership.owns(identity: scheduleIdentity, runID: runID) else { return false }
+        return isScheduleCurrent(runSchedule, requiresActiveMonitoring: requiresActiveMonitoring)
+    }
+
+    private func currentScheduleForCompletion(
+        _ runSchedule: Schedule,
+        requiresActiveMonitoring: Bool,
+        runID: UUID
+    ) -> Schedule? {
+        guard isScheduledRunStillValid(
+            runSchedule,
+            requiresActiveMonitoring: requiresActiveMonitoring,
+            runID: runID
+        ), let persisted = latestSchedule(matching: runSchedule.targetUDID), persisted == runSchedule else {
+            return nil
+        }
+        return persisted
+    }
+
+    private func isScheduleCurrent(
+        _ runSchedule: Schedule,
+        requiresActiveMonitoring: Bool
+    ) -> Bool {
+        guard !requiresActiveMonitoring || isMonitoring,
+              let persisted = latestSchedule(matching: runSchedule.targetUDID),
+              persisted.enabled else { return false }
+        return persisted == runSchedule
     }
 
     // MARK: - Backup Execution
 
-    private func runScheduledBackup(schedule runSchedule: Schedule, udid: String, preferNetwork: Bool) async {
+    private func runScheduledBackup(
+        schedule runSchedule: Schedule,
+        udid: String,
+        preferNetwork: Bool,
+        requiresActiveMonitoring: Bool,
+        runID: UUID
+    ) async {
         scheduledBackupProgress = "Starting scheduled backup..."
         addLog("Scheduled backup started for \(runSchedule.targetName ?? "device \(udid.prefix(8))...")", success: true)
 
@@ -240,7 +401,11 @@ final class BackupScheduler: ObservableObject {
 
         guard let backupViewModel else {
             let failure = "The shared backup queue is unavailable"
-            var updated = latestSchedule(matching: runSchedule.targetUDID) ?? runSchedule
+            guard var updated = currentScheduleForCompletion(
+                runSchedule,
+                requiresActiveMonitoring: requiresActiveMonitoring,
+                runID: runID
+            ) else { return }
             updated.lastRunDate = Date()
             updated.lastResult = failure
             updated.nextRunDate = nextRunDate(for: updated)
@@ -254,7 +419,11 @@ final class BackupScheduler: ObservableObject {
         let success = activity?.state == .completed
         let resultMessage = activity?.errorMessage ?? activity?.progressText ?? "Failed"
 
-        var updated = latestSchedule(matching: runSchedule.targetUDID) ?? runSchedule
+        guard var updated = currentScheduleForCompletion(
+            runSchedule,
+            requiresActiveMonitoring: requiresActiveMonitoring,
+            runID: runID
+        ) else { return }
         updated.lastRunDate = Date()
         updated.lastResult = success ? "Completed" : resultMessage
         updated.nextRunDate = nextRunDate(for: updated)
@@ -424,6 +593,7 @@ final class BackupScheduler: ObservableObject {
         let latest = latestSchedule(matching: previous.targetUDID) ?? previous
         let merged = mergeEditedFields(previous: previous, edited: schedule, into: latest)
         storeSchedule(merged, replacingTargetUDID: previous.targetUDID)
+        cancelInvalidScheduledWork()
     }
 
     /// Apply only fields changed by this editor onto the latest persisted value.

--- a/Sources/Phosphor/Services/BackupScheduler.swift
+++ b/Sources/Phosphor/Services/BackupScheduler.swift
@@ -193,7 +193,6 @@ final class BackupScheduler: ObservableObject {
             guard let self else { return }
             await self.run(
                 schedule: dueSchedule,
-                advanceAfterDiscoveryFailure: true,
                 requiresActiveMonitoring: true,
                 runID: runID
             )
@@ -205,11 +204,10 @@ final class BackupScheduler: ObservableObject {
         scheduledCheckTask?.cancel()
         scheduledCheckTask = nil
         scheduledRunTasks.values.forEach { $0.cancel() }
-        scheduledRunTasks.removeAll()
-        scheduledRunSchedules.removeAll()
-        scheduledRunIDs.removeAll()
-        scheduledRunOwnership.removeAll()
-        isRunningScheduledBackup = false
+        // Keep task/run ownership until each cancelled queue request reaches a
+        // terminal state. Releasing it here can let a replacement schedule join
+        // the stale per-device request before its cancellation handler runs.
+        isRunningScheduledBackup = !scheduledRunOwnership.isEmpty
     }
 
     private func cancelInvalidScheduledWork() {
@@ -217,10 +215,7 @@ final class BackupScheduler: ObservableObject {
             isScheduleCurrent(scheduledRun, requiresActiveMonitoring: true) ? nil : scheduleIdentity
         }
         for scheduleIdentity in invalidScheduleIdentities {
-            guard let runID = scheduledRunIDs[scheduleIdentity] else { continue }
             scheduledRunTasks[scheduleIdentity]?.cancel()
-            finishScheduledRunTask(identity: scheduleIdentity, runID: runID)
-            finishScheduledBackupRun(identity: scheduleIdentity, runID: runID)
         }
         isRunningScheduledBackup = !scheduledRunOwnership.isEmpty
     }
@@ -294,7 +289,6 @@ final class BackupScheduler: ObservableObject {
         guard scheduledRunOwnership.claim(identity: scheduleIdentity, runID: runID) else { return }
         await run(
             schedule: schedule,
-            advanceAfterDiscoveryFailure: false,
             requiresActiveMonitoring: false,
             runID: runID
         )
@@ -302,7 +296,6 @@ final class BackupScheduler: ObservableObject {
 
     private func run(
         schedule runSchedule: Schedule,
-        advanceAfterDiscoveryFailure: Bool,
         requiresActiveMonitoring: Bool,
         runID: UUID
     ) async {
@@ -328,13 +321,12 @@ final class BackupScheduler: ObservableObject {
                 requiresActiveMonitoring: requiresActiveMonitoring,
                 runID: runID
             ) else { return }
-            updated.lastResult = failure
-            if advanceAfterDiscoveryFailure {
-                updated.lastRunDate = Date()
-                updated.nextRunDate = nextRunDate(for: updated)
-            }
+            // Keep a missed target due. The monitor will retry on its next tick
+            // instead of skipping a Wi-Fi device until the next daily interval
+            // after one transient discovery miss.
+            updated.lastResult = "Waiting to retry: \(failure)"
             storeSchedule(updated, replacingTargetUDID: runSchedule.targetUDID)
-            addLog(failure, success: false)
+            addLog("Waiting to retry: \(failure)", success: false)
             return
         }
         await runScheduledBackup(
@@ -447,35 +439,10 @@ final class BackupScheduler: ObservableObject {
             ? pyEntries.filter { $0.connectionType != "USB" }
             : pyEntries
 
-        // Check specific target first.
-        if let target = runSchedule.targetUDID {
-            if let entry = eligiblePyEntries.first(where: { $0.udid == target }) {
-                return (TargetDevice(udid: target, preferNetwork: entry.connectionType != "USB"), nil)
-            }
-
-            if runSchedule.wifiOnly {
-                let networkDevices = await PyMobileDevice.listNetworkDevices()
-                if networkDevices.contains(target) { return (TargetDevice(udid: target, preferNetwork: true), nil) }
-            }
-
-            // Fallback: libimobiledevice. Use the network-only query when the schedule
-            // explicitly requests Wi-Fi backups so USB devices do not accidentally match.
-            let fallbackArgs = runSchedule.wifiOnly ? ["-n"] : ["-l"]
-            let result = await Shell.runAsync("idevice_id", arguments: fallbackArgs)
-            if result.succeeded {
-                let devices = result.output.components(separatedBy: "\n").filter { !$0.isEmpty }
-                if devices.contains(target) { return (TargetDevice(udid: target, preferNetwork: runSchedule.wifiOnly), nil) }
-            }
-            let failure = runSchedule.wifiOnly
-                ? "The scheduled device is not available over Wi-Fi"
-                : "The scheduled device is not connected"
-            return (nil, failure)
-        }
-
-        // Legacy schedules may not have a target yet. Preserve the convenient
-        // single-device behavior, but collect every applicable backend first so
-        // a partial primary result cannot hide a second phone or tablet that is
-        // visible only through a fallback.
+        // Collect every applicable backend before resolving. This both keeps
+        // legacy nil-target schedules fail-closed and lets an exact any-transport
+        // target prefer a USB route found by a fallback over a network-only
+        // observation from another backend.
         var discoveredCandidates = eligiblePyEntries.map {
             ScheduledBackupTargetResolver.Candidate(
                 udid: $0.udid,
@@ -490,15 +457,7 @@ final class BackupScheduler: ObservableObject {
             })
         }
 
-        // Fallback: libimobiledevice.
-        let fallbackArgs = runSchedule.wifiOnly ? ["-n"] : ["-l"]
-        let result = await Shell.runAsync("idevice_id", arguments: fallbackArgs)
-        if result.succeeded {
-            let devices = result.output.components(separatedBy: "\n").filter { !$0.isEmpty }
-            discoveredCandidates.append(contentsOf: devices.map {
-                ScheduledBackupTargetResolver.Candidate(udid: $0, preferNetwork: runSchedule.wifiOnly)
-            })
-        }
+        discoveredCandidates.append(contentsOf: await libimobiledeviceCandidates(wifiOnly: runSchedule.wifiOnly))
 
         switch resolveTarget(from: discoveredCandidates, targetUDID: runSchedule.targetUDID) {
         case .target(let target):
@@ -516,6 +475,35 @@ final class BackupScheduler: ObservableObject {
             ? "The scheduled device is not available over Wi-Fi"
             : "The scheduled device is not connected"
         return (nil, failure)
+    }
+
+    private func libimobiledeviceCandidates(
+        wifiOnly: Bool
+    ) async -> [ScheduledBackupTargetResolver.Candidate] {
+        if wifiOnly {
+            let network = await Shell.runAsync("idevice_id", arguments: ["-n"], timeout: 5)
+            guard network.succeeded else { return [] }
+            return network.output.components(separatedBy: "\n")
+                .filter { !$0.isEmpty }
+                .map { ScheduledBackupTargetResolver.Candidate(udid: $0, preferNetwork: true) }
+        }
+
+        async let usbResult = Shell.runAsync("idevice_id", arguments: ["-l"], timeout: 5)
+        async let networkResult = Shell.runAsync("idevice_id", arguments: ["-n"], timeout: 5)
+        let usb = await usbResult
+        let network = await networkResult
+        var candidates: [ScheduledBackupTargetResolver.Candidate] = []
+        if usb.succeeded {
+            candidates += usb.output.components(separatedBy: "\n")
+                .filter { !$0.isEmpty }
+                .map { ScheduledBackupTargetResolver.Candidate(udid: $0, preferNetwork: false) }
+        }
+        if network.succeeded {
+            candidates += network.output.components(separatedBy: "\n")
+                .filter { !$0.isEmpty }
+                .map { ScheduledBackupTargetResolver.Candidate(udid: $0, preferNetwork: true) }
+        }
+        return candidates
     }
 
     private func resolveTarget(

--- a/Sources/Phosphor/Services/DeviceCloneService.swift
+++ b/Sources/Phosphor/Services/DeviceCloneService.swift
@@ -20,6 +20,13 @@ final class DeviceCloneService: ObservableObject {
     @Published var isRunning = false
     @Published var lastError: String?
 
+    private struct BackupFingerprint: Equatable {
+        let lastBackupDate: Date?
+        let directoryModifiedAt: Date?
+        let statusModifiedAt: Date?
+        let manifestModifiedAt: Date?
+    }
+
     private let backupManager = BackupManager()
 
     /// Get all currently connected devices.
@@ -72,6 +79,13 @@ final class DeviceCloneService: ObservableObject {
         overallProgress = 0.05
         progress = "Starting backup of source device..."
 
+        backupManager.discoverBackups()
+        let previousFingerprints = Dictionary(uniqueKeysWithValues:
+            backupManager.backups
+                .filter { $0.udid == sourceUDID }
+                .map { ($0.path, backupFingerprint(for: $0)) }
+        )
+
         await backupViewModel.createBackup(udid: sourceUDID, encrypted: encrypted)
         let sourceActivity = backupViewModel.activity(for: sourceUDID)
         let backupSuccess = sourceActivity?.state == .completed
@@ -88,7 +102,13 @@ final class DeviceCloneService: ObservableObject {
 
         // Find backup
         backupManager.discoverBackups()
-        guard let latestBackup = backupManager.backups.first(where: { $0.udid == sourceUDID }) else {
+        let sourceBackups = backupManager.backups.filter { $0.udid == sourceUDID }
+        let freshSourceBackups = sourceBackups.filter {
+            previousFingerprints[$0.path] != backupFingerprint(for: $0)
+        }
+        guard let latestBackup = freshSourceBackups.max(by: {
+            backupFreshnessDate(for: $0) < backupFreshnessDate(for: $1)
+        }) else {
             lastError = "Could not find the backup that was just created"
             phase = .failed
             isRunning = false
@@ -120,6 +140,31 @@ final class DeviceCloneService: ObservableObject {
 
         isRunning = false
         return restoreSuccess
+    }
+
+    private func backupFingerprint(for backup: BackupInfo) -> BackupFingerprint {
+        let path = backup.path as NSString
+        return BackupFingerprint(
+            lastBackupDate: backup.lastBackupDate,
+            directoryModifiedAt: modificationDate(at: backup.path),
+            statusModifiedAt: modificationDate(at: path.appendingPathComponent("Status.plist")),
+            manifestModifiedAt: modificationDate(at: path.appendingPathComponent("Manifest.db"))
+        )
+    }
+
+    private func backupFreshnessDate(for backup: BackupInfo) -> Date {
+        let fingerprint = backupFingerprint(for: backup)
+        return [
+            fingerprint.lastBackupDate,
+            fingerprint.directoryModifiedAt,
+            fingerprint.statusModifiedAt,
+            fingerprint.manifestModifiedAt
+        ].compactMap { $0 }.max() ?? .distantPast
+    }
+
+    private func modificationDate(at path: String) -> Date? {
+        let attributes = try? FileManager.default.attributesOfItem(atPath: path)
+        return attributes?[.modificationDate] as? Date
     }
 
     func reset() {

--- a/Sources/Phosphor/Services/DeviceCloneService.swift
+++ b/Sources/Phosphor/Services/DeviceCloneService.swift
@@ -55,6 +55,7 @@ final class DeviceCloneService: ObservableObject {
     func clone(
         sourceUDID: String,
         destinationUDID: String,
+        backupViewModel: BackupViewModel,
         encrypted: Bool = false
     ) async -> Bool {
         guard sourceUDID != destinationUDID else {
@@ -71,15 +72,12 @@ final class DeviceCloneService: ObservableObject {
         overallProgress = 0.05
         progress = "Starting backup of source device..."
 
-        let backupSuccess = await backupManager.createBackup(udid: sourceUDID, encrypted: encrypted) { [weak self] text in
-            self?.progress = text
-            if let pct = PyMobileDevice.parseProgress(from: text) {
-                self?.overallProgress = pct / 2.0
-            }
-        }
+        await backupViewModel.createBackup(udid: sourceUDID, encrypted: encrypted)
+        let sourceActivity = backupViewModel.activity(for: sourceUDID)
+        let backupSuccess = sourceActivity?.state == .completed
 
         guard backupSuccess else {
-            lastError = backupManager.lastError ?? "Backup of source device failed"
+            lastError = sourceActivity?.errorMessage ?? "Backup of source device failed"
             phase = .failed
             isRunning = false
             return false

--- a/Sources/Phosphor/Services/ScheduledRunOwnership.swift
+++ b/Sources/Phosphor/Services/ScheduledRunOwnership.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+/// Per-schedule run ownership for asynchronous scheduler work.
+/// A completion may clear state only when it still owns the identity it started.
+struct ScheduledRunOwnership {
+    private var runIDByIdentity: [String: UUID] = [:]
+
+    var isEmpty: Bool { runIDByIdentity.isEmpty }
+
+    func isOwned(identity: String) -> Bool {
+        runIDByIdentity[identity] != nil
+    }
+
+    func owns(identity: String, runID: UUID) -> Bool {
+        runIDByIdentity[identity] == runID
+    }
+
+    mutating func claim(identity: String, runID: UUID) -> Bool {
+        guard runIDByIdentity[identity] == nil else { return false }
+        runIDByIdentity[identity] = runID
+        return true
+    }
+
+    @discardableResult
+    mutating func finish(identity: String, runID: UUID) -> Bool {
+        guard runIDByIdentity[identity] == runID else { return false }
+        runIDByIdentity.removeValue(forKey: identity)
+        return true
+    }
+
+    mutating func removeAll() {
+        runIDByIdentity.removeAll()
+    }
+}

--- a/Sources/Phosphor/Utilities/BackupJobQueue.swift
+++ b/Sources/Phosphor/Utilities/BackupJobQueue.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+/// Pure scheduling primitive for bounded, per-device backup concurrency.
+struct BackupJobQueue {
+    enum EnqueueResult: Equatable {
+        case started
+        case queued(position: Int)
+        case duplicate
+    }
+
+    enum CancelResult: Equatable {
+        case removedQueued
+        case cancelRunning
+        case notFound
+    }
+
+    let maxConcurrent: Int
+    private(set) var runningUDIDs: Set<String> = []
+    private(set) var queuedUDIDs: [String] = []
+
+    init(maxConcurrent: Int) {
+        self.maxConcurrent = max(1, maxConcurrent)
+    }
+
+    mutating func enqueue(udid: String) -> EnqueueResult {
+        guard !runningUDIDs.contains(udid), !queuedUDIDs.contains(udid) else {
+            return .duplicate
+        }
+        if runningUDIDs.count < maxConcurrent {
+            runningUDIDs.insert(udid)
+            return .started
+        }
+        queuedUDIDs.append(udid)
+        return .queued(position: queuedUDIDs.count)
+    }
+
+    /// Finishes one running job and atomically promotes the next queued device.
+    @discardableResult
+    mutating func finish(udid: String) -> String? {
+        guard runningUDIDs.remove(udid) != nil else { return nil }
+        guard !queuedUDIDs.isEmpty else { return nil }
+        let next = queuedUDIDs.removeFirst()
+        runningUDIDs.insert(next)
+        return next
+    }
+
+    mutating func cancel(udid: String) -> CancelResult {
+        if let index = queuedUDIDs.firstIndex(of: udid) {
+            queuedUDIDs.remove(at: index)
+            return .removedQueued
+        }
+        if runningUDIDs.contains(udid) {
+            return .cancelRunning
+        }
+        return .notFound
+    }
+}

--- a/Sources/Phosphor/Utilities/BackupRequestTracker.swift
+++ b/Sources/Phosphor/Utilities/BackupRequestTracker.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+/// Tracks which async callers still authorize a deduplicated per-device backup.
+///
+/// The queue owns one request per UDID. Additional callers wait on that same job.
+/// Cancelling the owner may cancel the job only when no waiter still authorizes it;
+/// cancelling a waiter never cancels another caller's request.
+struct BackupRequestTracker {
+    enum CancellationAction: Equatable {
+        case cancelJob
+        case detachRequest
+        case notFound
+    }
+
+    private var ownerByUDID: [String: UUID] = [:]
+    private var waiterIDsByUDID: [String: Set<UUID>] = [:]
+    private var abandonedOwnerIDs: Set<UUID> = []
+
+    mutating func registerOwner(_ requestID: UUID, udid: String) {
+        ownerByUDID[udid] = requestID
+        abandonedOwnerIDs.remove(requestID)
+    }
+
+    mutating func registerWaiter(_ requestID: UUID, udid: String) {
+        waiterIDsByUDID[udid, default: []].insert(requestID)
+    }
+
+    mutating func cancel(_ requestID: UUID, udid: String) -> CancellationAction {
+        if ownerByUDID[udid] == requestID {
+            let hasWaiters = !(waiterIDsByUDID[udid]?.isEmpty ?? true)
+            if hasWaiters {
+                abandonedOwnerIDs.insert(requestID)
+                return .detachRequest
+            }
+            return .cancelJob
+        }
+
+        guard waiterIDsByUDID[udid]?.remove(requestID) != nil else {
+            return .notFound
+        }
+        if waiterIDsByUDID[udid]?.isEmpty == true {
+            waiterIDsByUDID.removeValue(forKey: udid)
+        }
+
+        if let ownerID = ownerByUDID[udid],
+           abandonedOwnerIDs.contains(ownerID),
+           waiterIDsByUDID[udid] == nil {
+            return .cancelJob
+        }
+        return .detachRequest
+    }
+
+    mutating func finish(udid: String) {
+        if let ownerID = ownerByUDID.removeValue(forKey: udid) {
+            abandonedOwnerIDs.remove(ownerID)
+        }
+        waiterIDsByUDID.removeValue(forKey: udid)
+    }
+}

--- a/Sources/Phosphor/Utilities/ScheduledBackupTargetResolver.swift
+++ b/Sources/Phosphor/Utilities/ScheduledBackupTargetResolver.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+/// Resolves a scheduled-backup target without depending on discovery ordering.
+/// A legacy schedule without a saved target may continue when exactly one device
+/// is eligible, but it must fail closed when multiple devices are available.
+enum ScheduledBackupTargetResolver {
+    struct Candidate: Equatable {
+        let udid: String
+        let preferNetwork: Bool
+    }
+
+    enum Resolution: Equatable {
+        case target(Candidate)
+        case noneAvailable
+        case selectionRequired
+    }
+
+    static func resolve(
+        candidates: [Candidate],
+        targetUDID: String?
+    ) -> Resolution {
+        let uniqueCandidates = deduplicated(candidates)
+
+        if let targetUDID {
+            guard let target = uniqueCandidates.first(where: { $0.udid == targetUDID }) else {
+                return .noneAvailable
+            }
+            return .target(target)
+        }
+
+        switch uniqueCandidates.count {
+        case 0:
+            return .noneAvailable
+        case 1:
+            return .target(uniqueCandidates[0])
+        default:
+            return .selectionRequired
+        }
+    }
+
+    private static func deduplicated(_ candidates: [Candidate]) -> [Candidate] {
+        var orderedUDIDs: [String] = []
+        var candidatesByUDID: [String: Candidate] = [:]
+
+        for candidate in candidates {
+            if candidatesByUDID[candidate.udid] == nil {
+                orderedUDIDs.append(candidate.udid)
+            }
+            if candidatesByUDID[candidate.udid]?.preferNetwork != false || !candidate.preferNetwork {
+                candidatesByUDID[candidate.udid] = candidate
+            }
+        }
+
+        return orderedUDIDs.compactMap { candidatesByUDID[$0] }
+    }
+}

--- a/Sources/Phosphor/ViewModels/BackupViewModel.swift
+++ b/Sources/Phosphor/ViewModels/BackupViewModel.swift
@@ -213,7 +213,21 @@ final class BackupViewModel: ObservableObject {
                     errorMessage: nil
                 )
                 refreshLegacyProgressState()
-                await runBackupJob(udid: udid)
+                await withCheckedContinuation { continuation in
+                    // Every caller owns a detachable completion path, including
+                    // the request that starts the shared job. Keep the physical
+                    // backup in its own task so cancelling this request can return
+                    // immediately when another coalesced caller still authorizes it.
+                    backupCompletionContinuations[udid] = continuation
+                    let task = Task { [weak self] in
+                        guard let self else { return }
+                        await self.runBackupJob(udid: udid)
+                    }
+                    backupJobTasks[udid] = task
+                    if Task.isCancelled {
+                        cancelBackupRequest(udid: udid, requestID: request.id)
+                    }
+                }
             }
         } onCancel: {
             Task { @MainActor [weak self] in

--- a/Sources/Phosphor/ViewModels/BackupViewModel.swift
+++ b/Sources/Phosphor/ViewModels/BackupViewModel.swift
@@ -5,6 +5,47 @@ import SwiftUI
 @MainActor
 final class BackupViewModel: ObservableObject {
 
+    struct BackupActivity: Identifiable {
+        enum State: Equatable {
+            case queued(position: Int)
+            case running
+            case completed
+            case failed
+            case cancelled
+        }
+
+        var id: String { udid }
+        let udid: String
+        var state: State
+        var progressText: String
+        var progressFraction: Double?
+        var errorMessage: String?
+
+        var isActive: Bool {
+            switch state {
+            case .queued, .running: true
+            case .completed, .failed, .cancelled: false
+            }
+        }
+
+        var displayProgressText: String {
+            switch state {
+            case .queued(let position): return "Queued · #\(position)"
+            case .running:
+                guard let progressFraction else { return "Backing up" }
+                return "Backing up \(Int(progressFraction * 100))%"
+            case .completed: return "Completed"
+            case .failed: return "Failed"
+            case .cancelled: return "Cancelled"
+            }
+        }
+
+        var displayProgressFraction: Double {
+            guard let progressFraction else { return 0.05 }
+            return min(max(progressFraction, 0.05), 1)
+        }
+    }
+
     @Published var backups: [BackupInfo] = []
     @Published var selectedBackup: BackupInfo?
     @Published var isCreating = false
@@ -14,6 +55,7 @@ final class BackupViewModel: ObservableObject {
     @Published var alertMessage = ""
     @Published var backupIssue: BackupManager.BackupFailure?
     @Published var loadError: String?
+    @Published private(set) var backupActivities: [String: BackupActivity] = [:]
 
     // Browser state
     @Published var browserDomains: [String] = []
@@ -32,12 +74,18 @@ final class BackupViewModel: ObservableObject {
     private var currentManifest: BackupManifest?
     private var sizeResolutionTask: Task<Void, Never>?
     private var lastBackupRequest: BackupRequest?
-    private var backupOperationID: UUID?
+    private var jobQueue = BackupJobQueue(maxConcurrent: 2)
+    private var pendingBackupRequests: [String: BackupRequest] = [:]
+    private var backupManagers: [String: BackupManager] = [:]
+    private var backupJobTasks: [String: Task<Void, Never>] = [:]
+    private var backupCompletionContinuations: [String: CheckedContinuation<Void, Never>] = [:]
+    private var backupJobWaiters: [String: [CheckedContinuation<Void, Never>]] = [:]
 
     private struct BackupRequest {
         let udid: String
         let incremental: Bool
         let preferNetwork: Bool
+        let encrypted: Bool
     }
 
     func loadBackups() {
@@ -105,43 +153,184 @@ final class BackupViewModel: ObservableObject {
         }
     }
 
-    func createBackup(udid: String, incremental: Bool = false, preferNetwork: Bool = false) async {
-        let operationID = UUID()
-        backupOperationID = operationID
-        lastBackupRequest = BackupRequest(udid: udid, incremental: incremental, preferNetwork: preferNetwork)
-        isCreating = true
-        progressText = "Preparing..."
-        progressFraction = nil
+    func createBackup(udid: String, incremental: Bool = false, preferNetwork: Bool = false, encrypted: Bool = false) async {
+        let request = BackupRequest(udid: udid, incremental: incremental, preferNetwork: preferNetwork, encrypted: encrypted)
+        lastBackupRequest = request
+
+        switch jobQueue.enqueue(udid: udid) {
+        case .duplicate:
+            await withCheckedContinuation { continuation in
+                backupJobWaiters[udid, default: []].append(continuation)
+            }
+        case .queued(let position):
+            pendingBackupRequests[udid] = request
+            backupActivities[udid] = BackupActivity(
+                udid: udid,
+                state: .queued(position: position),
+                progressText: "Queued",
+                progressFraction: nil,
+                errorMessage: nil
+            )
+            refreshLegacyProgressState()
+            await withCheckedContinuation { continuation in
+                backupCompletionContinuations[udid] = continuation
+            }
+        case .started:
+            pendingBackupRequests[udid] = request
+            backupActivities[udid] = BackupActivity(
+                udid: udid,
+                state: .running,
+                progressText: "Preparing...",
+                progressFraction: nil,
+                errorMessage: nil
+            )
+            refreshLegacyProgressState()
+            await runBackupJob(udid: udid)
+        }
+    }
+
+    func activity(for udid: String) -> BackupActivity? {
+        backupActivities[udid]
+    }
+
+    func isBackupActive(for udid: String) -> Bool {
+        backupActivities[udid]?.isActive == true
+    }
+
+    func cancelBackup(udid: String) {
+        switch jobQueue.cancel(udid: udid) {
+        case .removedQueued:
+            pendingBackupRequests.removeValue(forKey: udid)
+            backupCompletionContinuations.removeValue(forKey: udid)?.resume()
+            resumeBackupWaiters(for: udid)
+            updateActivity(udid: udid) {
+                $0.state = .cancelled
+                $0.progressText = "Cancelled"
+            }
+            renumberQueuedActivities()
+            refreshLegacyProgressState()
+        case .cancelRunning:
+            if let manager = backupManagers[udid] {
+                manager.cancelBackup()
+            } else {
+                // A queued job is marked running when it is promoted, just before
+                // its task creates a BackupManager. Preserve cancellation through
+                // that handoff instead of letting the promoted job start anyway.
+                backupJobTasks[udid]?.cancel()
+            }
+            updateActivity(udid: udid) { $0.progressText = "Cancelling..." }
+        case .notFound:
+            break
+        }
+    }
+
+    private func runBackupJob(udid: String) async {
+        guard !Task.isCancelled else {
+            updateActivity(udid: udid) {
+                $0.state = .cancelled
+                $0.progressText = "Cancelled"
+            }
+            finishBackupJob(udid: udid)
+            return
+        }
+        guard let request = pendingBackupRequests[udid] else {
+            finishBackupJob(udid: udid)
+            return
+        }
+
+        let manager = BackupManager()
+        backupManagers[udid] = manager
+        updateActivity(udid: udid) {
+            $0.state = .running
+            $0.progressText = "Preparing..."
+        }
+        refreshLegacyProgressState()
 
         let success: Bool
-        if incremental {
-            success = await backupManager.createIncrementalBackup(udid: udid, preferNetwork: preferNetwork) { [weak self, operationID] text in
-                guard self?.backupOperationID == operationID else { return }
-                self?.updateBackupProgress(text)
+        if request.incremental {
+            success = await manager.createIncrementalBackup(udid: udid, preferNetwork: request.preferNetwork) { [weak self, weak manager] text in
+                guard let manager else { return }
+                self?.updateBackupProgress(udid: udid, text: text, manager: manager)
             }
         } else {
-            success = await backupManager.createBackup(udid: udid, preferNetwork: preferNetwork) { [weak self, operationID] text in
-                guard self?.backupOperationID == operationID else { return }
-                self?.updateBackupProgress(text)
+            success = await manager.createBackup(udid: udid, encrypted: request.encrypted, preferNetwork: request.preferNetwork) { [weak self, weak manager] text in
+                guard let manager else { return }
+                self?.updateBackupProgress(udid: udid, text: text, manager: manager)
             }
         }
 
-        guard backupOperationID == operationID else { return }
-        backupOperationID = nil
-        isCreating = false
         if success {
-            alertMessage = "Backup completed"
-            showAlert = true
+            updateActivity(udid: udid) {
+                $0.state = .completed
+                $0.progressText = "Completed"
+                $0.progressFraction = 1
+            }
             loadBackups()
-        } else if backupManager.lastOperationWasCancelled {
-            // User-initiated cancellation is not a backup failure.
-            progressText = "Cancelled"
-        } else if let failure = backupManager.lastBackupFailure {
-            backupIssue = failure
+        } else if manager.lastOperationWasCancelled {
+            updateActivity(udid: udid) {
+                $0.state = .cancelled
+                $0.progressText = "Cancelled"
+            }
         } else {
-            alertMessage = backupManager.lastError ?? "Backup failed"
-            showAlert = true
+            let error = manager.lastBackupFailure?.message ?? manager.lastError ?? "Backup failed"
+            updateActivity(udid: udid) {
+                $0.state = .failed
+                $0.progressText = "Failed"
+                $0.errorMessage = error
+            }
+            if let failure = manager.lastBackupFailure {
+                backupIssue = failure
+            }
         }
+
+        finishBackupJob(udid: udid)
+    }
+
+    private func finishBackupJob(udid: String) {
+        pendingBackupRequests.removeValue(forKey: udid)
+        backupManagers.removeValue(forKey: udid)
+        backupJobTasks.removeValue(forKey: udid)
+        backupCompletionContinuations.removeValue(forKey: udid)?.resume()
+        resumeBackupWaiters(for: udid)
+        let nextUDID = jobQueue.finish(udid: udid)
+        renumberQueuedActivities()
+        refreshLegacyProgressState()
+
+        if let nextUDID {
+            let task = Task { [weak self] in
+                guard let self else { return }
+                await self.runBackupJob(udid: nextUDID)
+            }
+            backupJobTasks[nextUDID] = task
+        }
+    }
+
+    private func updateActivity(udid: String, update: (inout BackupActivity) -> Void) {
+        guard var activity = backupActivities[udid] else { return }
+        update(&activity)
+        backupActivities[udid] = activity
+    }
+
+    private func resumeBackupWaiters(for udid: String) {
+        let waiters = backupJobWaiters.removeValue(forKey: udid) ?? []
+        waiters.forEach { $0.resume() }
+    }
+
+    private func renumberQueuedActivities() {
+        for (offset, udid) in jobQueue.queuedUDIDs.enumerated() {
+            updateActivity(udid: udid) {
+                $0.state = .queued(position: offset + 1)
+                $0.progressText = "Queued · #\(offset + 1)"
+            }
+        }
+    }
+
+    private func refreshLegacyProgressState() {
+        let active = backupActivities.values.filter(\.isActive)
+        isCreating = !active.isEmpty
+        let representative = active.first(where: { $0.state == .running }) ?? active.first
+        progressText = representative?.progressText ?? ""
+        progressFraction = representative?.progressFraction
     }
 
     private func recoveryUdid(for issue: BackupManager.BackupFailure) -> String? {
@@ -158,13 +347,16 @@ final class BackupViewModel: ObservableObject {
         return min(max(progressFraction, 0.05), 1.0)
     }
 
-    private func updateBackupProgress(_ text: String) {
-        progressText = text
-        if let pct = PyMobileDevice.parseProgress(from: text) {
-            progressFraction = pct
-        } else {
-            progressFraction = backupManager.backupPercent > 0 ? backupManager.backupPercent : progressFraction
+    private func updateBackupProgress(udid: String, text: String, manager: BackupManager) {
+        updateActivity(udid: udid) { activity in
+            activity.progressText = text
+            if let pct = PyMobileDevice.parseProgress(from: text) {
+                activity.progressFraction = pct
+            } else if manager.backupPercent > 0 {
+                activity.progressFraction = manager.backupPercent
+            }
         }
+        refreshLegacyProgressState()
     }
 
     private func recoveryPrefersNetwork(for udid: String) -> Bool {

--- a/Sources/Phosphor/ViewModels/BackupViewModel.swift
+++ b/Sources/Phosphor/ViewModels/BackupViewModel.swift
@@ -73,19 +73,27 @@ final class BackupViewModel: ObservableObject {
     let backupManager = BackupManager()
     private var currentManifest: BackupManifest?
     private var sizeResolutionTask: Task<Void, Never>?
-    private var lastBackupRequest: BackupRequest?
+    private var latestBackupRequests: [String: BackupRequest] = [:]
+    private var failedBackupRequests: [UUID: BackupRequest] = [:]
     private var jobQueue = BackupJobQueue(maxConcurrent: 2)
+    private var requestTracker = BackupRequestTracker()
     private var pendingBackupRequests: [String: BackupRequest] = [:]
     private var backupManagers: [String: BackupManager] = [:]
     private var backupJobTasks: [String: Task<Void, Never>] = [:]
     private var backupCompletionContinuations: [String: CheckedContinuation<Void, Never>] = [:]
-    private var backupJobWaiters: [String: [CheckedContinuation<Void, Never>]] = [:]
+    private var backupJobWaiters: [String: [BackupJobWaiter]] = [:]
 
     private struct BackupRequest {
+        let id: UUID
         let udid: String
         let incremental: Bool
         let preferNetwork: Bool
         let encrypted: Bool
+    }
+
+    private struct BackupJobWaiter {
+        let requestID: UUID
+        let continuation: CheckedContinuation<Void, Never>
     }
 
     func loadBackups() {
@@ -154,38 +162,63 @@ final class BackupViewModel: ObservableObject {
     }
 
     func createBackup(udid: String, incremental: Bool = false, preferNetwork: Bool = false, encrypted: Bool = false) async {
-        let request = BackupRequest(udid: udid, incremental: incremental, preferNetwork: preferNetwork, encrypted: encrypted)
-        lastBackupRequest = request
+        let request = BackupRequest(
+            id: UUID(),
+            udid: udid,
+            incremental: incremental,
+            preferNetwork: preferNetwork,
+            encrypted: encrypted
+        )
+        latestBackupRequests[udid] = request
 
-        switch jobQueue.enqueue(udid: udid) {
-        case .duplicate:
-            await withCheckedContinuation { continuation in
-                backupJobWaiters[udid, default: []].append(continuation)
+        await withTaskCancellationHandler {
+            guard !Task.isCancelled else { return }
+
+            switch jobQueue.enqueue(udid: udid) {
+            case .duplicate:
+                requestTracker.registerWaiter(request.id, udid: udid)
+                await withCheckedContinuation { continuation in
+                    backupJobWaiters[udid, default: []].append(
+                        BackupJobWaiter(requestID: request.id, continuation: continuation)
+                    )
+                    if Task.isCancelled {
+                        cancelBackupRequest(udid: udid, requestID: request.id)
+                    }
+                }
+            case .queued(let position):
+                requestTracker.registerOwner(request.id, udid: udid)
+                pendingBackupRequests[udid] = request
+                backupActivities[udid] = BackupActivity(
+                    udid: udid,
+                    state: .queued(position: position),
+                    progressText: "Queued",
+                    progressFraction: nil,
+                    errorMessage: nil
+                )
+                refreshLegacyProgressState()
+                await withCheckedContinuation { continuation in
+                    backupCompletionContinuations[udid] = continuation
+                    if Task.isCancelled {
+                        cancelBackupRequest(udid: udid, requestID: request.id)
+                    }
+                }
+            case .started:
+                requestTracker.registerOwner(request.id, udid: udid)
+                pendingBackupRequests[udid] = request
+                backupActivities[udid] = BackupActivity(
+                    udid: udid,
+                    state: .running,
+                    progressText: "Preparing...",
+                    progressFraction: nil,
+                    errorMessage: nil
+                )
+                refreshLegacyProgressState()
+                await runBackupJob(udid: udid)
             }
-        case .queued(let position):
-            pendingBackupRequests[udid] = request
-            backupActivities[udid] = BackupActivity(
-                udid: udid,
-                state: .queued(position: position),
-                progressText: "Queued",
-                progressFraction: nil,
-                errorMessage: nil
-            )
-            refreshLegacyProgressState()
-            await withCheckedContinuation { continuation in
-                backupCompletionContinuations[udid] = continuation
+        } onCancel: {
+            Task { @MainActor [weak self] in
+                self?.cancelBackupRequest(udid: udid, requestID: request.id)
             }
-        case .started:
-            pendingBackupRequests[udid] = request
-            backupActivities[udid] = BackupActivity(
-                udid: udid,
-                state: .running,
-                progressText: "Preparing...",
-                progressFraction: nil,
-                errorMessage: nil
-            )
-            refreshLegacyProgressState()
-            await runBackupJob(udid: udid)
         }
     }
 
@@ -201,6 +234,7 @@ final class BackupViewModel: ObservableObject {
         switch jobQueue.cancel(udid: udid) {
         case .removedQueued:
             pendingBackupRequests.removeValue(forKey: udid)
+            requestTracker.finish(udid: udid)
             backupCompletionContinuations.removeValue(forKey: udid)?.resume()
             resumeBackupWaiters(for: udid)
             updateActivity(udid: udid) {
@@ -219,6 +253,25 @@ final class BackupViewModel: ObservableObject {
                 backupJobTasks[udid]?.cancel()
             }
             updateActivity(udid: udid) { $0.progressText = "Cancelling..." }
+        case .notFound:
+            break
+        }
+    }
+
+    private func cancelBackupRequest(udid: String, requestID: UUID) {
+        switch requestTracker.cancel(requestID, udid: udid) {
+        case .cancelJob:
+            cancelBackup(udid: udid)
+        case .detachRequest:
+            if pendingBackupRequests[udid]?.id == requestID {
+                backupCompletionContinuations.removeValue(forKey: udid)?.resume()
+            } else if let index = backupJobWaiters[udid]?.firstIndex(where: { $0.requestID == requestID }) {
+                let waiter = backupJobWaiters[udid]?.remove(at: index)
+                if backupJobWaiters[udid]?.isEmpty == true {
+                    backupJobWaiters.removeValue(forKey: udid)
+                }
+                waiter?.continuation.resume()
+            }
         case .notFound:
             break
         }
@@ -279,6 +332,7 @@ final class BackupViewModel: ObservableObject {
                 $0.errorMessage = error
             }
             if let failure = manager.lastBackupFailure {
+                failedBackupRequests[failure.id] = request
                 backupIssue = failure
             }
         }
@@ -287,6 +341,7 @@ final class BackupViewModel: ObservableObject {
     }
 
     private func finishBackupJob(udid: String) {
+        requestTracker.finish(udid: udid)
         pendingBackupRequests.removeValue(forKey: udid)
         backupManagers.removeValue(forKey: udid)
         backupJobTasks.removeValue(forKey: udid)
@@ -313,7 +368,7 @@ final class BackupViewModel: ObservableObject {
 
     private func resumeBackupWaiters(for udid: String) {
         let waiters = backupJobWaiters.removeValue(forKey: udid) ?? []
-        waiters.forEach { $0.resume() }
+        waiters.forEach { $0.continuation.resume() }
     }
 
     private func renumberQueuedActivities() {
@@ -334,7 +389,13 @@ final class BackupViewModel: ObservableObject {
     }
 
     private func recoveryUdid(for issue: BackupManager.BackupFailure) -> String? {
-        issue.udid ?? lastBackupRequest?.udid
+        issue.udid ?? recoveryRequest(for: issue)?.udid
+    }
+
+    private func recoveryRequest(for issue: BackupManager.BackupFailure) -> BackupRequest? {
+        if let request = failedBackupRequests[issue.id] { return request }
+        if let udid = issue.udid { return latestBackupRequests[udid] }
+        return latestBackupRequests.count == 1 ? latestBackupRequests.values.first : nil
     }
 
     var displayProgressText: String {
@@ -359,10 +420,6 @@ final class BackupViewModel: ObservableObject {
         refreshLegacyProgressState()
     }
 
-    private func recoveryPrefersNetwork(for udid: String) -> Bool {
-        lastBackupRequest?.udid == udid ? (lastBackupRequest?.preferNetwork ?? false) : false
-    }
-
     func runFullBackup(for issue: BackupManager.BackupFailure) async {
         guard let udid = recoveryUdid(for: issue) else {
             backupIssue = BackupManager.BackupFailure(
@@ -373,8 +430,14 @@ final class BackupViewModel: ObservableObject {
             )
             return
         }
+        let request = recoveryRequest(for: issue)
         backupIssue = nil
-        await createBackup(udid: udid, incremental: false, preferNetwork: recoveryPrefersNetwork(for: udid))
+        await createBackup(
+            udid: udid,
+            incremental: false,
+            preferNetwork: request?.preferNetwork ?? false,
+            encrypted: request?.encrypted ?? false
+        )
     }
 
     func deleteIncompleteBackupAndRunFull(for issue: BackupManager.BackupFailure) async {
@@ -388,10 +451,16 @@ final class BackupViewModel: ObservableObject {
             return
         }
         do {
+            let request = recoveryRequest(for: issue)
             try BackupManager.deleteIncompleteBackup(for: udid, expectedPath: path)
             backupIssue = nil
             loadBackups()
-            await createBackup(udid: udid, incremental: false, preferNetwork: recoveryPrefersNetwork(for: udid))
+            await createBackup(
+                udid: udid,
+                incremental: false,
+                preferNetwork: request?.preferNetwork ?? false,
+                encrypted: request?.encrypted ?? false
+            )
         } catch {
             backupIssue = BackupManager.BackupFailure(
                 title: "Could Not Move Incomplete Backup",
@@ -404,10 +473,15 @@ final class BackupViewModel: ObservableObject {
         }
     }
 
-    func retryLastBackup() async {
-        guard let request = lastBackupRequest else { return }
+    func retryBackup(for issue: BackupManager.BackupFailure) async {
+        guard let request = recoveryRequest(for: issue) else { return }
         backupIssue = nil
-        await createBackup(udid: request.udid, incremental: request.incremental, preferNetwork: request.preferNetwork)
+        await createBackup(
+            udid: request.udid,
+            incremental: request.incremental,
+            preferNetwork: request.preferNetwork,
+            encrypted: request.encrypted
+        )
     }
 
     // MARK: - Browsing

--- a/Sources/Phosphor/Views/Apps/AppManagerView.swift
+++ b/Sources/Phosphor/Views/Apps/AppManagerView.swift
@@ -103,7 +103,7 @@ struct AppManagerView: View {
     private var backupPicker: some View {
         Menu {
             ForEach(backupVM.backups) { backup in
-                Button("\(backup.displayName) • iOS \(backup.iosVersion) • \(backup.relativeDate)\(backup.isEncrypted ? " • Encrypted" : "")") {
+                Button("\(backup.deviceIdentityLabel) • iOS \(backup.iosVersion) • \(backup.relativeDate)\(backup.isEncrypted ? " • Encrypted" : "")") {
                     selectBackup(backup)
                 }
             }
@@ -113,7 +113,7 @@ struct AppManagerView: View {
             HStack(spacing: 6) {
                 Image(systemName: "externaldrive.fill")
                     .foregroundStyle(.secondary)
-                Text(backupVM.selectedBackup.map { "\($0.displayName) • \($0.relativeDate)" } ?? "Choose Backup")
+                Text(backupVM.selectedBackup.map { "\($0.deviceIdentityLabel) • \($0.relativeDate)" } ?? "Choose Backup")
                     .lineLimit(1)
                 Image(systemName: "chevron.down")
                     .font(.system(size: 9, weight: .semibold))

--- a/Sources/Phosphor/Views/Backup/BackupBrowserView.swift
+++ b/Sources/Phosphor/Views/Backup/BackupBrowserView.swift
@@ -17,7 +17,7 @@ struct BackupBrowserView: View {
                     VStack(alignment: .leading, spacing: 2) {
                         Text("Backup Browser")
                             .font(.title2.weight(.semibold))
-                        Text("\(backup.deviceName) - \(backup.dateString)")
+                        Text("\(backup.deviceIdentityLabel) • \(backup.dateString)")
                             .font(.subheadline)
                             .foregroundStyle(.secondary)
                     }

--- a/Sources/Phosphor/Views/Backup/BackupListView.swift
+++ b/Sources/Phosphor/Views/Backup/BackupListView.swift
@@ -410,11 +410,14 @@ struct BackupListView: View {
                                 .foregroundStyle(.secondary)
                                 .lineLimit(1)
                         }
+                        .accessibilityElement(children: .combine)
+                        .accessibilityLabel("\(deviceIdentity(for: activity.udid)), \(activity.displayProgressText)")
                         Spacer()
                         Button("Cancel") {
                             backupVM.cancelBackup(udid: activity.udid)
                         }
                         .controlSize(.small)
+                        .accessibilityLabel("Cancel backup for \(deviceIdentity(for: activity.udid))")
                     }
                     if case .running = activity.state {
                         ProgressView(

--- a/Sources/Phosphor/Views/Backup/BackupListView.swift
+++ b/Sources/Phosphor/Views/Backup/BackupListView.swift
@@ -28,7 +28,7 @@ struct BackupListView: View {
                 VStack(alignment: .leading, spacing: 2) {
                     Text("Backups")
                         .font(.title2.weight(.semibold))
-                    Text("\(backupVM.backups.count) backups - \(backupVM.totalSize) total")
+                    Text(backupSummary)
                         .font(.subheadline)
                         .foregroundStyle(.secondary)
                 }
@@ -38,7 +38,6 @@ struct BackupListView: View {
                 newBackupMenu
                 .buttonStyle(.borderedProminent)
                 .tint(.brandAccent)
-                .disabled(backupVM.isCreating)
 
                 Button {
                     backupVM.loadBackups()
@@ -52,8 +51,8 @@ struct BackupListView: View {
 
             backupStateNotice
 
-            if backupVM.isCreating {
-                backupProgressView
+            if !activeBackupActivities.isEmpty {
+                backupActivityList
             }
 
             if let err = backupVM.loadError, backupVM.backups.isEmpty {
@@ -96,7 +95,7 @@ struct BackupListView: View {
             }
         } message: {
             if let backup = backupToDelete {
-                Text("This will permanently delete the backup of \(backup.deviceName) (\(backup.sizeResolved ? backup.sizeString : "size calculating")). This cannot be undone.")
+                Text("This will permanently delete \(backup.deviceIdentityLabel) (\(backup.sizeResolved ? backup.sizeString : "size calculating")). This cannot be undone.")
             }
         }
         .alert("Backup", isPresented: $backupVM.showAlert) {
@@ -143,7 +142,7 @@ struct BackupListView: View {
         }
         .sheet(isPresented: $showScheduleSheet) {
             BackupScheduleSheet()
-                .frame(width: 440, height: 400)
+                .frame(width: 480, height: 500)
         }
         .onAppear { backupVM.loadBackups() }
     }
@@ -176,6 +175,34 @@ struct BackupListView: View {
         } label: {
             Label("New Backup", systemImage: "plus")
         }
+    }
+
+    private var activeBackupActivities: [BackupViewModel.BackupActivity] {
+        backupVM.backupActivities.values
+            .filter(\.isActive)
+            .sorted { lhs, rhs in
+                switch (lhs.state, rhs.state) {
+                case (.running, .queued): true
+                case (.queued, .running): false
+                default: lhs.udid < rhs.udid
+                }
+            }
+    }
+
+    private var backedUpDeviceCount: Int {
+        Set(backupVM.backups.map { backup in
+            backup.udid.isEmpty ? "backup:\(backup.id)" : "device:\(backup.udid)"
+        }).count
+    }
+
+    private var backupSummary: String {
+        let backupWord = backupVM.backups.count == 1 ? "backup" : "backups"
+        let deviceWord = backedUpDeviceCount == 1 ? "device" : "devices"
+        return "\(backupVM.backups.count) \(backupWord) across \(backedUpDeviceCount) \(deviceWord) - \(backupVM.totalSize) total"
+    }
+
+    private var selectedDeviceBackupIsActive: Bool {
+        deviceVM.selectedDevice.map { backupVM.isBackupActive(for: $0.id) } == true
     }
 
 
@@ -368,22 +395,50 @@ struct BackupListView: View {
         }
     }
 
-    private var backupProgressView: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            HStack {
-                Text(backupVM.displayProgressText)
-                    .font(.system(size: 13, weight: .medium))
-                    .foregroundStyle(.secondary)
-                    .lineLimit(1)
-                Spacer()
+    private var backupActivityList: some View {
+        VStack(spacing: 0) {
+            ForEach(activeBackupActivities) { activity in
+                VStack(alignment: .leading, spacing: 8) {
+                    HStack(spacing: 8) {
+                        Image(systemName: activity.state == .running ? "externaldrive.badge.timemachine" : "clock")
+                            .foregroundStyle(Color.brandAccent)
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(deviceIdentity(for: activity.udid))
+                                .font(.system(size: 13, weight: .semibold))
+                            Text(activity.displayProgressText)
+                                .font(.system(size: 11))
+                                .foregroundStyle(.secondary)
+                                .lineLimit(1)
+                        }
+                        Spacer()
+                        Button("Cancel") {
+                            backupVM.cancelBackup(udid: activity.udid)
+                        }
+                        .controlSize(.small)
+                    }
+                    if case .running = activity.state {
+                        ProgressView(
+                            value: activity.displayProgressFraction,
+                            total: 1.0
+                        )
+                        .progressViewStyle(.linear)
+                        .tint(.brandAccent)
+                    }
+                }
+                .padding(.horizontal, 20)
+                .padding(.vertical, 10)
+                if activity.id != activeBackupActivities.last?.id { Divider() }
             }
-            ProgressView(value: backupVM.displayProgressFraction, total: 1.0)
-                .progressViewStyle(.linear)
-                .tint(.brandAccent)
         }
-        .padding(.horizontal, 20)
-        .padding(.vertical, 12)
         .background(Color.brandAccent.opacity(0.06))
+    }
+
+    private func deviceIdentity(for udid: String) -> String {
+        let suffix = String(udid.suffix(8))
+        guard let device = deviceVM.devices.first(where: { $0.id == udid }) else {
+            return "Device · ID …\(suffix)"
+        }
+        return "\(device.name) · \(device.displayModelName) · ID …\(suffix)"
     }
 
     @ViewBuilder
@@ -513,8 +568,10 @@ struct BackupRow: View {
 
             VStack(alignment: .leading, spacing: 3) {
                 HStack(spacing: 6) {
-                    Text(backup.deviceName)
+                    Text(backup.deviceIdentityLabel)
                         .font(.system(size: 14, weight: .medium))
+                        .lineLimit(1)
+                        .help("Full device ID: \(backup.udid.isEmpty ? "Unavailable" : backup.udid)")
 
                     if backup.isEncrypted {
                         Image(systemName: "lock.fill")
@@ -529,8 +586,6 @@ struct BackupRow: View {
                 }
 
                 HStack(spacing: 8) {
-                    Text(backup.modelName)
-                    Text("-")
                     Text("iOS \(backup.iosVersion)")
                 }
                 .font(.system(size: 12))
@@ -625,6 +680,8 @@ struct BackupRow: View {
 struct BackupScheduleSheet: View {
 
     @StateObject private var scheduler = BackupScheduler()
+    @EnvironmentObject private var deviceVM: DeviceViewModel
+    @EnvironmentObject private var backupVM: BackupViewModel
     @Environment(\.dismiss) private var dismiss
 
     var body: some View {
@@ -642,7 +699,25 @@ struct BackupScheduleSheet: View {
 
             Form {
                 Section("Schedule") {
+                    ScheduledBackupDevicePicker(
+                        targetUDID: Binding(
+                            get: { scheduler.schedule.targetUDID },
+                            set: { targetUDID in
+                                let targetName = deviceVM.devices.first(where: { $0.id == targetUDID })?.name
+                                scheduler.selectSchedule(targetUDID: targetUDID, targetName: targetName)
+                            }
+                        ),
+                        targetName: $scheduler.schedule.targetName,
+                        devices: deviceVM.devices,
+                        wifiOnly: scheduler.schedule.wifiOnly
+                    )
+
                     Toggle("Enable automatic backups", isOn: $scheduler.schedule.enabled)
+                        .disabled(
+                            !scheduler.schedule.enabled &&
+                            scheduler.schedule.targetUDID == nil &&
+                            deviceVM.devices.count != 1
+                        )
 
                     if scheduler.schedule.enabled {
                         Picker("Frequency", selection: $scheduler.schedule.frequency) {
@@ -702,7 +777,10 @@ struct BackupScheduleSheet: View {
                         Button("Run Now") {
                             Task { await scheduler.runNow() }
                         }
-                        .disabled(scheduler.isRunningScheduledBackup)
+                        .disabled(
+                            scheduler.isRunningScheduledBackup ||
+                            (scheduler.schedule.targetUDID == nil && deviceVM.devices.count > 1)
+                        )
                     }
 
                     if !scheduler.recentLogs.isEmpty {
@@ -731,5 +809,6 @@ struct BackupScheduleSheet: View {
         .onChange(of: scheduler.schedule.frequency) { _, _ in scheduler.updateNextRunDate() }
         .onChange(of: scheduler.schedule.preferredHour) { _, _ in scheduler.updateNextRunDate() }
         .onChange(of: scheduler.schedule.preferredMinute) { _, _ in scheduler.updateNextRunDate() }
+        .onAppear { scheduler.attachBackupViewModel(backupVM) }
     }
 }

--- a/Sources/Phosphor/Views/Backup/BackupListView.swift
+++ b/Sources/Phosphor/Views/Backup/BackupListView.swift
@@ -350,7 +350,7 @@ struct BackupListView: View {
             backupVM.backupIssue = nil
             NSApp.sendAction(Selector(("showSettingsWindow:")), to: nil, from: nil)
         case .retry:
-            Task { await backupVM.retryLastBackup() }
+            Task { await backupVM.retryBackup(for: issue) }
         case .none:
             backupVM.backupIssue = nil
         }

--- a/Sources/Phosphor/Views/Backup/BackupTimeMachineView.swift
+++ b/Sources/Phosphor/Views/Backup/BackupTimeMachineView.swift
@@ -87,7 +87,7 @@ struct BackupTimeMachineView: View {
                 performRestore(request)
             }
         } message: { request in
-            Text("Restore \(request.targetName) from \(request.backup.dateString)? The device will restart, and this cannot be undone.")
+            Text("Restore \(request.targetName) · ID …\(request.targetUDID.suffix(8)) using \(request.backup.deviceIdentityLabel) from \(request.backup.dateString)? The target device will restart, and this cannot be undone.")
         }
     }
 
@@ -145,9 +145,10 @@ struct BackupTimeMachineView: View {
                     .font(.system(size: 16))
                     .foregroundStyle(.white.opacity(0.9))
 
-                Text(backup.deviceName)
+                Text(backup.deviceIdentityLabel)
                     .font(.system(size: 14, weight: .semibold))
                     .foregroundStyle(.white)
+                    .lineLimit(1)
 
                 Spacer()
 

--- a/Sources/Phosphor/Views/Backup/BackupUnlockSheet.swift
+++ b/Sources/Phosphor/Views/Backup/BackupUnlockSheet.swift
@@ -22,7 +22,7 @@ struct BackupUnlockSheet: View {
                 VStack(alignment: .leading, spacing: 2) {
                     Text("Unlock Encrypted Backup")
                         .font(.headline)
-                    Text("\(backup.displayName) • \(backup.relativeDate)")
+                    Text("\(backup.deviceIdentityLabel) • \(backup.relativeDate)")
                         .font(.system(size: 11))
                         .foregroundStyle(.secondary)
                 }

--- a/Sources/Phosphor/Views/Backup/ScheduledBackupDevicePicker.swift
+++ b/Sources/Phosphor/Views/Backup/ScheduledBackupDevicePicker.swift
@@ -1,0 +1,58 @@
+import SwiftUI
+
+/// Shared scheduled-backup target picker used by both schedule configuration surfaces.
+struct ScheduledBackupDevicePicker: View {
+    @Binding var targetUDID: String?
+    @Binding var targetName: String?
+    let devices: [DeviceInfo]
+    let wifiOnly: Bool
+
+    private var currentTargetIsConnected: Bool {
+        guard let targetUDID else { return false }
+        return devices.contains(where: { $0.id == targetUDID })
+    }
+
+    private var targetBinding: Binding<String?> {
+        Binding(
+            get: { targetUDID },
+            set: { newValue in
+                targetUDID = newValue
+                targetName = newValue.flatMap { selectedID in
+                    devices.first(where: { $0.id == selectedID })?.name
+                }
+            }
+        )
+    }
+
+    var body: some View {
+        Picker("Device", selection: targetBinding) {
+            Text("Choose a Device").tag(String?.none)
+            ForEach(devices) { device in
+                Text("\(device.name) — \(device.displayModelName) — ID …\(device.id.suffix(8)) (\(device.connectionType.rawValue))")
+                    .tag(Optional(device.id))
+            }
+            if let targetUDID, !currentTargetIsConnected {
+                Text("\(targetName ?? "Previously Selected Device") — ID …\(targetUDID.suffix(8)) — Not Connected")
+                    .tag(Optional(targetUDID))
+            }
+        }
+
+        if targetUDID == nil {
+            Text(devices.count > 1
+                ? "Choose which device may run on this schedule. Phosphor will not pick one automatically."
+                : "Choose a device for this schedule. Legacy schedules may use the only available device, but never choose between multiple devices.")
+                .font(.caption)
+                .foregroundStyle(devices.count > 1 ? .orange : .secondary)
+        } else if !currentTargetIsConnected {
+            Text("The schedule will wait until this device is available instead of backing up a different device.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        } else if wifiOnly,
+                  let targetUDID,
+                  devices.first(where: { $0.id == targetUDID })?.connectionType != .wifi {
+            Text("This device is currently connected by USB. The schedule will wait until it is available over Wi-Fi.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+}

--- a/Sources/Phosphor/Views/Clone/DeviceCloneView.swift
+++ b/Sources/Phosphor/Views/Clone/DeviceCloneView.swift
@@ -5,6 +5,7 @@ import SwiftUI
 struct DeviceCloneView: View {
 
     @EnvironmentObject var deviceVM: DeviceViewModel
+    @EnvironmentObject var backupVM: BackupViewModel
     @StateObject private var cloneService = DeviceCloneService()
     @State private var availableDevices: [(udid: String, name: String)] = []
     @State private var sourceUDID: String?
@@ -32,7 +33,7 @@ struct DeviceCloneView: View {
         } message: {
             let srcName = availableDevices.first(where: { $0.udid == sourceUDID })?.name ?? "Unknown"
             let dstName = availableDevices.first(where: { $0.udid == destinationUDID })?.name ?? "Unknown"
-            Text("This will create a full backup of \(srcName) and restore it to \(dstName). All data on the destination device will be replaced. The destination device will restart.")
+            Text("This will create a full backup of \(srcName) · ID …\(sourceUDID?.suffix(8) ?? "Unknown") and restore it to \(dstName) · ID …\(destinationUDID?.suffix(8) ?? "Unknown"). All data on the destination device will be replaced. The destination device will restart.")
         }
     }
 
@@ -329,7 +330,7 @@ struct DeviceCloneView: View {
     private func startClone() {
         guard let src = sourceUDID, let dst = destinationUDID else { return }
         Task {
-            let _ = await cloneService.clone(sourceUDID: src, destinationUDID: dst)
+            let _ = await cloneService.clone(sourceUDID: src, destinationUDID: dst, backupViewModel: backupVM)
         }
     }
 }

--- a/Sources/Phosphor/Views/Device/DeviceOverviewView.swift
+++ b/Sources/Phosphor/Views/Device/DeviceOverviewView.swift
@@ -383,8 +383,8 @@ struct DeviceOverviewView: View {
                     Task { await deviceVM.takeScreenshot() }
                 }
                 ActionButton(
-                    icon: backupVM.isCreating ? "hourglass" : backupActionIcon(for: device),
-                    label: backupVM.isCreating ? "Backing Up..." : backupActionLabel(for: device),
+                    icon: backupVM.isBackupActive(for: device.id) ? "hourglass" : backupActionIcon(for: device),
+                    label: backupVM.isBackupActive(for: device.id) ? "Backing Up..." : backupActionLabel(for: device),
                     color: .brandAccent
                 ) {
                     startBackup(for: device)

--- a/Sources/Phosphor/Views/Device/DeviceOverviewView.swift
+++ b/Sources/Phosphor/Views/Device/DeviceOverviewView.swift
@@ -389,7 +389,7 @@ struct DeviceOverviewView: View {
                 ) {
                     startBackup(for: device)
                 }
-                .disabled(backupVM.isCreating)
+                .disabled(backupVM.isBackupActive(for: device.id))
                 .help("Start a backup for this device")
                 if !device.isPaired {
                     ActionButton(icon: "link", label: "Pair", color: .green) {
@@ -409,13 +409,21 @@ struct DeviceOverviewView: View {
                 }
             }
 
-            if backupVM.isCreating {
+            if let activity = backupVM.activity(for: device.id), activity.isActive {
                 VStack(alignment: .leading, spacing: 8) {
-                    Text(backupVM.displayProgressText)
-                        .font(.caption.weight(.medium))
-                        .foregroundStyle(.secondary)
-                        .lineLimit(1)
-                    ProgressView(value: backupVM.displayProgressFraction, total: 1.0)
+                    HStack {
+                        Text(activity.displayProgressText)
+                            .font(.caption.weight(.medium))
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                        Spacer()
+                        Button("Cancel") { backupVM.cancelBackup(udid: device.id) }
+                            .controlSize(.small)
+                    }
+                    ProgressView(
+                        value: activity.displayProgressFraction,
+                        total: 1.0
+                    )
                         .progressViewStyle(.linear)
                         .tint(.brandAccent)
                 }

--- a/Sources/Phosphor/Views/Messages/MessageListView.swift
+++ b/Sources/Phosphor/Views/Messages/MessageListView.swift
@@ -166,7 +166,7 @@ struct MessageListView: View {
                 .foregroundStyle(.secondary)
             Menu {
                 ForEach(backupVM.backups) { backup in
-                    Button("\(backup.displayName) • iOS \(backup.iosVersion) • \(backup.relativeDate)\(backup.isEncrypted ? " • Encrypted" : "")") {
+                    Button("\(backup.deviceIdentityLabel) • iOS \(backup.iosVersion) • \(backup.relativeDate)\(backup.isEncrypted ? " • Encrypted" : "")") {
                         selectBackup(backup)
                     }
                 }
@@ -176,7 +176,7 @@ struct MessageListView: View {
                 }
             } label: {
                 HStack {
-                    Text(backupVM.selectedBackup.map { "\($0.displayName) • iOS \($0.iosVersion) • \($0.relativeDate)\($0.isEncrypted ? " • Encrypted" : "")" } ?? "Choose Backup")
+                    Text(backupVM.selectedBackup.map { "\($0.deviceIdentityLabel) • iOS \($0.iosVersion) • \($0.relativeDate)\($0.isEncrypted ? " • Encrypted" : "")" } ?? "Choose Backup")
                         .lineLimit(1)
                     Image(systemName: "chevron.down")
                         .font(.system(size: 9, weight: .semibold))

--- a/Sources/Phosphor/Views/Settings/SettingsView.swift
+++ b/Sources/Phosphor/Views/Settings/SettingsView.swift
@@ -3,6 +3,8 @@ import SwiftUI
 /// App settings: backup location, dependencies check, about.
 struct SettingsView: View {
 
+    @EnvironmentObject private var deviceVM: DeviceViewModel
+    @EnvironmentObject private var backupVM: BackupViewModel
     @AppStorage("phosphor.backupDirectory") private var backupDirectory = BackupManager.defaultBackupDir
     @State private var dependencyList: [DependencyItem] = []
     @State private var isCheckingDependencies = false
@@ -34,6 +36,7 @@ struct SettingsView: View {
         }
         .frame(width: 560, height: 460)
         .task {
+            scheduler.attachBackupViewModel(backupVM)
             await refreshDependencies()
         }
     }
@@ -156,7 +159,25 @@ struct SettingsView: View {
     private var backupScheduleTab: some View {
         Form {
             Section("Automatic Backups") {
+                ScheduledBackupDevicePicker(
+                    targetUDID: Binding(
+                        get: { scheduler.schedule.targetUDID },
+                        set: { targetUDID in
+                            let targetName = deviceVM.devices.first(where: { $0.id == targetUDID })?.name
+                            scheduler.selectSchedule(targetUDID: targetUDID, targetName: targetName)
+                        }
+                    ),
+                    targetName: $scheduler.schedule.targetName,
+                    devices: deviceVM.devices,
+                    wifiOnly: scheduler.schedule.wifiOnly
+                )
+
                 Toggle("Enable scheduled backups", isOn: $scheduler.schedule.enabled)
+                    .disabled(
+                        !scheduler.schedule.enabled &&
+                        scheduler.schedule.targetUDID == nil &&
+                        deviceVM.devices.count != 1
+                    )
 
                 if scheduler.schedule.enabled {
                     Picker("Frequency", selection: $scheduler.schedule.frequency) {


### PR DESCRIPTION
## Summary
- target scheduled backups by UDID and fail closed when a legacy schedule is ambiguous
- persist independent per-device schedules and route manual, scheduled, and clone backups through one bounded two-device queue
- prevent same-device overlap while allowing distinct devices to run concurrently
- identify source, destination, active, queued, historical, unlockable, and exported backups with stable device identifiers
- preserve backward compatibility for existing single-schedule data

## Safety
- explicit targets never fall back to another device
- Wi-Fi-only schedules require the selected device's network representation
- queued cancellation retains ownership until work actually finishes
- destructive operations are process-wide limited to two and exclusive per UDID

## Verification
- `PYTHONDONTWRITEBYTECODE=1 python3 Scripts/regression/run.py` — 72 checks passed
- `swift build` — passed
- `swift build -c release` — passed
- `bash Scripts/build.sh` — passed
- `Scripts/benchmark-performance.sh` — passed
- packaged app smoke launch — one visible Phosphor window confirmed through CoreGraphics
- independent final release-blocker review — PASS, no actionable blockers

The unrelated in-progress background-backup work remained isolated in its original checkout and is not included in this branch.

<!-- Follow-up: scheduled-work ownership -->
### Follow-up: scheduled-work ownership

This follow-up persists explicit schedule clearing, tracks delayed work with per-run UUID ownership, and revalidates the exact persisted schedule after asynchronous discovery and backup completion. A cleared/retargeted schedule cannot be resurrected, and stale task cleanup cannot erase a newer run for the same device. Concurrent-backup status and Cancel controls also expose device-specific VoiceOver labels and progress.

Verification:
- 76 regression checks passed
- `swift build -c release` passed
- generation/ownership behavior regressions cover stale completion and replacement races
