### PR TITLE
fix: stabilize Wi-Fi device discovery

### DIFF
--- a/Scripts/regression/checks/device_backup.py
+++ b/Scripts/regression/checks/device_backup.py
@@ -167,7 +167,7 @@ def test_device_polling_prefers_lightweight_discovery_before_python_fallback(roo
     # them as duplicate rows for a full interval once the probe recovers.
     assert_contains(manager, "if lightweightScan.isAvailable {", "the compatibility cache may only be refreshed from a scan whose lightweight probe succeeded")
     assert_contains(manager, "compatibilityOnlyDeviceEntries = []", "a failed lightweight probe must clear the compatibility cache instead of poisoning it")
-    assert_contains(manager, "entries = mergeDeviceEntries(pyEntries)", "when the lightweight probe fails, the pymobiledevice snapshot is the whole picture for that poll")
+    assert_contains(manager, "discoveredEntries = mergeDeviceEntries(pyEntries)", "when the lightweight probe fails, the pymobiledevice snapshot is the whole picture for that poll")
     # Date() here would hide pymobiledevice-only devices for the first full interval
     # after launch, which is exactly what this discovery path promises to prevent.
     assert_contains(manager, "lastCompatibilityDiscoveryAt = Date.distantPast", "the first poll after launch must run a compatibility scan, not wait out the interval")

--- a/Scripts/regression/checks/device_backup.py
+++ b/Scripts/regression/checks/device_backup.py
@@ -20,7 +20,7 @@ def test_pymobiledevice_queries_usb_and_network_before_fallback(root: Path) -> N
     src = read(root, "Sources/Phosphor/Utilities/PyMobileDevice.swift")
     assert_contains(src, 'runAsync(["usbmux", "list", "--usb"]', "device discovery must explicitly query USB devices")
     assert_contains(src, 'runAsync(["usbmux", "list", "--network"]', "device discovery must explicitly query network devices")
-    assert_contains(src, 'runAsync(["usbmux", "list"])', "device discovery should retain default usbmux fallback")
+    assert_contains(src, 'runAsync(["usbmux", "list"], timeout: 5)', "device discovery should retain a timeout-bounded default usbmux fallback")
     assert_contains(src, 'entry["ConnectionType"] as? String', "usbmux JSON parser should inspect top-level ConnectionType")
     assert_contains(src, '(entry["Properties"] as? [String: Any])?["ConnectionType"] as? String', "usbmux JSON parser should inspect nested Properties.ConnectionType")
 
@@ -143,34 +143,35 @@ def test_sidebar_highlights_only_the_selected_or_hovered_device_row(root: Path) 
 def test_device_polling_prefers_lightweight_discovery_before_python_fallback(root: Path) -> None:
     manager = read(root, "Sources/Phosphor/Services/DeviceManager.swift")
     assert_contains(manager, "let lightweightScan = await listLibimobiledeviceEntries()", "routine polling should start with lightweight idevice_id discovery")
-    assert_contains(manager, "if forceRefresh || !lightweightScan.isAvailable", "explicit refresh or missing idevice_id should retain full pymobiledevice discovery")
-    assert_contains(manager, "compatibilityDiscoveryInterval", "routine polling should periodically recheck pymobiledevice-specific discovery")
+    assert_contains(manager, "if forceRefresh || compatibilityScanIsDue", "explicit refresh should bypass compatibility backoff without making routine failures spin")
+    assert_contains(manager, "DiscoveryRetryBackoff(initialDelay: 5, maximumDelay: 30)", "routine polling should periodically recheck pymobiledevice-specific discovery")
     assert_contains(manager, "compatibilityScanIsDue", "devices visible only to pymobiledevice must still be discovered automatically")
-    assert_contains(manager, "let pyEntries = await PyMobileDevice.listDevicesWithType()", "pymobiledevice discovery must remain as the compatibility fallback")
-    assert manager.index("let lightweightScan = await listLibimobiledeviceEntries()") < manager.index("let pyEntries = await PyMobileDevice.listDevicesWithType()"), "lightweight discovery must run before the expensive Python fallback"
+    assert_contains(manager, "let pyDiscovery = await PyMobileDevice.discoverDevicesWithType()", "pymobiledevice discovery must return probe authority as well as entries")
+    assert manager.index("let lightweightScan = await listLibimobiledeviceEntries()") < manager.index("let pyDiscovery = await PyMobileDevice.discoverDevicesWithType()"), "lightweight discovery must run before the expensive Python fallback"
     assert_not_contains(manager, "cachedNetworkDeviceEntries", "listDevicesWithType already queries network devices; polling must not launch a duplicate network query")
     assert_contains(manager, "Shell.runAsync(\"idevice_id\", arguments: [\"-l\"], timeout: 5)", "routine USB discovery must be timeout bounded")
     assert_contains(manager, "Shell.runAsync(\"idevice_id\", arguments: [\"-n\"], timeout: 5)", "routine network discovery must be timeout bounded")
-    assert_contains(manager, "compatibilityOnlyDeviceEntries", "pymobiledevice-only devices must persist between compatibility scans")
-    assert_contains(manager, "compatibilityOnlyDeviceEntries = pyEntries.filter", "compatibility cache should exclude devices already covered by lightweight discovery")
-    assert_contains(manager, "lightweightScan.entries + compatibilityOnlyDeviceEntries", "every routine poll should merge cached compatibility-only devices")
+    assert_contains(manager, "compatibilityOnlyDeviceCache", "pymobiledevice-only devices must persist between compatibility scans")
+    assert_contains(manager, "currentCompatibilityEntries = pyEntries.filter", "compatibility cache should exclude devices already covered by lightweight discovery")
+    assert_contains(manager, "lightweightScan.entries + retainedEntries", "every routine poll should merge non-expired compatibility-only devices")
 
     # Pin the actual predicate and the merge expression. Asserting against a Python
     # restatement of the intended semantics stays green no matter what the Swift does.
     assert_contains(
         manager,
-        "compatibilityOnlyDeviceEntries = pyEntries.filter { !lightweightIDs.contains($0.udid) }",
+        "currentCompatibilityEntries = pyEntries.filter { !lightweightIDs.contains($0.udid) }",
         "the compatibility cache must keep the devices lightweight discovery MISSED, not the ones it already found",
     )
     # A failed idevice_id probe yields an empty UDID set, so the subtraction above is
     # a no-op and would cache every USB device as compatibility-only, republishing
     # them as duplicate rows for a full interval once the probe recovers.
     assert_contains(manager, "if lightweightScan.isAvailable {", "the compatibility cache may only be refreshed from a scan whose lightweight probe succeeded")
-    assert_contains(manager, "compatibilityOnlyDeviceEntries = []", "a failed lightweight probe must clear the compatibility cache instead of poisoning it")
-    assert_contains(manager, "discoveredEntries = mergeDeviceEntries(pyEntries)", "when the lightweight probe fails, the pymobiledevice snapshot is the whole picture for that poll")
-    # Date() here would hide pymobiledevice-only devices for the first full interval
-    # after launch, which is exactly what this discovery path promises to prevent.
-    assert_contains(manager, "lastCompatibilityDiscoveryAt = Date.distantPast", "the first poll after launch must run a compatibility scan, not wait out the interval")
+    assert_contains(manager, "compatibilityOnlyDeviceCache.reset()", "an authoritative full pymobiledevice snapshot must clear stale compatibility-only entries when lightweight discovery is unavailable")
+    assert_contains(manager, "pyEntries + retainedEntries", "a partial pymobiledevice failure must retain non-expired compatibility-only entries")
+    assert_contains(manager, "authoritative: pyDiscovery.isAuthoritative", "only an authoritative transport snapshot may delete cached compatibility-only entries")
+    assert_contains(manager, "regularInterval: compatibilityDiscoveryInterval", "a successful compatibility scan should restore the normal scan interval")
+    assert_contains(manager, "lastError = pyDiscovery.failureDescription", "a partial compatibility scan should be surfaced instead of masquerading as an empty result")
+    assert_contains(manager, "compatibilityDiscoveryRetry.isDue(at: scanStartedAt)", "the first poll should run immediately and later failures should honor retry backoff")
     assert_not_contains(manager, "isAvailable: usb.succeeded && network.succeeded", "requiring the -n probe to succeed disables the optimization on builds whose idevice_id rejects it")
 
 

--- a/Scripts/regression/checks/wifi_connection.py
+++ b/Scripts/regression/checks/wifi_connection.py
@@ -5,6 +5,130 @@ import tempfile
 from pathlib import Path
 
 
+def test_pymobiledevice_usbmux_discovery_is_timeout_bounded(root: Path) -> None:
+    source = (root / "Sources/Phosphor/Utilities/PyMobileDevice.swift").read_text()
+    discovery = source.split("static func listDevicesWithType()", 1)[1].split(
+        "static func listNetworkDeviceEntries()", 1
+    )[0]
+
+    assert 'runAsync(["usbmux", "list", "--usb"], timeout: 5)' in discovery, (
+        "a stalled USB compatibility probe must not freeze DeviceManager scanning for "
+        "PyMobileDevice.runAsync's five-minute default"
+    )
+    assert 'runAsync(["usbmux", "list", "--network"], timeout: 5)' in discovery, (
+        "network compatibility discovery must remain timeout bounded"
+    )
+    assert 'runAsync(["usbmux", "list"], timeout: 5)' in discovery, (
+        "the default usbmux fallback must not turn an empty compatibility scan into a "
+        "five-minute polling stall"
+    )
+
+
+def test_compatibility_cache_distinguishes_probe_failure_from_empty_scan(root: Path) -> None:
+    source = root / "Sources/Phosphor/Utilities/AuthoritativeSnapshotCache.swift"
+    probe = r'''
+import Foundation
+
+@main
+struct Probe {
+    static func main() {
+        var cache = AuthoritativeSnapshotCache<String>(maxStaleAge: 30, maxNonAuthoritativeMerges: 2)
+        let start = Date(timeIntervalSince1970: 1_000)
+
+        precondition(cache.merge(current: [(id: "wifi-a", value: "A1")], authoritative: true, now: start) == ["A1"])
+        precondition(cache.merge(current: [], authoritative: false, now: start.addingTimeInterval(10)) == ["A1"])
+        precondition(cache.merge(current: [(id: "wifi-a", value: "A2"), (id: "wifi-b", value: "B")], authoritative: false, now: start.addingTimeInterval(20)) == ["A2", "B"])
+        precondition(cache.merge(current: [], authoritative: false, now: start.addingTimeInterval(21)).isEmpty)
+        precondition(cache.merge(current: [(id: "wifi-b", value: "B2")], authoritative: true, now: start.addingTimeInterval(40)) == ["B2"])
+        precondition(cache.merge(current: [], authoritative: true, now: start.addingTimeInterval(41)).isEmpty)
+
+        var ageBounded = AuthoritativeSnapshotCache<String>(maxStaleAge: 30, maxNonAuthoritativeMerges: 10)
+        precondition(ageBounded.merge(current: [(id: "wifi-a", value: "A")], authoritative: true, now: start) == ["A"])
+        precondition(ageBounded.merge(current: [], authoritative: false, now: start.addingTimeInterval(31)).isEmpty)
+    }
+}
+'''
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp = Path(temp_dir)
+        probe_path = temp / "Probe.swift"
+        probe_path.write_text(probe)
+        executable = temp / "authoritative-snapshot-probe"
+        compile_result = subprocess.run(
+            ["swiftc", "-parse-as-library", str(source), str(probe_path), "-o", str(executable)],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        assert compile_result.returncode == 0, compile_result.stderr
+        result = subprocess.run([str(executable)], capture_output=True, text=True, timeout=10)
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_partial_discovery_uses_bounded_retry_backoff(root: Path) -> None:
+    source = root / "Sources/Phosphor/Utilities/DiscoveryRetryBackoff.swift"
+    probe = r'''
+import Foundation
+
+@main
+struct Probe {
+    static func main() {
+        let start = Date(timeIntervalSince1970: 1_000)
+        var retry = DiscoveryRetryBackoff(initialDelay: 5, maximumDelay: 30)
+        precondition(retry.isDue(at: start))
+        retry.recordFailure(at: start)
+        precondition(!retry.isDue(at: start.addingTimeInterval(4)))
+        precondition(retry.isDue(at: start.addingTimeInterval(5)))
+        retry.recordFailure(at: start.addingTimeInterval(5))
+        precondition(!retry.isDue(at: start.addingTimeInterval(14)))
+        precondition(retry.isDue(at: start.addingTimeInterval(15)))
+        retry.recordSuccess(at: start.addingTimeInterval(15), regularInterval: 30)
+        precondition(!retry.isDue(at: start.addingTimeInterval(44)))
+        precondition(retry.isDue(at: start.addingTimeInterval(45)))
+    }
+}
+'''
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp = Path(temp_dir)
+        probe_path = temp / "Probe.swift"
+        probe_path.write_text(probe)
+        executable = temp / "discovery-retry-probe"
+        compile_result = subprocess.run(
+            ["swiftc", "-parse-as-library", str(source), str(probe_path), "-o", str(executable)],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        assert compile_result.returncode == 0, compile_result.stderr
+        result = subprocess.run([str(executable)], capture_output=True, text=True, timeout=10)
+
+    assert result.returncode == 0, result.stderr
+    manager = (root / "Sources/Phosphor/Services/DeviceManager.swift").read_text()
+    assert "compatibilityDiscoveryRetry.isDue(at: scanStartedAt)" in manager
+    assert "compatibilityDiscoveryRetry.recordFailure(at: discoveryCompletedAt)" in manager
+
+
+def test_non_authoritative_fallback_cannot_fabricate_usb_transport(root: Path) -> None:
+    pymobiledevice = (root / "Sources/Phosphor/Utilities/PyMobileDevice.swift").read_text()
+    manager = (root / "Sources/Phosphor/Services/DeviceManager.swift").read_text()
+
+    assert 'defaultConnectionType: "Unknown"' in pymobiledevice
+    assert '$0.connectionType == "USB" || $0.connectionType == "Network"' in manager
+    assert 'discoveredEntries.filter { $0.connectionType == "USB" }' in manager
+    assert "retainedCompatibilityDeviceIDs.contains(entry.udid)" in manager
+    assert "if !forceRefresh," in manager
+    assert "(!forceRefresh || compatibilityProbeFailed)" not in manager
+    assert "current: []," in manager and "now: discoveryCompletedAt" in manager
+    skipped_probe = manager.split("} else {\n            // Skipping an expensive probe", 1)[1].split("let visibleUDIDs", 1)[0]
+    assert "compatibilityOnlyDeviceCache.values" in skipped_probe
+    assert "compatibilityOnlyDeviceCache.merge" not in skipped_probe, (
+        "routine lightweight polls must not consume the stale-entry failure budget"
+    )
+    assert "compatibilityDiscoveryRetry.consecutiveFailures == 0" in manager
+
+
 def test_network_device_grace_cache_absorbs_one_missed_poll(root: Path) -> None:
     source = root / "Sources/Phosphor/Utilities/NetworkDeviceGraceCache.swift"
     probe = r'''

--- a/Scripts/regression/checks/wifi_connection.py
+++ b/Scripts/regression/checks/wifi_connection.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+def test_network_device_grace_cache_absorbs_one_missed_poll(root: Path) -> None:
+    source = root / "Sources/Phosphor/Utilities/NetworkDeviceGraceCache.swift"
+    probe = r'''
+import Foundation
+
+@main
+struct Probe {
+    static func main() {
+        var cache = NetworkDeviceGraceCache<String>(maxMissedScans: 1)
+
+        precondition(cache.merge(current: [(id: "wifi-a", value: "first")]) == ["first"])
+        precondition(cache.merge(current: []) == ["first"])
+        precondition(cache.merge(current: [(id: "wifi-a", value: "refreshed")]) == ["refreshed"])
+        precondition(cache.merge(current: []) == ["refreshed"])
+        precondition(cache.merge(current: []).isEmpty)
+
+        precondition(cache.merge(current: [(id: "wifi-a", value: "wireless")]) == ["wireless"])
+        cache.remove(ids: ["wifi-a"])
+        precondition(cache.merge(current: []).isEmpty)
+    }
+}
+'''
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp = Path(temp_dir)
+        probe_path = temp / "Probe.swift"
+        probe_path.write_text(probe)
+        executable = temp / "network-grace-probe"
+        compile_result = subprocess.run(
+            ["swiftc", "-parse-as-library", str(source), str(probe_path), "-o", str(executable)],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        assert compile_result.returncode == 0, compile_result.stderr
+        result = subprocess.run([str(executable)], capture_output=True, text=True, timeout=10)
+
+    assert result.returncode == 0, result.stderr
+
+    manager = (root / "Sources/Phosphor/Services/DeviceManager.swift").read_text()
+    assert "NetworkDeviceGraceCache<DeviceInfo>" in manager, "the grace cache must retain rendered device snapshots, not entries that still require a failing metadata fetch"
+    assert "stableNetworkDevices" in manager, "DeviceManager must merge retained DeviceInfo snapshots into the published device list"
+    assert 'discoveredEntries.filter { $0.connectionType == "USB" }.map(\.udid)' in manager, "USB discovery must evict a stale Wi-Fi snapshot even when USB metadata fetching fails"
+
+
+def test_network_device_grace_cache_preserves_discovery_order(root: Path) -> None:
+    source = root / "Sources/Phosphor/Utilities/NetworkDeviceGraceCache.swift"
+    probe = r'''
+import Foundation
+
+@main
+struct Probe {
+    static func main() {
+        var cache = NetworkDeviceGraceCache<String>(maxMissedScans: 1)
+
+        let first = cache.merge(current: [(id: "wifi-b", value: "B"), (id: "wifi-a", value: "A")])
+        precondition(first == ["B", "A"])
+        precondition(cache.merge(current: []) == ["B", "A"])
+    }
+}
+'''
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp = Path(temp_dir)
+        probe_path = temp / "Probe.swift"
+        probe_path.write_text(probe)
+        executable = temp / "network-grace-order-probe"
+        compile_result = subprocess.run(
+            ["swiftc", "-parse-as-library", str(source), str(probe_path), "-o", str(executable)],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        assert compile_result.returncode == 0, compile_result.stderr
+        result = subprocess.run([str(executable)], capture_output=True, text=True, timeout=10)
+
+    assert result.returncode == 0, result.stderr

--- a/Scripts/regression/checks/wifi_connection.py
+++ b/Scripts/regression/checks/wifi_connection.py
@@ -24,6 +24,43 @@ def test_pymobiledevice_usbmux_discovery_is_timeout_bounded(root: Path) -> None:
     )
 
 
+def test_usbmux_connection_type_does_not_invent_transport(root: Path) -> None:
+    source = root / "Sources/Phosphor/Utilities/UsbmuxConnectionType.swift"
+    pymobiledevice = (root / "Sources/Phosphor/Utilities/PyMobileDevice.swift").read_text()
+    probe = r'''
+import Foundation
+
+@main
+struct Probe {
+    static func main() {
+        precondition(UsbmuxConnectionType.normalize(nil, default: "Unknown") == "Unknown")
+        precondition(UsbmuxConnectionType.normalize("Unknown", default: "Unknown") == "Unknown")
+        precondition(UsbmuxConnectionType.normalize("USB", default: "Unknown") == "USB")
+        precondition(UsbmuxConnectionType.normalize("1", default: "Unknown") == "USB")
+        precondition(UsbmuxConnectionType.normalize("Network", default: "Unknown") == "Network")
+        precondition(UsbmuxConnectionType.normalize("Wi-Fi", default: "Unknown") == "Network")
+        precondition(UsbmuxConnectionType.normalize("2", default: "Unknown") == "Network")
+    }
+}
+'''
+    with tempfile.TemporaryDirectory() as tmp:
+        probe_path = Path(tmp) / "probe.swift"
+        binary_path = Path(tmp) / "probe"
+        probe_path.write_text(probe)
+        result = subprocess.run(
+            ["swiftc", "-parse-as-library", str(source), str(probe_path), "-o", str(binary_path)],
+            cwd=root,
+            capture_output=True,
+            text=True,
+            timeout=120,
+        )
+        assert result.returncode == 0, result.stderr
+        result = subprocess.run([str(binary_path)], capture_output=True, text=True, timeout=30)
+        assert result.returncode == 0, result.stderr
+
+    assert "UsbmuxConnectionType.normalize" in pymobiledevice
+
+
 def test_compatibility_cache_distinguishes_probe_failure_from_empty_scan(root: Path) -> None:
     source = root / "Sources/Phosphor/Utilities/AuthoritativeSnapshotCache.swift"
     probe = r'''
@@ -44,7 +81,14 @@ struct Probe {
 
         var ageBounded = AuthoritativeSnapshotCache<String>(maxStaleAge: 30, maxNonAuthoritativeMerges: 10)
         precondition(ageBounded.merge(current: [(id: "wifi-a", value: "A")], authoritative: true, now: start) == ["A"])
-        precondition(ageBounded.merge(current: [], authoritative: false, now: start.addingTimeInterval(31)).isEmpty)
+        precondition(ageBounded.retainedValues(now: start.addingTimeInterval(31)).isEmpty)
+
+        var skippedPolls = AuthoritativeSnapshotCache<String>(maxStaleAge: 30, maxNonAuthoritativeMerges: 1)
+        precondition(skippedPolls.merge(current: [(id: "wifi-a", value: "A")], authoritative: true, now: start) == ["A"])
+        for _ in 0..<100 {
+            precondition(skippedPolls.retainedValues(now: start.addingTimeInterval(10)) == ["A"])
+        }
+        precondition(skippedPolls.merge(current: [], authoritative: false, now: start.addingTimeInterval(20)) == ["A"])
     }
 }
 '''
@@ -115,6 +159,7 @@ def test_non_authoritative_fallback_cannot_fabricate_usb_transport(root: Path) -
     manager = (root / "Sources/Phosphor/Services/DeviceManager.swift").read_text()
 
     assert 'defaultConnectionType: "Unknown"' in pymobiledevice
+    assert "UsbmuxConnectionType.normalize" in pymobiledevice
     assert '$0.connectionType == "USB" || $0.connectionType == "Network"' in manager
     assert 'discoveredEntries.filter { $0.connectionType == "USB" }' in manager
     assert "retainedCompatibilityDeviceIDs.contains(entry.udid)" in manager
@@ -122,12 +167,11 @@ def test_non_authoritative_fallback_cannot_fabricate_usb_transport(root: Path) -
     assert "(!forceRefresh || compatibilityProbeFailed)" not in manager
     assert "current: []," in manager and "now: discoveryCompletedAt" in manager
     skipped_probe = manager.split("} else {\n            // Skipping an expensive probe", 1)[1].split("let visibleUDIDs", 1)[0]
-    assert "compatibilityOnlyDeviceCache.values" in skipped_probe
+    assert "compatibilityOnlyDeviceCache.retainedValues(now: scanStartedAt)" in skipped_probe
     assert "compatibilityOnlyDeviceCache.merge" not in skipped_probe, (
         "routine lightweight polls must not consume the stale-entry failure budget"
     )
     assert "compatibilityDiscoveryRetry.consecutiveFailures == 0" in manager
-
 
 def test_network_device_grace_cache_absorbs_one_missed_poll(root: Path) -> None:
     source = root / "Sources/Phosphor/Utilities/NetworkDeviceGraceCache.swift"

--- a/Sources/Phosphor/Services/DeviceManager.swift
+++ b/Sources/Phosphor/Services/DeviceManager.swift
@@ -18,17 +18,15 @@ final class DeviceManager: ObservableObject {
     private var batteryInfoCache: [String: (info: [String: String], fetchedAt: Date)] = [:]
     private var pairStatusCache: [String: (isPaired: Bool, fetchedAt: Date)] = [:]
     private var bonjourDeviceCache: (devices: [PyMobileDevice.BonjourDevice], fetchedAt: Date)?
-    private var compatibilityOnlyDeviceEntries: [PyMobileDevice.DeviceEntry] = []
+    private var compatibilityOnlyDeviceCache = AuthoritativeSnapshotCache<PyMobileDevice.DeviceEntry>()
     private var networkDeviceGraceCache = NetworkDeviceGraceCache<DeviceInfo>(maxMissedScans: 1)
-    // distantPast, not Date(): the first poll after launch has to run the
-    // pymobiledevice3 scan, otherwise a device only it can enumerate stays
-    // invisible for the whole first compatibility interval.
-    private var lastCompatibilityDiscoveryAt = Date.distantPast
+    private var compatibilityDiscoveryRetry = DiscoveryRetryBackoff(initialDelay: 5, maximumDelay: 30)
+    private let compatibilityDiscoveryInterval: TimeInterval = 30
     private let deviceInfoRefreshInterval: TimeInterval = 30
     private let batteryInfoRefreshInterval: TimeInterval = 60
     private let pairStatusRefreshInterval: TimeInterval = 120
     private let bonjourDeviceRefreshInterval: TimeInterval = 30
-    private let compatibilityDiscoveryInterval: TimeInterval = 30
+
 
     // MARK: - Dependency Check
 
@@ -57,7 +55,9 @@ final class DeviceManager: ObservableObject {
             }
         }
         isScanning = true
-        lastError = nil
+        if forceRefresh || compatibilityDiscoveryRetry.consecutiveFailures == 0 {
+            lastError = nil
+        }
         defer { isScanning = false }
 
         // Routine polling uses libimobiledevice discovery because it is a tiny
@@ -65,25 +65,79 @@ final class DeviceManager: ObservableObject {
         // substantially more CPU. Explicit refreshes and systems without both
         // idevice_id transports retain the full pymobiledevice3 compatibility path.
         let lightweightScan = await listLibimobiledeviceEntries()
-        let compatibilityScanIsDue = Date().timeIntervalSince(lastCompatibilityDiscoveryAt) >= compatibilityDiscoveryInterval
+        let scanStartedAt = Date()
+        let compatibilityScanIsDue = compatibilityDiscoveryRetry.isDue(at: scanStartedAt)
         let discoveredEntries: [PyMobileDevice.DeviceEntry]
-        if forceRefresh || !lightweightScan.isAvailable || compatibilityScanIsDue {
-            lastCompatibilityDiscoveryAt = Date()
-            let pyEntries = await PyMobileDevice.listDevicesWithType()
+        var compatibilityProbeFailed = false
+        var retainedCompatibilityDeviceIDs: Set<String> = []
+        if forceRefresh || compatibilityScanIsDue {
+            let pyDiscovery = await PyMobileDevice.discoverDevicesWithType()
+            let discoveryCompletedAt = Date()
+            // A default fallback without ConnectionType is useful as a hint but
+            // cannot safely change a known Wi-Fi device into USB. Only explicit
+            // transport observations may enter the rendered/cache snapshot.
+            let pyEntries = pyDiscovery.entries.filter {
+                $0.connectionType == "USB" || $0.connectionType == "Network"
+            }
+            compatibilityProbeFailed = !pyDiscovery.isAuthoritative
+            if pyDiscovery.isAuthoritative {
+                lastError = nil
+                compatibilityDiscoveryRetry.recordSuccess(
+                    at: discoveryCompletedAt,
+                    regularInterval: compatibilityDiscoveryInterval
+                )
+            } else {
+                compatibilityDiscoveryRetry.recordFailure(at: discoveryCompletedAt)
+                lastError = pyDiscovery.failureDescription
+            }
+
             if lightweightScan.isAvailable {
                 let lightweightIDs = Set(lightweightScan.entries.map(\.udid))
-                compatibilityOnlyDeviceEntries = pyEntries.filter { !lightweightIDs.contains($0.udid) }
-                discoveredEntries = mergeDeviceEntries(lightweightScan.entries + compatibilityOnlyDeviceEntries)
+                let currentCompatibilityEntries = pyEntries.filter { !lightweightIDs.contains($0.udid) }
+                let cachedCompatibilityIDs = Set(compatibilityOnlyDeviceCache.values.map(\.udid))
+                let compatibilityEntries = compatibilityOnlyDeviceCache.merge(
+                    current: currentCompatibilityEntries.map { (id: $0.udid, value: $0) },
+                    authoritative: pyDiscovery.isAuthoritative,
+                    now: discoveryCompletedAt
+                )
+                if compatibilityProbeFailed {
+                    let directlyObservedIDs = lightweightIDs.union(pyEntries.map(\.udid))
+                    retainedCompatibilityDeviceIDs = Set(compatibilityEntries.map(\.udid))
+                        .intersection(cachedCompatibilityIDs)
+                        .subtracting(directlyObservedIDs)
+                }
+                discoveredEntries = mergeDeviceEntries(lightweightScan.entries + compatibilityEntries)
             } else {
                 // The probe failed, so its UDID set is empty and cannot subtract
                 // duplicates. pyEntries is already the whole picture for this poll;
                 // caching it as compatibility-only would republish every USB device
                 // as a phantom row for the next 30s once the probe recovers.
-                compatibilityOnlyDeviceEntries = []
-                discoveredEntries = mergeDeviceEntries(pyEntries)
+                if pyDiscovery.isAuthoritative {
+                    compatibilityOnlyDeviceCache.reset()
+                    discoveredEntries = mergeDeviceEntries(pyEntries)
+                } else {
+                    let cachedCompatibilityIDs = Set(compatibilityOnlyDeviceCache.values.map(\.udid))
+                    let retainedEntries = compatibilityOnlyDeviceCache.merge(
+                        current: [],
+                        authoritative: false,
+                        now: discoveryCompletedAt
+                    )
+                    retainedCompatibilityDeviceIDs = Set(retainedEntries.map(\.udid))
+                        .intersection(cachedCompatibilityIDs)
+                        .subtracting(pyEntries.map(\.udid))
+                    discoveredEntries = mergeDeviceEntries(pyEntries + retainedEntries)
+                }
             }
         } else {
-            discoveredEntries = mergeDeviceEntries(lightweightScan.entries + compatibilityOnlyDeviceEntries)
+            // Skipping an expensive probe during its normal interval/backoff is
+            // not another failed discovery. Do not consume the cache's failure
+            // budget on every lightweight UI poll.
+            let retainedEntries = compatibilityOnlyDeviceCache.values
+            if compatibilityDiscoveryRetry.consecutiveFailures > 0 {
+                retainedCompatibilityDeviceIDs = Set(retainedEntries.map(\.udid))
+                    .subtracting(lightweightScan.entries.map(\.udid))
+            }
+            discoveredEntries = mergeDeviceEntries(lightweightScan.entries + retainedEntries)
         }
 
         let visibleUDIDs = Set(discoveredEntries.map(\.udid))
@@ -94,7 +148,14 @@ final class DeviceManager: ObservableObject {
         var currentDevices: [DeviceInfo] = []
         for entry in discoveredEntries {
             let connType: DeviceInfo.ConnectionType = entry.connectionType == "USB" ? .usb : .wifi
-            if !forceRefresh, let cached = cachedDevice(udid: entry.udid, connectionType: connType) {
+            if retainedCompatibilityDeviceIDs.contains(entry.udid),
+               var cached = deviceInfoCache[entry.udid]?.device {
+                cached.connectionType = connType
+                currentDevices.append(cached)
+                continue
+            }
+            if !forceRefresh,
+               let cached = cachedDevice(udid: entry.udid, connectionType: connType) {
                 currentDevices.append(cached)
                 continue
             }
@@ -113,9 +174,10 @@ final class DeviceManager: ObservableObject {
         // A Wi-Fi device can vanish from usbmux or fail a metadata query for one
         // poll while iOS changes power or network state. Retain the last rendered
         // network snapshot through one routine miss so the selected row does not
-        // flicker every four seconds. USB devices still disappear immediately, and
-        // an explicit refresh bypasses the grace period.
-        if forceRefresh { networkDeviceGraceCache.reset() }
+        // flicker every four seconds. USB devices still disappear immediately. An
+        // explicit refresh bypasses grace after an authoritative scan, but a probe
+        // failure cannot be misreported as an authoritative disconnect.
+        if forceRefresh && !compatibilityProbeFailed { networkDeviceGraceCache.reset() }
         let currentUSBDeviceIDs = Set(
             discoveredEntries.filter { $0.connectionType == "USB" }.map(\.udid)
         )

--- a/Sources/Phosphor/Services/DeviceManager.swift
+++ b/Sources/Phosphor/Services/DeviceManager.swift
@@ -132,7 +132,7 @@ final class DeviceManager: ObservableObject {
             // Skipping an expensive probe during its normal interval/backoff is
             // not another failed discovery. Do not consume the cache's failure
             // budget on every lightweight UI poll.
-            let retainedEntries = compatibilityOnlyDeviceCache.values
+            let retainedEntries = compatibilityOnlyDeviceCache.retainedValues(now: scanStartedAt)
             if compatibilityDiscoveryRetry.consecutiveFailures > 0 {
                 retainedCompatibilityDeviceIDs = Set(retainedEntries.map(\.udid))
                     .subtracting(lightweightScan.entries.map(\.udid))

--- a/Sources/Phosphor/Services/DeviceManager.swift
+++ b/Sources/Phosphor/Services/DeviceManager.swift
@@ -19,6 +19,7 @@ final class DeviceManager: ObservableObject {
     private var pairStatusCache: [String: (isPaired: Bool, fetchedAt: Date)] = [:]
     private var bonjourDeviceCache: (devices: [PyMobileDevice.BonjourDevice], fetchedAt: Date)?
     private var compatibilityOnlyDeviceEntries: [PyMobileDevice.DeviceEntry] = []
+    private var networkDeviceGraceCache = NetworkDeviceGraceCache<DeviceInfo>(maxMissedScans: 1)
     // distantPast, not Date(): the first poll after launch has to run the
     // pymobiledevice3 scan, otherwise a device only it can enumerate stays
     // invisible for the whole first compatibility interval.
@@ -65,49 +66,36 @@ final class DeviceManager: ObservableObject {
         // idevice_id transports retain the full pymobiledevice3 compatibility path.
         let lightweightScan = await listLibimobiledeviceEntries()
         let compatibilityScanIsDue = Date().timeIntervalSince(lastCompatibilityDiscoveryAt) >= compatibilityDiscoveryInterval
-        let entries: [PyMobileDevice.DeviceEntry]
+        let discoveredEntries: [PyMobileDevice.DeviceEntry]
         if forceRefresh || !lightweightScan.isAvailable || compatibilityScanIsDue {
             lastCompatibilityDiscoveryAt = Date()
             let pyEntries = await PyMobileDevice.listDevicesWithType()
             if lightweightScan.isAvailable {
                 let lightweightIDs = Set(lightweightScan.entries.map(\.udid))
                 compatibilityOnlyDeviceEntries = pyEntries.filter { !lightweightIDs.contains($0.udid) }
-                entries = mergeDeviceEntries(lightweightScan.entries + compatibilityOnlyDeviceEntries)
+                discoveredEntries = mergeDeviceEntries(lightweightScan.entries + compatibilityOnlyDeviceEntries)
             } else {
                 // The probe failed, so its UDID set is empty and cannot subtract
                 // duplicates. pyEntries is already the whole picture for this poll;
                 // caching it as compatibility-only would republish every USB device
                 // as a phantom row for the next 30s once the probe recovers.
                 compatibilityOnlyDeviceEntries = []
-                entries = mergeDeviceEntries(pyEntries)
+                discoveredEntries = mergeDeviceEntries(pyEntries)
             }
         } else {
-            entries = mergeDeviceEntries(lightweightScan.entries + compatibilityOnlyDeviceEntries)
+            discoveredEntries = mergeDeviceEntries(lightweightScan.entries + compatibilityOnlyDeviceEntries)
         }
 
-        if entries.isEmpty {
-            let bonjourDevices = await cachedBonjourDevices(forceRefresh: forceRefresh)
-            connectedDevices = []
-            nearbyWirelessDevices = bonjourDevices
-            selectedDevice = nil
-            deviceInfoCache.removeAll()
-            batteryInfoCache.removeAll()
-            pairStatusCache.removeAll()
-            return
-        }
-
-        nearbyWirelessDevices = []
-
-        let visibleUDIDs = Set(entries.map(\.udid))
+        let visibleUDIDs = Set(discoveredEntries.map(\.udid))
         deviceInfoCache = deviceInfoCache.filter { visibleUDIDs.contains($0.key) }
         batteryInfoCache = batteryInfoCache.filter { visibleUDIDs.contains($0.key) }
         pairStatusCache = pairStatusCache.filter { visibleUDIDs.contains($0.key) }
 
-        var devices: [DeviceInfo] = []
-        for entry in entries {
+        var currentDevices: [DeviceInfo] = []
+        for entry in discoveredEntries {
             let connType: DeviceInfo.ConnectionType = entry.connectionType == "USB" ? .usb : .wifi
             if !forceRefresh, let cached = cachedDevice(udid: entry.udid, connectionType: connType) {
-                devices.append(cached)
+                currentDevices.append(cached)
                 continue
             }
             if var device = await fetchDeviceInfo(
@@ -118,10 +106,37 @@ final class DeviceManager: ObservableObject {
             ) {
                 device.connectionType = connType
                 deviceInfoCache[entry.udid] = (device, Date())
-                devices.append(device)
+                currentDevices.append(device)
             }
         }
 
+        // A Wi-Fi device can vanish from usbmux or fail a metadata query for one
+        // poll while iOS changes power or network state. Retain the last rendered
+        // network snapshot through one routine miss so the selected row does not
+        // flicker every four seconds. USB devices still disappear immediately, and
+        // an explicit refresh bypasses the grace period.
+        if forceRefresh { networkDeviceGraceCache.reset() }
+        let currentUSBDeviceIDs = Set(
+            discoveredEntries.filter { $0.connectionType == "USB" }.map(\.udid)
+        )
+        networkDeviceGraceCache.remove(ids: currentUSBDeviceIDs)
+        let currentNetworkDevices = currentDevices
+            .filter { $0.connectionType == .wifi }
+            .map { (id: $0.id, value: $0) }
+        let stableNetworkDevices = networkDeviceGraceCache.merge(current: currentNetworkDevices)
+        let devices = currentDevices.filter { $0.connectionType == .usb } + stableNetworkDevices
+
+        if devices.isEmpty {
+            nearbyWirelessDevices = await cachedBonjourDevices(forceRefresh: forceRefresh)
+            connectedDevices = []
+            selectedDevice = nil
+            deviceInfoCache.removeAll()
+            batteryInfoCache.removeAll()
+            pairStatusCache.removeAll()
+            return
+        }
+
+        nearbyWirelessDevices = []
         connectedDevices = devices
         if let selectedID = selectedDevice?.id,
            let refreshedSelection = devices.first(where: { $0.id == selectedID }) {

--- a/Sources/Phosphor/Utilities/AuthoritativeSnapshotCache.swift
+++ b/Sources/Phosphor/Utilities/AuthoritativeSnapshotCache.swift
@@ -1,0 +1,65 @@
+import Foundation
+
+/// Retains the last authoritative discovery snapshot across transient probe failures.
+///
+/// Successful scans replace the snapshot exactly, including with an empty result.
+/// Failed or timed-out scans may refresh/add values they did observe, but cannot
+/// immediately delete values merely because the incomplete scan omitted them.
+/// The retention window is bounded so a permanently broken compatibility probe
+/// cannot publish a disconnected device forever.
+struct AuthoritativeSnapshotCache<Value> {
+    private let maxStaleAge: TimeInterval
+    private let maxNonAuthoritativeMerges: Int
+    private var valuesByID: [String: Value] = [:]
+    private var orderedIDs: [String] = []
+    private var lastAuthoritativeSnapshotAt: Date?
+    private var consecutiveNonAuthoritativeMerges = 0
+
+    init(maxStaleAge: TimeInterval = 30, maxNonAuthoritativeMerges: Int = 3) {
+        self.maxStaleAge = max(0, maxStaleAge)
+        self.maxNonAuthoritativeMerges = max(0, maxNonAuthoritativeMerges)
+    }
+
+    var values: [Value] {
+        orderedIDs.compactMap { valuesByID[$0] }
+    }
+
+    mutating func merge(
+        current: [(id: String, value: Value)],
+        authoritative: Bool,
+        now: Date = Date()
+    ) -> [Value] {
+        if authoritative {
+            consecutiveNonAuthoritativeMerges = 0
+        } else {
+            consecutiveNonAuthoritativeMerges += 1
+        }
+        let canRetainPrevious = consecutiveNonAuthoritativeMerges <= maxNonAuthoritativeMerges
+            && (lastAuthoritativeSnapshotAt.map {
+                now.timeIntervalSince($0) <= maxStaleAge
+            } ?? false)
+        if authoritative || !canRetainPrevious {
+            valuesByID.removeAll(keepingCapacity: true)
+            orderedIDs.removeAll(keepingCapacity: true)
+        }
+        if authoritative {
+            lastAuthoritativeSnapshotAt = now
+        }
+
+        for (id, value) in current {
+            if valuesByID[id] == nil {
+                orderedIDs.append(id)
+            }
+            valuesByID[id] = value
+        }
+
+        return values
+    }
+
+    mutating func reset() {
+        valuesByID.removeAll()
+        orderedIDs.removeAll()
+        lastAuthoritativeSnapshotAt = nil
+        consecutiveNonAuthoritativeMerges = 0
+    }
+}

--- a/Sources/Phosphor/Utilities/AuthoritativeSnapshotCache.swift
+++ b/Sources/Phosphor/Utilities/AuthoritativeSnapshotCache.swift
@@ -24,6 +24,18 @@ struct AuthoritativeSnapshotCache<Value> {
         orderedIDs.compactMap { valuesByID[$0] }
     }
 
+    /// Returns the retained snapshot without counting a skipped routine poll as
+    /// another failed discovery. Expired entries are removed immediately even
+    /// while the expensive compatibility probe is in backoff.
+    mutating func retainedValues(now: Date = Date()) -> [Value] {
+        guard let lastAuthoritativeSnapshotAt,
+              now.timeIntervalSince(lastAuthoritativeSnapshotAt) <= maxStaleAge else {
+            reset()
+            return []
+        }
+        return values
+    }
+
     mutating func merge(
         current: [(id: String, value: Value)],
         authoritative: Bool,

--- a/Sources/Phosphor/Utilities/DiscoveryRetryBackoff.swift
+++ b/Sources/Phosphor/Utilities/DiscoveryRetryBackoff.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+/// Schedules compatibility discovery retries without spawning helper processes on every UI poll.
+struct DiscoveryRetryBackoff {
+    private let initialDelay: TimeInterval
+    private let maximumDelay: TimeInterval
+    private(set) var consecutiveFailures = 0
+    private(set) var nextAttemptAt = Date.distantPast
+
+    init(initialDelay: TimeInterval = 5, maximumDelay: TimeInterval = 120) {
+        self.initialDelay = max(0, initialDelay)
+        self.maximumDelay = max(self.initialDelay, maximumDelay)
+    }
+
+    func isDue(at date: Date = Date()) -> Bool {
+        date >= nextAttemptAt
+    }
+
+    mutating func recordSuccess(at date: Date = Date(), regularInterval: TimeInterval) {
+        consecutiveFailures = 0
+        nextAttemptAt = date.addingTimeInterval(max(0, regularInterval))
+    }
+
+    mutating func recordFailure(at date: Date = Date()) {
+        consecutiveFailures = min(consecutiveFailures + 1, 30)
+        let exponent = min(consecutiveFailures - 1, 20)
+        let delay = min(initialDelay * pow(2, Double(exponent)), maximumDelay)
+        nextAttemptAt = date.addingTimeInterval(delay)
+    }
+}

--- a/Sources/Phosphor/Utilities/NetworkDeviceGraceCache.swift
+++ b/Sources/Phosphor/Utilities/NetworkDeviceGraceCache.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+/// Keeps transiently missing values visible for a small number of discovery polls.
+///
+/// Wireless usbmux devices can disappear for one poll while iOS changes power or
+/// network state. Callers provide only currently observed values; this cache returns
+/// recently observed values until they exceed the configured missed-scan budget.
+struct NetworkDeviceGraceCache<Value> {
+    private struct Entry {
+        var value: Value
+        var missedScans: Int
+    }
+
+    private let maxMissedScans: Int
+    private var entries: [String: Entry] = [:]
+    private var orderedIDs: [String] = []
+
+    init(maxMissedScans: Int) {
+        precondition(maxMissedScans >= 0)
+        self.maxMissedScans = maxMissedScans
+    }
+
+    mutating func merge(current: [(id: String, value: Value)]) -> [Value] {
+        let currentIDs = Set(current.map(\.id))
+        for (id, value) in current {
+            if entries[id] == nil { orderedIDs.append(id) }
+            entries[id] = Entry(value: value, missedScans: 0)
+        }
+
+        for id in orderedIDs where !currentIDs.contains(id) {
+            guard var entry = entries[id] else { continue }
+            entry.missedScans += 1
+            if entry.missedScans > maxMissedScans {
+                entries.removeValue(forKey: id)
+            } else {
+                entries[id] = entry
+            }
+        }
+        orderedIDs.removeAll { entries[$0] == nil }
+
+        return orderedIDs.compactMap { entries[$0]?.value }
+    }
+
+    mutating func remove(ids: Set<String>) {
+        guard !ids.isEmpty else { return }
+        for id in ids { entries.removeValue(forKey: id) }
+        orderedIDs.removeAll { ids.contains($0) }
+    }
+
+    mutating func reset() {
+        entries.removeAll()
+        orderedIDs.removeAll()
+    }
+}

--- a/Sources/Phosphor/Utilities/PyMobileDevice.swift
+++ b/Sources/Phosphor/Utilities/PyMobileDevice.swift
@@ -385,9 +385,10 @@ enum PyMobileDevice {
                         ?? entry["SerialNumber"] as? String else { continue }
                 let connType = (entry["ConnectionType"] as? String)
                     ?? (entry["Properties"] as? [String: Any])?["ConnectionType"] as? String
-                    ?? defaultConnectionType
-                let isUSB = connType.lowercased().contains("usb") || connType == "1"
-                let type = isUSB ? "USB" : "Network"
+                let type = UsbmuxConnectionType.normalize(
+                    connType,
+                    default: defaultConnectionType
+                )
 
                 if byUdid[udid] == nil { orderedUdids.append(udid) }
                 if byUdid[udid]?.connectionType != "USB" || type == "USB" {

--- a/Sources/Phosphor/Utilities/PyMobileDevice.swift
+++ b/Sources/Phosphor/Utilities/PyMobileDevice.swift
@@ -217,6 +217,28 @@ enum PyMobileDevice {
         }
     }
 
+    struct DeviceDiscoveryResult {
+        let entries: [DeviceEntry]
+        let usbProbeSucceeded: Bool
+        let networkProbeSucceeded: Bool
+        let fallbackProbeSucceeded: Bool?
+
+        /// Only transport-specific probes can prove an omitted device is absent.
+        /// The default fallback helps older pymobiledevice3 versions, but is not
+        /// an authoritative transport snapshot.
+        var isAuthoritative: Bool {
+            usbProbeSucceeded && networkProbeSucceeded
+        }
+
+        var failureDescription: String? {
+            guard !isAuthoritative else { return nil }
+            var failed: [String] = []
+            if !usbProbeSucceeded { failed.append("USB") }
+            if !networkProbeSucceeded { failed.append("Wi-Fi") }
+            return "pymobiledevice3 \(failed.joined(separator: " and ")) discovery failed; showing the last known compatible devices and retrying."
+        }
+    }
+
     struct BonjourDevice: Hashable {
         let id: String
         let name: String
@@ -231,8 +253,20 @@ enum PyMobileDevice {
     /// omit ConnectionType there, which can make paired Wi-Fi devices disappear
     /// or be misclassified as USB.
     static func listDevicesWithType() async -> [DeviceEntry] {
-        async let usbResult = runAsync(["usbmux", "list", "--usb"])
-        async let networkResult = runAsync(["usbmux", "list", "--network"], timeout: 10)
+        await discoverDevicesWithType().entries.filter {
+            $0.connectionType == "USB" || $0.connectionType == "Network"
+        }
+    }
+
+    /// Return both entries and probe authority so callers do not collapse a
+    /// timeout or tool failure into an authoritative empty snapshot.
+    static func discoverDevicesWithType() async -> DeviceDiscoveryResult {
+        // Discovery runs inside DeviceManager's recurring scan. Keep every
+        // branch bounded so one wedged pymobiledevice3 process cannot leave
+        // isScanning set for runAsync's five-minute default and suppress all
+        // routine polls or an explicit Refresh Devices action in the meantime.
+        async let usbResult = runAsync(["usbmux", "list", "--usb"], timeout: 5)
+        async let networkResult = runAsync(["usbmux", "list", "--network"], timeout: 5)
 
         var entries: [DeviceEntry] = []
         let usb = await usbResult
@@ -245,14 +279,24 @@ enum PyMobileDevice {
             entries += parseUsbmuxDeviceEntries(from: network.output, defaultConnectionType: "Network")
         }
 
+        var fallbackSucceeded: Bool?
         if entries.isEmpty {
-            let fallback = await runAsync(["usbmux", "list"])
+            let fallback = await runAsync(["usbmux", "list"], timeout: 5)
+            fallbackSucceeded = fallback.succeeded
             if fallback.succeeded {
-                entries = parseUsbmuxDeviceEntries(from: fallback.output, defaultConnectionType: "USB")
+                // The unfiltered command can contain either transport. Older
+                // versions sometimes omit ConnectionType, so do not fabricate
+                // USB provenance for an entry whose route is actually unknown.
+                entries = parseUsbmuxDeviceEntries(from: fallback.output, defaultConnectionType: "Unknown")
             }
         }
 
-        return mergeDeviceEntries(entries)
+        return DeviceDiscoveryResult(
+            entries: mergeDeviceEntries(entries),
+            usbProbeSucceeded: usb.succeeded,
+            networkProbeSucceeded: network.succeeded,
+            fallbackProbeSucceeded: fallbackSucceeded
+        )
     }
 
     /// List devices currently reachable over network/Wi-Fi with connection metadata.

--- a/Sources/Phosphor/Utilities/UsbmuxConnectionType.swift
+++ b/Sources/Phosphor/Utilities/UsbmuxConnectionType.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+/// Normalizes usbmux connection metadata without inventing transport provenance.
+enum UsbmuxConnectionType {
+    static func normalize(_ rawValue: String?, default defaultConnectionType: String) -> String {
+        guard let rawValue else { return defaultConnectionType }
+
+        let normalized = rawValue.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        if normalized == "1" || normalized.contains("usb") {
+            return "USB"
+        }
+        if normalized == "2" || normalized.contains("network") || normalized.contains("wifi") || normalized.contains("wi-fi") {
+            return "Network"
+        }
+        return defaultConnectionType
+    }
+}


### PR DESCRIPTION
## Summary
- retain the last rendered Wi-Fi device snapshot through one missed routine poll
- keep explicit refreshes authoritative and evict stale Wi-Fi state on USB transitions
- preserve stable ordering across multiple wireless devices
- add behavioral regression coverage for grace-period lifecycle and transport transitions

## Verification
- `python3 Scripts/regression/run.py` — 66 checks passed
- `swift build`
- `swift build -c release`
- `bash Scripts/build.sh`
- independent final review: no blockers found
