### PR TITLE
fix: retain backup destination for each operation

### DIFF
--- a/Scripts/regression/checks/backup_operation_lease.py
+++ b/Scripts/regression/checks/backup_operation_lease.py
@@ -42,3 +42,89 @@ def test_backup_ownership_blocks_overlap_across_every_backup_owner(root: Path) -
     assert_contains(clone, "backupViewModel.createBackup", "clone source backups must go through the ownership-taking BackupManager")
 
     assert_contains(app, "backupVM.isCreating", "Quick Actions must disable while a backup is running")
+
+
+def test_backup_root_snapshot_survives_settings_change_through_fallback_and_finalization(root: Path) -> None:
+    """A run that starts at root A must not split work with root B after Settings changes.
+
+    The trace models each mode's primary failure followed by fallback and finalization;
+    the source assertions bind that behavior to the concrete BackupManager calls.
+    """
+    manager = read(root, "Sources/Phosphor/Services/BackupManager.swift")
+
+    def modeled_run(mode: str) -> dict[str, str]:
+        active_root = "/backups/A"
+        operation_root = active_root  # acquired immediately with the operation lease
+        paths = {"preflight": operation_root, "primary": operation_root}
+        active_root = "/backups/B"  # Settings changes while the primary is running
+        paths.update(
+            fallback=operation_root,
+            verification=operation_root,
+            discovery=operation_root,
+            failure=operation_root,
+        )
+        assert active_root == "/backups/B"
+        return paths
+
+    for mode in ("full", "incremental"):
+        assert set(modeled_run(mode).values()) == {"/backups/A"}, (
+            f"{mode} backup must retain its root after Settings changes"
+        )
+
+    full = manager.split("func createBackup(", 1)[1].split("private func idevicebackupArguments", 1)[0]
+    incremental = manager.split("func createIncrementalBackup(", 1)[1].split("// MARK: - Restore", 1)[0]
+    for mode, body in (("full", full), ("incremental", incremental)):
+        assert "let backupRoot = Self.activeBackupDir" in body, f"{mode} backup must snapshot root after its lease"
+        assert body.index("beginCancellableOperation(udid: udid)") < body.index("let backupRoot = Self.activeBackupDir"), (
+            f"{mode} backup must snapshot root only after obtaining device ownership"
+        )
+        assert "Self.validateBackupDirectory(backupRoot)" in body, f"{mode} preflight must use the snapshot"
+        assert "Self.backupMetadataHealth(for: udid, in: backupRoot)" in body, f"{mode} metadata lookup must use the snapshot"
+        assert "finalizeSuccessfulBackup(udid: udid, directory: backupRoot" in body, f"{mode} verification/finalization must use the snapshot"
+        assert "idevicebackupArguments(udid: udid, directory: backupRoot, full:" in body, f"{mode} fallback arguments must use the snapshot"
+        assert "Self.backupPath(for: udid, in: backupRoot)" in body, f"{mode} failure recovery paths must use the snapshot"
+
+    finalize = manager.split("private func finalizeSuccessfulBackup(", 1)[1].split("/// Create a new backup.", 1)[0]
+    assert "directory: String" in finalize, "finalization must accept the operation root"
+    assert "Self.backupMetadataHealth(for: udid, in: directory)" in finalize, "verification must use the operation root"
+    assert "discoverBackups(at: directory)" in finalize, "post-success discovery must use the operation root"
+
+    primary = manager.split("private func createBackupViaPymobiledevice(", 1)[1].split("/// Create an incremental backup", 1)[0]
+    assert "directory: String" in primary, "primary backend must accept the operation root"
+    assert "directory: directory" in primary, "primary backend must use the operation root"
+
+
+def test_incomplete_backup_recovery_uses_the_failed_operation_root(root: Path) -> None:
+    """Recovery must trash the captured failed folder, even after Settings changes."""
+    manager = read(root, "Sources/Phosphor/Services/BackupManager.swift")
+    view_model = read(root, "Sources/Phosphor/ViewModels/BackupViewModel.swift")
+
+    with tempfile.TemporaryDirectory(prefix="phosphor-recovery-root-") as temp_dir:
+        temp = Path(temp_dir)
+        root_a = temp / "A"
+        root_b = temp / "B"
+        failed = root_a / "device"
+        other = root_b / "device"
+        failed.mkdir(parents=True)
+        other.mkdir(parents=True)
+        (failed / "Info.plist").write_text("partial")
+        (other / "Info.plist").write_text("new-root")
+
+        failed_root = failed.parent
+        active_root = root_b  # Settings changes after failure is surfaced.
+        # Model the recovery contract: remove only from the captured operation root;
+        # a new backup then starts from the current explicitly selected root.
+        import shutil
+        shutil.rmtree(failed_root / "device")
+        assert not failed.exists(), "recovery must remove the failed operation folder"
+        assert other.exists(), "recovery must not inspect or remove the current different root"
+        assert active_root == root_b
+
+    recovery = view_model.split("func deleteIncompleteBackupAndRunFull", 1)[1].split("func retryBackup", 1)[0]
+    assert "let recoveryRoot = (path as NSString).deletingLastPathComponent" in recovery, (
+        "recovery must derive the failed operation root from its captured path"
+    )
+    assert "deleteIncompleteBackup(for: udid, expectedPath: path, in: recoveryRoot)" in recovery, (
+        "recovery must delete from the captured operation root, not mutable active settings"
+    )
+    assert "in directory: String?" in manager, "the backup manager deletion API must accept an explicit recovery root"

--- a/Scripts/regression/checks/device_backup.py
+++ b/Scripts/regression/checks/device_backup.py
@@ -641,7 +641,7 @@ def test_incremental_backups_require_existing_metadata(root: Path) -> None:
     assert_not_contains(manager, "removeItem(atPath: path)", "Incomplete-backup recovery should not permanently delete backup folders")
     assert_contains(manager, "finalizeSuccessfulBackup", "Completed backup commands should be verified before the UI reports success")
     assert_contains(manager, "Backup Metadata Incomplete", "Post-backup verification should surface incomplete metadata as a structured failure")
-    assert_contains(manager, "backupMetadataHealth(for: udid)", "Post-backup verification should require complete metadata for the target device")
+    assert_contains(manager, "backupMetadataHealth(for: udid, in: directory)", "Post-backup verification should require complete metadata for the target device")
 
     view = read(root, "Sources/Phosphor/Views/Backup/BackupListView.swift")
     assert_contains(view, "shouldOfferIncremental(for: device)", "Backup UI should only offer incremental when a backup exists for the selected device")

--- a/Scripts/regression/checks/readiness_center.py
+++ b/Scripts/regression/checks/readiness_center.py
@@ -95,4 +95,6 @@ def test_readiness_center_incomplete_backup_recovery_action(root: Path) -> None:
     assert "pendingRecovery" in view, "readiness recovery should require a confirmation alert"
     assert "Move Incomplete Backup to Trash" in view, "readiness center should expose the cleanup action"
     assert "BackupManager.deleteIncompleteBackup" in view, "cleanup should use the guarded BackupManager trash flow"
+    assert "let recoveryRoot = (path as NSString).deletingLastPathComponent" in view, "readiness recovery must derive the root from its captured incomplete path"
+    assert "deleteIncompleteBackup(for: udid, expectedPath: path, in: recoveryRoot)" in view, "readiness recovery must not re-read the mutable backup root"
     assert "device.connectionType == .usb" in view, "readiness should auto-start full backup only on USB"

--- a/Sources/Phosphor/Services/BackupManager.swift
+++ b/Sources/Phosphor/Services/BackupManager.swift
@@ -452,19 +452,20 @@ final class BackupManager: ObservableObject {
 
     private func finalizeSuccessfulBackup(
         udid: String,
+        directory: String,
         operationID: UUID,
         onProgress: @escaping (String) -> Void
     ) -> Bool {
-        switch Self.backupMetadataHealth(for: udid) {
+        switch Self.backupMetadataHealth(for: udid, in: directory) {
         case .complete:
             finishOperation(operationID)
             backupProgress = "Backup complete"
             backupPercent = 1.0
-            discoverBackups()
+            discoverBackups(at: directory)
             onProgress("Backup complete")
             return true
         case .missing:
-            let path = Self.backupPath(for: udid)
+            let path = Self.backupPath(for: udid, in: directory)
             finishOperation(operationID)
             backupProgress = "Backup metadata incomplete"
             lastBackupFailure = BackupFailure(
@@ -505,6 +506,7 @@ final class BackupManager: ObservableObject {
         // Per-device ownership first (#60): if another owner already holds this
         // UDID we must not take the comparison gate on its behalf.
         guard let operationID = beginCancellableOperation(udid: udid) else { return false }
+        let backupRoot = Self.activeBackupDir
         // Then the reader/writer gate (#70). beginBackup preempts any in-flight
         // comparison rather than being refused by one, so this always succeeds.
         let coordinatorToken = BackupOperationCoordinator.shared.beginBackup()
@@ -519,7 +521,7 @@ final class BackupManager: ObservableObject {
 
         // Preflight: bail early with a clear message when the directory is unreadable
         // (most commonly a Full Disk Access grant missing on the default location).
-        let preflight = Self.validateBackupDirectory(Self.activeBackupDir)
+        let preflight = Self.validateBackupDirectory(backupRoot)
         if !preflight.ok {
             finishOperation(operationID)
             backupProgress = "Backup failed"
@@ -527,16 +529,16 @@ final class BackupManager: ObservableObject {
             lastBackupFailure = BackupFailure(
                 title: "Backup Folder Not Accessible",
                 message: preflight.reason ?? "Phosphor cannot read or write the selected backup folder.",
-                technicalDetails: Self.activeBackupDir,
+                technicalDetails: backupRoot,
                 recoveryAction: .openBackupSettings,
                 udid: udid,
-                recoveryPath: Self.activeBackupDir
+                recoveryPath: backupRoot
             )
             onProgress(preflight.reason ?? "Backup directory is not accessible.")
             return false
         }
 
-        if case .incomplete(let path) = Self.backupMetadataHealth(for: udid) {
+        if case .incomplete(let path) = Self.backupMetadataHealth(for: udid, in: backupRoot) {
             finishOperation(operationID)
             backupProgress = "Incomplete backup found"
             lastBackupFailure = BackupFailure(
@@ -555,13 +557,14 @@ final class BackupManager: ObservableObject {
         // Primary: pymobiledevice3
         let pySuccess = await createBackupViaPymobiledevice(
             udid: udid,
+            directory: backupRoot,
             full: true,
             preferNetwork: preferNetwork,
             operationID: operationID,
             onProgress: onProgress
         )
         if pySuccess {
-            return finalizeSuccessfulBackup(udid: udid, operationID: operationID, onProgress: onProgress)
+            return finalizeSuccessfulBackup(udid: udid, directory: backupRoot, operationID: operationID, onProgress: onProgress)
         }
         if operationWasCancelled(operationID) {
             markOperationCancelled(operationID)
@@ -574,7 +577,7 @@ final class BackupManager: ObservableObject {
         backupProgress = "Backing up..."
         onProgress("Backing up")
 
-        let args = idevicebackupArguments(udid: udid, full: true, preferNetwork: preferNetwork)
+        let args = idevicebackupArguments(udid: udid, directory: backupRoot, full: true, preferNetwork: preferNetwork)
         var idevicebackupStderr = ""
 
         return await withCheckedContinuation { continuation in
@@ -605,7 +608,7 @@ final class BackupManager: ObservableObject {
                             return
                         }
                         if exitCode == 0 {
-                            let verified = self.finalizeSuccessfulBackup(udid: udid, operationID: operationID, onProgress: onProgress)
+                            let verified = self.finalizeSuccessfulBackup(udid: udid, directory: backupRoot, operationID: operationID, onProgress: onProgress)
                             continuation.resume(returning: verified)
                             return
                         } else {
@@ -618,7 +621,7 @@ final class BackupManager: ObservableObject {
                                 primary: "Both backup methods failed.",
                                 stderr: combinedStderr,
                                 udid: udid,
-                                recoveryPath: Self.backupPath(for: udid)
+                                recoveryPath: Self.backupPath(for: udid, in: backupRoot)
                             )
                             self.lastBackupFailure = failure
                             self.lastError = Self.composeFailureMessage(
@@ -633,18 +636,19 @@ final class BackupManager: ObservableObject {
         }
     }
 
-    private func idevicebackupArguments(udid: String, full: Bool, preferNetwork: Bool) -> [String] {
+    private func idevicebackupArguments(udid: String, directory: String, full: Bool, preferNetwork: Bool) -> [String] {
         var args = ["-u", udid]
         if preferNetwork { args.append("-n") }
         args.append("backup")
         if full { args.append("--full") }
-        args.append(Self.activeBackupDir)
+        args.append(directory)
         return args
     }
 
     /// Backup using pymobiledevice3.
     private func createBackupViaPymobiledevice(
         udid: String,
+        directory: String,
         full: Bool,
         preferNetwork: Bool,
         operationID: UUID,
@@ -661,7 +665,7 @@ final class BackupManager: ObservableObject {
 
         return await withCheckedContinuation { continuation in
             activeProcess = PyMobileDevice.backup(
-                directory: Self.activeBackupDir,
+                directory: directory,
                 udid: udid,
                 full: full,
                 preferNetwork: preferNetwork,
@@ -728,6 +732,7 @@ final class BackupManager: ObservableObject {
         // Per-device ownership first (#60): if another owner already holds this
         // UDID we must not take the comparison gate on its behalf.
         guard let operationID = beginCancellableOperation(udid: udid) else { return false }
+        let backupRoot = Self.activeBackupDir
         // Then the reader/writer gate (#70). beginBackup preempts any in-flight
         // comparison rather than being refused by one, so this always succeeds.
         let coordinatorToken = BackupOperationCoordinator.shared.beginBackup()
@@ -740,7 +745,7 @@ final class BackupManager: ObservableObject {
         lastError = nil
         lastBackupFailure = nil
 
-        let preflight = Self.validateBackupDirectory(Self.activeBackupDir)
+        let preflight = Self.validateBackupDirectory(backupRoot)
         if !preflight.ok {
             finishOperation(operationID)
             backupProgress = "Backup failed"
@@ -748,16 +753,16 @@ final class BackupManager: ObservableObject {
             lastBackupFailure = BackupFailure(
                 title: "Backup Folder Not Accessible",
                 message: preflight.reason ?? "Phosphor cannot read or write the selected backup folder.",
-                technicalDetails: Self.activeBackupDir,
+                technicalDetails: backupRoot,
                 recoveryAction: .openBackupSettings,
                 udid: udid,
-                recoveryPath: Self.activeBackupDir
+                recoveryPath: backupRoot
             )
             onProgress(preflight.reason ?? "Backup directory is not accessible.")
             return false
         }
 
-        switch Self.backupMetadataHealth(for: udid) {
+        switch Self.backupMetadataHealth(for: udid, in: backupRoot) {
         case .complete:
             break
         case .missing:
@@ -766,10 +771,10 @@ final class BackupManager: ObservableObject {
             lastBackupFailure = BackupFailure(
                 title: "Full Backup Required",
                 message: "No complete backup exists for this device yet. Run a full backup first; future Wi-Fi backups can be incremental.",
-                technicalDetails: Self.backupPath(for: udid),
+                technicalDetails: Self.backupPath(for: udid, in: backupRoot),
                 recoveryAction: .runFullBackup,
                 udid: udid,
-                recoveryPath: Self.backupPath(for: udid)
+                recoveryPath: Self.backupPath(for: udid, in: backupRoot)
             )
             lastError = lastBackupFailure?.message
             onProgress(lastError ?? "Run a full backup first.")
@@ -794,13 +799,14 @@ final class BackupManager: ObservableObject {
         if PyMobileDevice.available() {
             let success = await createBackupViaPymobiledevice(
                 udid: udid,
+                directory: backupRoot,
                 full: false,
                 preferNetwork: preferNetwork,
                 operationID: operationID,
                 onProgress: onProgress
             )
             if success {
-                return finalizeSuccessfulBackup(udid: udid, operationID: operationID, onProgress: onProgress)
+                return finalizeSuccessfulBackup(udid: udid, directory: backupRoot, operationID: operationID, onProgress: onProgress)
             }
             if operationWasCancelled(operationID) {
                 markOperationCancelled(operationID)
@@ -815,7 +821,7 @@ final class BackupManager: ObservableObject {
         return await withCheckedContinuation { continuation in
             activeProcess = Shell.runStreaming(
                 "idevicebackup2",
-                arguments: idevicebackupArguments(udid: udid, full: false, preferNetwork: preferNetwork),
+                arguments: idevicebackupArguments(udid: udid, directory: backupRoot, full: false, preferNetwork: preferNetwork),
                 timeout: Self.streamingBackupTimeout,
                 onOutput: { [weak self] output in
                     let trimmed = output.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -840,7 +846,7 @@ final class BackupManager: ObservableObject {
                             return
                         }
                         if exitCode == 0 {
-                            let verified = self.finalizeSuccessfulBackup(udid: udid, operationID: operationID, onProgress: onProgress)
+                            let verified = self.finalizeSuccessfulBackup(udid: udid, directory: backupRoot, operationID: operationID, onProgress: onProgress)
                             continuation.resume(returning: verified)
                             return
                         } else {
@@ -853,7 +859,7 @@ final class BackupManager: ObservableObject {
                                 primary: "Incremental backup failed via both backends.",
                                 stderr: combinedStderr,
                                 udid: udid,
-                                recoveryPath: Self.backupPath(for: udid)
+                                recoveryPath: Self.backupPath(for: udid, in: backupRoot)
                             )
                             self.lastBackupFailure = failure
                             self.lastError = Self.composeFailureMessage(

--- a/Sources/Phosphor/ViewModels/BackupViewModel.swift
+++ b/Sources/Phosphor/ViewModels/BackupViewModel.swift
@@ -466,7 +466,8 @@ final class BackupViewModel: ObservableObject {
         }
         do {
             let request = recoveryRequest(for: issue)
-            try BackupManager.deleteIncompleteBackup(for: udid, expectedPath: path)
+            let recoveryRoot = (path as NSString).deletingLastPathComponent
+            try BackupManager.deleteIncompleteBackup(for: udid, expectedPath: path, in: recoveryRoot)
             backupIssue = nil
             loadBackups()
             await createBackup(

--- a/Sources/Phosphor/Views/Readiness/ReadinessCenterView.swift
+++ b/Sources/Phosphor/Views/Readiness/ReadinessCenterView.swift
@@ -165,7 +165,8 @@ struct ReadinessCenterView: View {
         switch operation {
         case .deleteIncompleteBackupAndRunFull(let udid, let path):
             do {
-                try BackupManager.deleteIncompleteBackup(for: udid, expectedPath: path)
+                let recoveryRoot = (path as NSString).deletingLastPathComponent
+                try BackupManager.deleteIncompleteBackup(for: udid, expectedPath: path, in: recoveryRoot)
                 backupVM.loadBackups()
                 await deviceVM.refreshReadiness()
 


### PR DESCRIPTION
## Summary
- Rebuilds the safe, isolated destination-snapshot repair on current `main`.
- Full and incremental backups retain their starting root through preflight, both backends, metadata verification, discovery, and failure reporting.
- Incomplete-backup recovery in both Backups and Readiness Center acts on the captured failed-operation root even if Settings changes afterward.

## Verification
- `python3 Scripts/regression/run.py` (141 checks)
- `swift build`
- `swift build -c release` (independent review)
- Independent review: no blockers.

The prior network-location monitor and archive-rewrite work is intentionally removed; it needs its own redesigned follow-ups.