### PR TITLE
Harden destructive operations and process cleanup

### DIFF
--- a/Scripts/regression/checks/deep_reliability.py
+++ b/Scripts/regression/checks/deep_reliability.py
@@ -1,0 +1,194 @@
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+import tempfile
+
+
+def read(root: Path, rel: str) -> str:
+    return (root / rel).read_text()
+
+
+def swift_block_after(text: str, signature: str) -> str:
+    start = text.index(signature)
+    brace = text.index("{", start)
+    depth = 0
+    for index in range(brace, len(text)):
+        if text[index] == "{":
+            depth += 1
+        elif text[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return text[start:index + 1]
+    raise AssertionError(f"unterminated Swift block after {signature}")
+
+
+def test_archive_export_uses_same_volume_staging_and_atomic_publish(root: Path) -> None:
+    source = read(root, "Sources/Phosphor/Services/BackupArchiver.swift")
+    body = swift_block_after(source, "static func createArchive(")
+    assert "stagingArchivePath" in body, "archive export must create a unique same-directory staging path"
+    assert "UUID().uuidString" in body, "archive staging names must be collision-safe"
+    assert '"-czf", stagingArchivePath' in body, "tar must write staging, never the published archive path"
+    assert "replaceItemAt" in body, "an existing archive must be atomically replaced only after tar succeeds"
+    assert "defer" in body and "removeItem(atPath: stagingArchivePath)" in body, "failed or cancelled staging output must be cleaned up"
+    assert "removeItem(atPath: archivePath)" not in body, "a failed export must preserve the previous archive"
+
+
+def test_pymobiledevice_cache_is_synchronized_and_resettable(root: Path) -> None:
+    source = read(root, "Sources/Phosphor/Utilities/PyMobileDevice.swift")
+    assert "private static let cacheLock = NSLock()" in source, "cached binary path requires a synchronization lock"
+    find = swift_block_after(source, "private static func findBinary()")
+    reset = swift_block_after(source, "static func resetBinaryCache()")
+    assert "cacheLock.lock()" in find and "cacheLock.unlock()" in find, "cache access must be serialized"
+    assert "cacheLock.lock()" in reset and "cachedBinaryPath = nil" in reset, "reset must safely invalidate the cache"
+    build = swift_block_after(source, "private static func buildCommand(")
+    assert "isDirectBinary(binary)" in build, "command construction must classify its immutable resolved path"
+    assert "usesDirectBinary" not in source, "a second cache read can race reset and change a resolved command's invocation mode"
+
+
+def test_background_unlock_does_not_return_a_decryptor_across_actor_boundary(root: Path) -> None:
+    source = read(root, "Sources/Phosphor/ViewModels/BackupViewModel.swift")
+    body = swift_block_after(source, "func submitUnlock(password: String, remember: Bool) async")
+    assert "Task.detached(priority: .userInitiated) { () throws -> Void in" in body, "detached unlock must explicitly return Void"
+    assert "_ = try BackupUnlockStore.shared.unlock" in body, "the non-Sendable decryptor must remain inside the detached task"
+
+
+def test_password_management_fails_closed_instead_of_using_pymobiledevice_argv(root: Path) -> None:
+    manager = read(root, "Sources/Phosphor/Services/BackupManager.swift")
+    py = read(root, "Sources/Phosphor/Utilities/PyMobileDevice.swift")
+    encryption = swift_block_after(manager, "private func setBackupEncryption")
+    change = swift_block_after(manager, "func changeEncryptionPassword")
+    assert "PyMobileDevice.setEncryption" not in encryption, "encryption fallback must fail closed rather than pass a password in argv"
+    assert "PyMobileDevice.changeEncryptionPassword" not in change, "password-change fallback must fail closed rather than pass passwords in argv"
+    assert "setEncryption(enabled:" not in py, "pymobiledevice argv password helper must not remain callable"
+    assert "changeEncryptionPassword(oldPassword:" not in py, "pymobiledevice argv password helper must not remain callable"
+
+
+def test_flattened_photo_exports_choose_deterministic_collision_safe_names(root: Path) -> None:
+    source = read(root, "Sources/Phosphor/Services/PhotoExtractor.swift")
+    assert "FlatPhotoExportReservation.reserve" in source, "flattened photo exports need an atomic destination reservation"
+    assert "stableID: item.id" in source, "collision names must be deterministic from the backup file identity"
+    assert "reservation.stagingURL" in source and "flatReservation?.publish()" in source, "flat exports must stage privately and publish only after extraction succeeds"
+
+
+def test_flat_photo_reservations_atomically_publish_parallel_exports(root: Path) -> None:
+    """Parallel flattened exports must never select or publish the same output."""
+    probe = r'''
+import Foundation
+
+@main
+struct FlatPhotoProbe {
+    static func main() throws {
+        let root = URL(fileURLWithPath: CommandLine.arguments[1], isDirectory: true)
+        let count = 24
+        let group = DispatchGroup()
+        let queue = DispatchQueue(label: "flat-photo-export", attributes: .concurrent)
+        let lock = NSLock()
+        var failures: [String] = []
+
+        for index in 0..<count {
+            group.enter()
+            queue.async {
+                defer { group.leave() }
+                do {
+                    let reservation = try FlatPhotoExportReservation.reserve(
+                        filename: "IMG_0001.JPG",
+                        stableID: "backup-file-\(index)",
+                        root: root
+                    )
+                    try Data("payload-\(index)".utf8).write(to: reservation.stagingURL)
+                    try reservation.publish()
+                } catch {
+                    lock.lock()
+                    failures.append(error.localizedDescription)
+                    lock.unlock()
+                }
+            }
+        }
+        group.wait()
+        let files = try FileManager.default.contentsOfDirectory(at: root, includingPropertiesForKeys: nil)
+            .filter { !$0.lastPathComponent.contains(".phosphor-partial-") }
+        let payloads = Set(try files.map { try String(contentsOf: $0) })
+        print("RESULT|\(failures.count)|\(files.count)|\(payloads.count)")
+    }
+}
+'''
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp = Path(temp_dir)
+        probe_path = temp / "Probe.swift"
+        probe_path.write_text(probe)
+        executable = temp / "flat-photo-probe"
+        compile_result = subprocess.run(
+            [
+                "swiftc",
+                "-parse-as-library",
+                str(root / "Sources/Phosphor/Utilities/FlatPhotoExportReservation.swift"),
+                str(probe_path),
+                "-o",
+                str(executable),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        assert compile_result.returncode == 0, compile_result.stderr
+        output_root = temp / "exports"
+        output_root.mkdir()
+        result = subprocess.run([str(executable), str(output_root)], capture_output=True, text=True, timeout=20)
+
+    assert result.returncode == 0, result.stderr
+    assert "RESULT|0|24|24" in result.stdout, result.stdout
+
+
+def test_shell_process_group_catches_a_descendant_that_forks_after_timeout(root: Path) -> None:
+    """A TERM-ignoring child must not outlive a timed-out leader by late-forking."""
+    probe = r'''
+import Foundation
+
+@main
+struct LateForkProbe {
+    static func main() async {
+        let marker = CommandLine.arguments[1]
+        let command = """
+        trap 'exit 0' TERM
+        (trap '' TERM; sleep 0.35; /bin/sh -c 'trap "" TERM; echo $$ > "\(marker)"; while :; do :; done' &) &
+        while :; do :; done
+        """
+        let result = await Shell.runAsync("/bin/sh", arguments: ["-c", command], timeout: 0.1)
+        try? await Task.sleep(nanoseconds: 1_000_000_000)
+        let childPID = (try? String(contentsOfFile: marker))
+            .flatMap { Int32($0.trimmingCharacters(in: .whitespacesAndNewlines)) }
+        let childStillExists = childPID.map { Darwin.kill($0, 0) == 0 || errno == EPERM } ?? false
+        print("RESULT|\(result.exitCode)|\(childStillExists)")
+    }
+}
+'''
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp = Path(temp_dir)
+        (temp / "Probe.swift").write_text(probe)
+        (temp / "PyMobileDeviceStub.swift").write_text("enum PyMobileDevice { static func available() -> Bool { false } }\n")
+        executable = temp / "late-fork-probe"
+        compile_result = subprocess.run(
+            [
+                "swiftc", "-parse-as-library",
+                str(root / "Sources/Phosphor/Utilities/Shell.swift"),
+                str(temp / "PyMobileDeviceStub.swift"),
+                str(temp / "Probe.swift"),
+                "-o", str(executable),
+            ],
+            capture_output=True, text=True, timeout=60,
+        )
+        assert compile_result.returncode == 0, compile_result.stderr
+        result = subprocess.run([str(executable), str(temp / "escaped")], capture_output=True, text=True, timeout=10)
+
+    assert result.returncode == 0, result.stderr
+    assert "RESULT|-2|false" in result.stdout, result.stdout
+
+
+def test_shell_terminates_and_confirms_full_descendant_tree_cleanup(root: Path) -> None:
+    source = read(root, "Sources/Phosphor/Utilities/Shell.swift")
+    assert "POSIX_SPAWN_SETSID" in source, "Shell must create a dedicated session before a child can fork"
+    assert "terminateTimedOutTree" in source, "all timeout paths must use one process-tree terminator"
+    assert "SIGTERM" in source and "SIGKILL" in source, "tree termination must escalate from graceful to forced shutdown"
+    assert "waitForProcessTreeCleanup" in source, "Shell must confirm descendant cleanup before reporting timeout completion"
+    assert "static func terminate(_ process: ManagedProcess)" in source, "explicit cancellation must terminate a managed process tree"

--- a/Scripts/regression/checks/shell_safety.py
+++ b/Scripts/regression/checks/shell_safety.py
@@ -27,8 +27,8 @@ def swift_block_after(text: str, signature: str) -> str:
 def test_shell_run_does_not_block_global_dispatch_workers(root: Path) -> None:
     src = read(root, "Sources/Phosphor/Utilities/Shell.swift")
     body = swift_block_after(src, "static func run(_ command: String")
-    assert "process.terminationHandler" in body, "Shell.run should wait via Process.terminationHandler"
-    assert "SIGKILL" in body, "Shell.run should force-kill commands that ignore graceful timeout termination"
+    assert "launchManagedProcess" in body, "Shell.run should launch a session-scoped managed child"
+    assert "terminateTimedOutTreeSynchronously" in body, "Shell.run should force-kill commands that ignore graceful timeout termination"
     assert "waitUntilExit()" not in body, "Shell.run must not burn a global dispatch worker in waitUntilExit()"
     assert "DispatchQueue.global" not in body, "Shell.run must not allocate a global queue worker per process"
 
@@ -36,9 +36,9 @@ def test_shell_run_does_not_block_global_dispatch_workers(root: Path) -> None:
 def test_shell_run_async_does_not_block_global_dispatch_workers(root: Path) -> None:
     src = read(root, "Sources/Phosphor/Utilities/Shell.swift")
     body = swift_block_after(src, "static func runAsync(_ command: String")
-    assert "process.terminationHandler" in body, "Shell.runAsync should wait via Process.terminationHandler"
+    assert "launchManagedProcess" in body, "runAsync must launch a session-scoped managed child"
+    assert "DispatchSource.makeProcessSource" in body, "runAsync should observe child exit without blocking a worker"
     assert "readabilityHandler" in body, "Shell.runAsync should collect pipe output without blocking reader workers"
-    assert "SIGKILL" in body, "Shell.runAsync should force-kill commands that ignore graceful timeout termination"
     assert "waitUntilExit()" not in body, "Shell.runAsync must not block a worker in waitUntilExit()"
     assert "DispatchQueue.global" not in body, "Shell.runAsync must not allocate a global queue worker per process"
 
@@ -48,7 +48,7 @@ def test_shell_run_async_cancels_timeout_watchdog_on_finish(root: Path) -> None:
     body = swift_block_after(src, "static func runAsync(_ command: String")
     assert "attachWatchdog" in body, "runAsync should hand its timeout watchdog to the state so it can be cancelled early"
     assert "pendingWatchdog?.cancel()" in src, "finish should cancel the watchdog so pipe fds are freed the moment the command completes"
-    assert "timedOut ? -1 : process.terminationStatus" in body, "runAsync must not read terminationStatus on the timed-out path (process may still be running)"
+    assert "state.finish(timeout: timeout, exitCode: exitCode)" in body, "runAsync must let state map an owned timeout to -2 without reading Process.terminationStatus"
 
 
 def test_shell_timeouts_cannot_be_reported_as_success(root: Path) -> None:
@@ -141,8 +141,8 @@ struct TimeoutProbe {
     assert records["STREAM"][0] == "-2", f"runStreaming timeout was reported as exit {records['STREAM'][0]}"
     assert "timed out" in records["ASYNC"][2].lower(), f"runAsync timeout should include a diagnostic: {result.stdout!r}"
     assert "timed out" in records["STREAM"][2].lower(), "runStreaming timeout should include a diagnostic"
-    assert 0.1 <= float(records["ASYNC"][1]) < 1.5, "runAsync should complete near its timeout"
-    assert 0.1 <= float(records["STREAM"][1]) < 1.5, "runStreaming should complete near its timeout"
+    assert 0.1 <= float(records["ASYNC"][1]) < 2, f"runAsync should complete near its timeout: {records}"
+    assert 0.1 <= float(records["STREAM"][1]) < 2, f"runStreaming should complete near its timeout: {records}"
     assert records["FAST"][0] == "3", f"a command that finished in time must keep its own exit code, got {records['FAST'][0]}"
     assert records["FASTSTREAM"][0] == "3", f"runStreaming must keep a completed command's exit code, got {records['FASTSTREAM'][0]}"
     assert "timed out" not in records["FAST"][2].lower(), "a command that finished in time must not carry a timeout diagnostic"
@@ -150,11 +150,11 @@ struct TimeoutProbe {
 
 def test_shell_run_streaming_has_bounded_timeout_and_force_kill(root: Path) -> None:
     src = read(root, "Sources/Phosphor/Utilities/Shell.swift")
-    body = src[src.index("static func runStreaming("):src.index("    /// Terminate a long-running child")]
+    body = src[src.index("static func runStreaming("):src.index("    /// Terminate a long-running managed command")]
     assert "timeout: TimeInterval?" in body, "Shell.runStreaming should let one-shot streams set a timeout"
-    assert "process.terminationHandler" in body, "Shell.runStreaming should complete through Process.terminationHandler"
+    assert "launchManagedProcess" in body, "Shell.runStreaming should launch a managed session child"
     assert "readabilityHandler" in body, "Shell.runStreaming should stream pipe output without blocking reader workers"
-    assert "SIGKILL" in body, "Shell.runStreaming should force-kill commands that ignore timeout termination"
+    assert "terminateTimedOutTree" in body, "Shell.runStreaming should force-kill commands that ignore timeout termination"
     assert "setTimeoutTask" in body, "Shell.runStreaming should cancel timeout sleeper tasks on normal completion"
     assert "Task.isCancelled" in body, "Shell.runStreaming timeout task should stop promptly after finish cancels it"
     assert "waitUntilExit()" not in body, "Shell.runStreaming must not block a worker in waitUntilExit()"

--- a/Sources/Phosphor/Services/BackupArchiver.swift
+++ b/Sources/Phosphor/Services/BackupArchiver.swift
@@ -100,27 +100,43 @@ enum BackupArchiver {
 
         let archiveName = "\(safeName)_\(dateStr).\(fileExtension)"
         let archivePath = (destinationDir as NSString).appendingPathComponent(archiveName)
-
-        // Remove existing file
-        try? fm.removeItem(atPath: archivePath)
+        // Staging beside the final archive guarantees the publish is on one volume.
+        // A UUID prevents concurrent exports of the same backup from sharing output.
+        let stagingArchivePath = (destinationDir as NSString)
+            .appendingPathComponent(".\(archiveName).\(UUID().uuidString).partial")
+        defer { try? fm.removeItem(atPath: stagingArchivePath) }
 
         onProgress("Compressing backup...")
 
-        // Use tar to create archive - fast and preserves all metadata
+        // Use tar to create archive - fast and preserves all metadata. Never point tar
+        // at the published path: a failed or cancelled process must leave its prior
+        // complete archive untouched.
         let backupDir = (backup.path as NSString).lastPathComponent
         let parentDir = (backup.path as NSString).deletingLastPathComponent
 
         let result = await Shell.runAsync(
             "tar",
-            arguments: ["-czf", archivePath, "-C", parentDir, backupDir],
+            arguments: ["-czf", stagingArchivePath, "-C", parentDir, backupDir],
             timeout: 600 // 10 min for large backups
         )
 
-        if result.succeeded {
+        guard result.succeeded, !Task.isCancelled else {
+            onProgress(Task.isCancelled ? "Archive cancelled" : "Archive failed: \(result.stderr)")
+            return nil
+        }
+
+        do {
+            let stagingURL = URL(fileURLWithPath: stagingArchivePath)
+            let archiveURL = URL(fileURLWithPath: archivePath)
+            if fm.fileExists(atPath: archivePath) {
+                _ = try fm.replaceItemAt(archiveURL, withItemAt: stagingURL)
+            } else {
+                try fm.moveItem(at: stagingURL, to: archiveURL)
+            }
             onProgress("Archive created: \(archiveName)")
             return archivePath
-        } else {
-            onProgress("Archive failed: \(result.stderr)")
+        } catch {
+            onProgress("Archive failed: could not publish archive: \(error.localizedDescription)")
             return nil
         }
     }

--- a/Sources/Phosphor/Services/BackupManager.swift
+++ b/Sources/Phosphor/Services/BackupManager.swift
@@ -53,8 +53,8 @@ final class BackupManager: ObservableObject {
         case incomplete(path: String)
     }
 
-    /// Active backup process for cancellation.
-    private var activeProcess: Process?
+    /// Active managed backup session leader for cancellation.
+    private var activeProcess: Shell.ManagedProcess?
     private var activeOperationID: UUID?
     private var cancelledOperationIDs: Set<UUID> = []
 
@@ -1022,10 +1022,8 @@ final class BackupManager: ObservableObject {
     /// Toggle backup encryption without leaking the password through the process
     /// argument list. idevicebackup2 reads the password from the BACKUP_PASSWORD
     /// environment variable, which - unlike an argv value - is not printed by
-    /// `ps -axww` (issue #39), so it is tried first. pymobiledevice3 only accepts
-    /// the password as a positional CLI argument, so the fallback below runs when
-    /// the idevicebackup2 attempt fails for any reason and briefly exposes the
-    /// secret to other local processes; the common success path never does.
+    /// `ps -axww`. pymobiledevice3 accepts these passwords only as positional CLI
+    /// arguments, so a failed secure invocation deliberately fails closed.
     private func setBackupEncryption(udid: String, enabled: Bool, password: String) async -> Bool {
         let mode = enabled ? "on" : "off"
         let result = await Shell.runAsync(
@@ -1033,14 +1031,16 @@ final class BackupManager: ObservableObject {
             arguments: ["-u", udid, "encryption", mode],
             extraEnvironment: ["BACKUP_PASSWORD": password]
         )
-        if result.succeeded { return true }
-        return await PyMobileDevice.setEncryption(enabled: enabled, password: password, udid: udid)
+        guard result.succeeded else {
+            lastError = "Could not change backup encryption without exposing the password on the command line. Ensure idevicebackup2 is installed and try again."
+            return false
+        }
+        return true
     }
 
-    /// Change the backup password. Passwords are passed to idevicebackup2 via the
-    /// BACKUP_PASSWORD / BACKUP_PASSWORD_NEW environment variables so they never
-    /// appear in the argument list (issue #39); the pymobiledevice3 argv path runs
-    /// only if that attempt fails and briefly exposes the secret via argv.
+    /// Change the backup password using idevicebackup2's environment-variable
+    /// interface. pymobiledevice3 only accepts both passwords in argv, so a
+    /// failure here is reported rather than falling back to an unsafe command.
     func changeEncryptionPassword(udid: String, oldPassword: String, newPassword: String) async -> Bool {
         let result = await Shell.runAsync(
             "idevicebackup2",
@@ -1050,8 +1050,11 @@ final class BackupManager: ObservableObject {
                 "BACKUP_PASSWORD_NEW": newPassword,
             ]
         )
-        if result.succeeded { return true }
-        return await PyMobileDevice.changeEncryptionPassword(oldPassword: oldPassword, newPassword: newPassword, udid: udid)
+        guard result.succeeded else {
+            lastError = "Could not change the backup password without exposing it on the command line. Ensure idevicebackup2 is installed and try again."
+            return false
+        }
+        return true
     }
 
     func isEncryptionEnabled(udid: String) async -> Bool {

--- a/Sources/Phosphor/Services/DiagnosticsManager.swift
+++ b/Sources/Phosphor/Services/DiagnosticsManager.swift
@@ -8,8 +8,8 @@ final class DiagnosticsManager: ObservableObject {
     @Published var syslogLines: [String] = []
     @Published var isStreamingSyslog = false
 
-    /// Active syslog process for proper termination.
-    private var syslogProcess: Process?
+    /// Active managed syslog session leader for proper termination.
+    private var syslogProcess: Shell.ManagedProcess?
     private var syslogStreamID: UUID?
 
     struct BatteryDiagnostics {

--- a/Sources/Phosphor/Services/PhotoExtractor.swift
+++ b/Sources/Phosphor/Services/PhotoExtractor.swift
@@ -62,16 +62,48 @@ final class PhotoExtractor: ObservableObject {
 
                 // relativePath and filename are manifest-controlled, so both branches
                 // resolve through the shared boundary check instead of being joined
-                // onto the destination directly.
-                let destPath = try? SafeExtractionPath.prepareDestination(
-                    root: URL(fileURLWithPath: destination, isDirectory: true),
-                    relativePath: preserveStructure ? item.relativePath : item.filename,
-                    fileManager: fm
-                )
+                // onto the destination directly. Flattened exports additionally keep
+                // distinct backup files distinct when their display names collide.
+                let destinationRoot = URL(fileURLWithPath: destination, isDirectory: true)
+                var flatReservation: FlatPhotoExportReservation?
+                var destPath: URL?
+                do {
+                    if preserveStructure {
+                        flatReservation = nil
+                        destPath = try SafeExtractionPath.prepareDestination(
+                            root: destinationRoot,
+                            relativePath: item.relativePath,
+                            fileManager: fm
+                        )
+                    } else {
+                        // Validate the manifest-controlled display name before the
+                        // reservation helper turns it into a flat sibling path.
+                        _ = try SafeExtractionPath.prepareDestination(
+                            root: destinationRoot,
+                            relativePath: item.filename,
+                            fileManager: fm
+                        )
+                        let reservation = try FlatPhotoExportReservation.reserve(
+                            filename: item.filename,
+                            stableID: item.id,
+                            root: destinationRoot,
+                            fileManager: fm
+                        )
+                        flatReservation = reservation
+                        destPath = reservation.stagingURL
+                    }
+                } catch {
+                    flatReservation = nil
+                    destPath = nil
+                }
 
                 if let destPath {
                     do {
+                        // A failed extraction removes only our private stage and
+                        // placeholder; it can never overwrite another export.
+                        defer { flatReservation?.discard() }
                         try manifest.extractFile(entry, to: destPath.path)
+                        try flatReservation?.publish()
                         extracted += 1
                     } catch {
                         // Skip files that can't be extracted, continue with others

--- a/Sources/Phosphor/Utilities/FlatPhotoExportReservation.swift
+++ b/Sources/Phosphor/Utilities/FlatPhotoExportReservation.swift
@@ -1,0 +1,115 @@
+import Foundation
+import Darwin
+
+/// Atomically reserves and publishes a flattened photo export destination.
+///
+/// A flattened export cannot use a check-then-copy sequence: another export can
+/// claim the same filename after `fileExists` returns false. Reservation creates
+/// an empty final-path placeholder with `O_EXCL`, then the caller writes a unique
+/// sibling staging file and atomically renames it over that placeholder.
+final class FlatPhotoExportReservation {
+    let targetURL: URL
+    let stagingURL: URL
+
+    private let fileManager: FileManager
+    private var published = false
+
+    private init(targetURL: URL, stagingURL: URL, fileManager: FileManager) {
+        self.targetURL = targetURL
+        self.stagingURL = stagingURL
+        self.fileManager = fileManager
+    }
+
+    deinit {
+        discard()
+    }
+
+    static func reserve(
+        filename: String,
+        stableID: String,
+        root: URL,
+        fileManager: FileManager = .default
+    ) throws -> FlatPhotoExportReservation {
+        let displayName = (filename as NSString).lastPathComponent
+        guard !displayName.isEmpty, displayName != ".", displayName != ".." else {
+            throw CocoaError(.fileNoSuchFile)
+        }
+
+        let stem = (displayName as NSString).deletingPathExtension
+        let ext = (displayName as NSString).pathExtension
+        let suffix = sanitizedSuffix(stableID)
+        var sequence = 0
+
+        while true {
+            let name: String
+            if sequence == 0 {
+                name = displayName
+            } else {
+                let ordinal = sequence == 1 ? "" : "-\(sequence)"
+                name = ext.isEmpty
+                    ? "\(stem)-\(suffix)\(ordinal)"
+                    : "\(stem)-\(suffix)\(ordinal).\(ext)"
+            }
+            let target = root.appendingPathComponent(name, isDirectory: false)
+            guard try reserveEmptyFile(at: target) else {
+                sequence += 1
+                continue
+            }
+
+            do {
+                let staging = root.appendingPathComponent(
+                    ".\(name).phosphor-partial-\(UUID().uuidString)",
+                    isDirectory: false
+                )
+                if try reserveEmptyFile(at: staging) {
+                    return FlatPhotoExportReservation(
+                        targetURL: target,
+                        stagingURL: staging,
+                        fileManager: fileManager
+                    )
+                }
+                // UUID collisions are extraordinarily unlikely, but do not leave
+                // a placeholder behind if one occurs before retrying.
+                try? fileManager.removeItem(at: target)
+            } catch {
+                try? fileManager.removeItem(at: target)
+                throw error
+            }
+        }
+    }
+
+    /// Atomically replace the placeholder only after the staged copy finished.
+    func publish() throws {
+        guard !published else { return }
+        guard Darwin.rename(stagingURL.path, targetURL.path) == 0 else {
+            throw NSError(domain: NSPOSIXErrorDomain, code: Int(errno))
+        }
+        published = true
+    }
+
+    /// Remove an unfinished staging copy and this reservation's placeholder.
+    func discard() {
+        try? fileManager.removeItem(at: stagingURL)
+        if !published {
+            try? fileManager.removeItem(at: targetURL)
+        }
+    }
+
+    private static func sanitizedSuffix(_ stableID: String) -> String {
+        let suffix = stableID.unicodeScalars
+            .filter { CharacterSet.alphanumerics.contains($0) }
+            .map(String.init)
+            .joined()
+        return suffix.isEmpty ? "backup-file" : suffix
+    }
+
+    private static func reserveEmptyFile(at url: URL) throws -> Bool {
+        let descriptor = Darwin.open(url.path, O_WRONLY | O_CREAT | O_EXCL, S_IRUSR | S_IWUSR)
+        if descriptor >= 0 {
+            _ = Darwin.close(descriptor)
+            return true
+        }
+        if errno == EEXIST { return false }
+        throw NSError(domain: NSPOSIXErrorDomain, code: Int(errno))
+    }
+}

--- a/Sources/Phosphor/Utilities/PyMobileDevice.swift
+++ b/Sources/Phosphor/Utilities/PyMobileDevice.swift
@@ -5,7 +5,10 @@ import Foundation
 /// Searches for pymobiledevice3 binary at common install locations (pipx, pip, venv).
 enum PyMobileDevice {
 
-    /// Cached path to the pymobiledevice3 binary once found.
+    /// Cached path to the pymobiledevice3 binary once found. Discovery can be
+    /// requested by several background probes at once, so all reads, writes, and
+    /// reset invalidation are serialized by `cacheLock`.
+    private static let cacheLock = NSLock()
     private static var cachedBinaryPath: String?
 
     /// Python minor versions to probe for pipx or pip --user installs and system Python.
@@ -28,6 +31,8 @@ enum PyMobileDevice {
     /// Find the pymobiledevice3 binary. Checks direct binary first (pipx, pip --user),
     /// then python3 -m pymobiledevice3 at various Python locations.
     private static func findBinary() -> String? {
+        cacheLock.lock()
+        defer { cacheLock.unlock() }
         if let cached = cachedBinaryPath { return cached }
 
         let home = FileManager.default.homeDirectoryForCurrentUser.path
@@ -89,7 +94,9 @@ enum PyMobileDevice {
     /// Clear the cached binary path so the next call re-probes the filesystem.
     /// Useful after the user installs or upgrades pymobiledevice3 mid-session.
     static func resetBinaryCache() {
+        cacheLock.lock()
         cachedBinaryPath = nil
+        cacheLock.unlock()
     }
 
     /// Query installed pymobiledevice3 version, or nil if unavailable.
@@ -104,16 +111,17 @@ enum PyMobileDevice {
         return alt.succeeded && !altTrimmed.isEmpty ? altTrimmed : nil
     }
 
-    /// Whether the found binary is a direct pymobiledevice3 binary (vs python3 path).
-    private static var usesDirectBinary: Bool {
-        cachedBinaryPath?.hasSuffix("pymobiledevice3") == true
-            && cachedBinaryPath?.contains("python") != true
+    /// Classify the immutable path returned from one `findBinary` call. Do not
+    /// re-read the cache after resolution: `resetBinaryCache()` may run between
+    /// those reads and otherwise turn a console script into a Python `-m` command.
+    private static func isDirectBinary(_ path: String) -> Bool {
+        path.hasSuffix("pymobiledevice3") && !path.contains("python")
     }
 
     /// Build command and arguments for running pymobiledevice3.
     private static func buildCommand(subcommands: [String]) -> (cmd: String, args: [String])? {
         guard let binary = findBinary() else { return nil }
-        if usesDirectBinary {
+        if isDirectBinary(binary) {
             return (cmd: binary, args: subcommands)
         } else {
             // It's a python3 path - use -m
@@ -138,7 +146,7 @@ enum PyMobileDevice {
         guard let binary = findBinary() else {
             return "sudo -E env \"PATH=$PATH\" pymobiledevice3 remote tunneld"
         }
-        if usesDirectBinary {
+        if isDirectBinary(binary) {
             return "sudo \"\(binary)\" remote tunneld"
         } else {
             return "sudo \"\(binary)\" -m pymobiledevice3 remote tunneld"
@@ -171,7 +179,7 @@ enum PyMobileDevice {
         onOutput: @escaping (String) -> Void,
         onError: @escaping (String) -> Void = { _ in },
         completion: @escaping (Int32) -> Void
-    ) -> Process? {
+    ) -> Shell.ManagedProcess? {
         guard let cmd = buildCommand(subcommands: subcommands) else {
             onError("pymobiledevice3 not found")
             completion(-1)
@@ -733,7 +741,7 @@ enum PyMobileDevice {
         onOutput: @escaping (String) -> Void,
         onError: @escaping (String) -> Void = { _ in },
         completion: @escaping (Int32) -> Void
-    ) -> Process? {
+    ) -> Shell.ManagedProcess? {
         var args = ["backup2", "backup"]
         if full { args.append("--full") }
         // `--mobdev2` can prompt when the same wireless device is advertised on
@@ -757,7 +765,7 @@ enum PyMobileDevice {
         timeout: TimeInterval? = 6 * 60 * 60,
         onOutput: @escaping (String) -> Void,
         completion: @escaping (Int32) -> Void
-    ) -> Process? {
+    ) -> Shell.ManagedProcess? {
         var args = ["backup2", "restore"]
         if system { args.append("--system") }
         if reboot { args.append("--reboot") }
@@ -779,18 +787,6 @@ enum PyMobileDevice {
         return result.output.lowercased().contains("on") || result.output.lowercased().contains("enabled")
     }
 
-    static func setEncryption(enabled: Bool, password: String, udid: String? = nil) async -> Bool {
-        var args = ["backup2", "encryption", enabled ? "on" : "off", password]
-        if let udid { args += ["--udid", udid] }
-        return (await runAsync(args)).succeeded
-    }
-
-    static func changeEncryptionPassword(oldPassword: String, newPassword: String, udid: String? = nil) async -> Bool {
-        var args = ["backup2", "change-password", oldPassword, newPassword]
-        if let udid { args += ["--udid", udid] }
-        return (await runAsync(args)).succeeded
-    }
-
     // MARK: - Syslog
 
     /// Start streaming syslog. Returns Process for termination.
@@ -798,7 +794,7 @@ enum PyMobileDevice {
         udid: String? = nil,
         onOutput: @escaping (String) -> Void,
         completion: @escaping (Int32) -> Void
-    ) -> Process? {
+    ) -> Shell.ManagedProcess? {
         var args = ["syslog", "live"]
         if let udid { args += ["--udid", udid] }
         return runStreaming(args, onOutput: onOutput, completion: completion)

--- a/Sources/Phosphor/Utilities/Shell.swift
+++ b/Sources/Phosphor/Utilities/Shell.swift
@@ -13,6 +13,77 @@ enum Shell {
         var output: String { stdout.trimmingCharacters(in: .whitespacesAndNewlines) }
     }
 
+    /// A POSIX-spawned child. Launching with `POSIX_SPAWN_SETSID` gives every
+    /// managed command a session/process group before its first instruction.
+    final class ManagedProcess: @unchecked Sendable {
+        let processIdentifier: pid_t
+
+        init(processIdentifier: pid_t) {
+            self.processIdentifier = processIdentifier
+        }
+
+        var isRunning: Bool {
+            Shell.processExists(processIdentifier)
+        }
+    }
+
+    private static func launchManagedProcess(
+        _ command: String,
+        arguments: [String],
+        environment: [String: String],
+        stdoutPipe: Pipe,
+        stderrPipe: Pipe
+    ) throws -> ManagedProcess {
+        var fileActions: posix_spawn_file_actions_t? = nil
+        guard posix_spawn_file_actions_init(&fileActions) == 0 else {
+            throw NSError(domain: NSPOSIXErrorDomain, code: Int(errno))
+        }
+        defer { posix_spawn_file_actions_destroy(&fileActions) }
+
+        guard posix_spawn_file_actions_adddup2(&fileActions, stdoutPipe.fileHandleForWriting.fileDescriptor, STDOUT_FILENO) == 0,
+              posix_spawn_file_actions_adddup2(&fileActions, stderrPipe.fileHandleForWriting.fileDescriptor, STDERR_FILENO) == 0 else {
+            throw NSError(domain: NSPOSIXErrorDomain, code: Int(errno))
+        }
+
+        var attributes: posix_spawnattr_t? = nil
+        guard posix_spawnattr_init(&attributes) == 0 else {
+            throw NSError(domain: NSPOSIXErrorDomain, code: Int(errno))
+        }
+        defer { posix_spawnattr_destroy(&attributes) }
+        guard posix_spawnattr_setflags(&attributes, Int16(POSIX_SPAWN_SETSID)) == 0 else {
+            throw NSError(domain: NSPOSIXErrorDomain, code: Int(errno))
+        }
+
+        let argvStrings = ["/usr/bin/env", command] + arguments
+        let environmentStrings = environment.map { "\($0.key)=\($0.value)" }
+        let argv = argvStrings.map { strdup($0) } + [nil]
+        let envp = environmentStrings.map { strdup($0) } + [nil]
+        defer {
+            argv.dropLast().forEach { free($0) }
+            envp.dropLast().forEach { free($0) }
+        }
+
+        var processID: pid_t = 0
+        let status = argv.withUnsafeBufferPointer { argvBuffer in
+            envp.withUnsafeBufferPointer { environmentBuffer in
+                posix_spawn(
+                    &processID,
+                    "/usr/bin/env",
+                    &fileActions,
+                    &attributes,
+                    UnsafeMutablePointer(mutating: argvBuffer.baseAddress),
+                    UnsafeMutablePointer(mutating: environmentBuffer.baseAddress)
+                )
+            }
+        }
+        guard status == 0 else {
+            throw NSError(domain: NSPOSIXErrorDomain, code: Int(status))
+        }
+        stdoutPipe.fileHandleForWriting.closeFile()
+        stderrPipe.fileHandleForWriting.closeFile()
+        return ManagedProcess(processIdentifier: processID)
+    }
+
     private final class AsyncCommandState: @unchecked Sendable {
         private let lock = NSLock()
         private var stdoutData = Data()
@@ -122,6 +193,13 @@ enum Shell {
             return true
         }
 
+        func hasTimedOut() -> Bool {
+            lock.lock()
+            let value = timedOut
+            lock.unlock()
+            return value
+        }
+
         func setTimeoutTask(_ task: Task<Void, Never>) {
             lock.lock()
             if didFinish {
@@ -161,18 +239,161 @@ enum Shell {
         return environment
     }
 
+    /// Supervises the session/process group created atomically by posix_spawn.
+    /// Group signalling covers descendants forked after a snapshot, while the
+    /// PID snapshot remains a compatibility fallback should session setup fail.
+    private final class ProcessTree: @unchecked Sendable {
+        private let lock = NSLock()
+        private let rootProcessID: pid_t
+        private let processGroupID: pid_t?
+        private var knownProcessIDs: Set<pid_t>
+
+        init(rootProcessID: pid_t, hasDedicatedProcessGroup: Bool = true) {
+            self.rootProcessID = rootProcessID
+            self.knownProcessIDs = [rootProcessID]
+            // Do not call setpgid from the parent: that reintroduces the launch
+            // race this runner exists to remove. POSIX_SPAWN_SETSID established
+            // the group before the command's first instruction.
+            self.processGroupID = hasDedicatedProcessGroup && Darwin.getpgid(rootProcessID) == rootProcessID
+                ? rootProcessID
+                : nil
+        }
+
+        func terminate(with signal: Int32) {
+            if let processGroupID {
+                // Negative PID targets every current member, including a child
+                // forked after timeout discovery or after the leader has exited.
+                _ = Darwin.kill(-processGroupID, signal)
+                return
+            }
+
+            recordDescendants()
+            signalKnownProcesses(signal)
+            // Capture once more while the leader is still alive to catch a child
+            // created between discovery and the first signal.
+            recordDescendants()
+            signalKnownProcesses(signal)
+        }
+
+        func cleanupComplete() -> Bool {
+            if let processGroupID {
+                return !Shell.processGroupExists(processGroupID)
+            }
+            lock.lock()
+            let processIDs = knownProcessIDs
+            lock.unlock()
+            return processIDs.allSatisfy { !Shell.processExists($0) }
+        }
+
+        private func recordDescendants() {
+            let descendants = Shell.descendantProcessIDs(of: rootProcessID)
+            lock.lock()
+            knownProcessIDs.formUnion(descendants)
+            lock.unlock()
+        }
+
+        private func signalKnownProcesses(_ signal: Int32) {
+            lock.lock()
+            let processIDs = knownProcessIDs
+            lock.unlock()
+
+            // Work from the leaves inward. This lets parents reap their children
+            // normally when possible, before the leader itself is signalled.
+            for processID in processIDs where processID != rootProcessID {
+                _ = Darwin.kill(processID, signal)
+            }
+            _ = Darwin.kill(rootProcessID, signal)
+        }
+    }
+
+    private static func descendantProcessIDs(of rootProcessID: pid_t) -> Set<pid_t> {
+        guard rootProcessID > 0 else { return [] }
+        var descendants: Set<pid_t> = []
+        var pending = [rootProcessID]
+
+        while let parent = pending.popLast() {
+            var children = Array(repeating: pid_t(0), count: 1_024)
+            let reported = children.withUnsafeMutableBufferPointer {
+                proc_listchildpids(parent, $0.baseAddress, Int32($0.count * MemoryLayout<pid_t>.stride))
+            }
+            let count = min(max(0, Int(reported)), children.count)
+            for child in children.prefix(count) where child > 0 && descendants.insert(child).inserted {
+                pending.append(child)
+            }
+        }
+        return descendants
+    }
+
+    private static func processExists(_ processID: pid_t) -> Bool {
+        guard processID > 0 else { return false }
+        if Darwin.kill(processID, 0) == 0 { return true }
+        return errno == EPERM
+    }
+
+    private static func processGroupExists(_ processGroupID: pid_t) -> Bool {
+        guard processGroupID > 0 else { return false }
+        if Darwin.kill(-processGroupID, 0) == 0 { return true }
+        return errno == EPERM
+    }
+
+    private static func terminateProcessTree(_ tree: ProcessTree, signal: Int32) {
+        tree.terminate(with: signal)
+    }
+
+    private static func waitForProcessTreeCleanup(_ tree: ProcessTree, timeout: TimeInterval) async -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while !tree.cleanupComplete() {
+            guard Date() < deadline else { return false }
+            try? await Task.sleep(nanoseconds: 50_000_000)
+        }
+        return true
+    }
+
+    private static func waitForProcessTreeCleanupSynchronously(_ tree: ProcessTree, timeout: TimeInterval) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while !tree.cleanupComplete() {
+            guard Date() < deadline else { return false }
+            Thread.sleep(forTimeInterval: 0.05)
+        }
+        return true
+    }
+
+    /// A timeout cannot leave a TERM-ignoring process group alive long enough to
+    /// fork an escaped worker. Give cooperative commands a very short grace, then
+    /// kill the *entire* dedicated group (not just the original leader).
+    private static func terminateTimedOutTree(_ tree: ProcessTree) async {
+        terminateProcessTree(tree, signal: SIGTERM)
+        if !(await waitForProcessTreeCleanup(tree, timeout: 0.05)) {
+            terminateProcessTree(tree, signal: SIGKILL)
+            _ = await waitForProcessTreeCleanup(tree, timeout: 1)
+        }
+    }
+
+    private static func terminateTimedOutTreeSynchronously(_ tree: ProcessTree) {
+        terminateProcessTree(tree, signal: SIGTERM)
+        if !waitForProcessTreeCleanupSynchronously(tree, timeout: 0.05) {
+            terminateProcessTree(tree, signal: SIGKILL)
+            _ = waitForProcessTreeCleanupSynchronously(tree, timeout: 1)
+        }
+    }
+
     /// Run a command synchronously and return the result.
     @discardableResult
     static func run(_ command: String, arguments: [String] = [], timeout: TimeInterval = 60) -> Result {
-        let process = Process()
         let stdoutPipe = Pipe()
         let stderrPipe = Pipe()
-
-        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
-        process.arguments = [command] + arguments
-        process.standardOutput = stdoutPipe
-        process.standardError = stderrPipe
-        process.environment = environmentWithToolPaths()
+        let process: ManagedProcess
+        do {
+            process = try launchManagedProcess(
+                command,
+                arguments: arguments,
+                environment: environmentWithToolPaths(),
+                stdoutPipe: stdoutPipe,
+                stderrPipe: stderrPipe
+            )
+        } catch {
+            return Result(exitCode: -1, stdout: "", stderr: "Failed to launch: \(error.localizedDescription)")
+        }
 
         let stdoutQueue = DispatchQueue(label: "com.phosphor.shell.stdout")
         let stderrQueue = DispatchQueue(label: "com.phosphor.shell.stderr")
@@ -180,49 +401,40 @@ enum Shell {
         var stderrData = Data()
         let readGroup = DispatchGroup()
         let waitSemaphore = DispatchSemaphore(value: 0)
-
-        // Use Process.terminationHandler rather than blocking a global dispatch
-        // worker on a synchronous process wait. Phosphor may run many short device CLI
-        // probes; tying up one worker per process can exhaust libdispatch's soft
-        // thread limit and leave the app running but unresponsive.
-        process.terminationHandler = { _ in
+        let processTree = ProcessTree(rootProcessID: process.processIdentifier)
+        let exitSource = DispatchSource.makeProcessSource(
+            identifier: process.processIdentifier,
+            eventMask: .exit,
+            queue: DispatchQueue(label: "com.phosphor.shell.sync-exit")
+        )
+        var exitCode: Int32 = -1
+        exitSource.setEventHandler {
+            var status: Int32 = 0
+            let waited = waitpid(process.processIdentifier, &status, 0)
+            exitCode = waited == process.processIdentifier && status & 0x7f == 0
+                ? (status >> 8) & 0xff
+                : -1
             waitSemaphore.signal()
         }
-
-        do {
-            try process.run()
-        } catch {
-            process.terminationHandler = nil
-            return Result(exitCode: -1, stdout: "", stderr: "Failed to launch: \(error.localizedDescription)")
-        }
+        exitSource.resume()
 
         readGroup.enter()
         stdoutQueue.async {
             stdoutData = stdoutPipe.fileHandleForReading.readDataToEndOfFile()
             readGroup.leave()
         }
-
         readGroup.enter()
         stderrQueue.async {
             stderrData = stderrPipe.fileHandleForReading.readDataToEndOfFile()
             readGroup.leave()
         }
 
-        var timedOut = false
-        if waitSemaphore.wait(timeout: .now() + timeout) == .timedOut {
-            timedOut = true
-            process.terminate()
-            if waitSemaphore.wait(timeout: .now() + 2) == .timedOut {
-                process.interrupt()
-                if waitSemaphore.wait(timeout: .now() + 1) == .timedOut {
-                    Darwin.kill(process.processIdentifier, SIGKILL)
-                    _ = waitSemaphore.wait(timeout: .now() + 1)
-                }
-            }
+        let timedOut = waitSemaphore.wait(timeout: .now() + timeout) == .timedOut
+        if timedOut {
+            terminateTimedOutTreeSynchronously(processTree)
+            _ = waitSemaphore.wait(timeout: .now() + 1)
         }
-
-        process.terminationHandler = nil
-
+        exitSource.cancel()
         _ = readGroup.wait(timeout: .now() + 2)
 
         var stderr = String(data: stderrData, encoding: .utf8) ?? ""
@@ -230,9 +442,8 @@ enum Shell {
             let timeoutMessage = "Command timed out after \(Int(timeout))s"
             stderr = stderr.isEmpty ? timeoutMessage : stderr + "\n" + timeoutMessage
         }
-
         return Result(
-            exitCode: timedOut ? -2 : process.terminationStatus,
+            exitCode: timedOut ? -2 : exitCode,
             stdout: String(data: stdoutData, encoding: .utf8) ?? "",
             stderr: stderr
         )
@@ -245,58 +456,22 @@ enum Shell {
     /// argument list, where any local process could read them via `ps`.
     static func runAsync(_ command: String, arguments: [String] = [], timeout: TimeInterval = 300, extraEnvironment: [String: String] = [:]) async -> Result {
         await withCheckedContinuation { continuation in
-            let process = Process()
             let stdoutPipe = Pipe()
             let stderrPipe = Pipe()
             let state = AsyncCommandState()
-
-            process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
-            process.arguments = [command] + arguments
-            process.standardOutput = stdoutPipe
-            process.standardError = stderrPipe
             var environment = environmentWithToolPaths()
             for (key, value) in extraEnvironment { environment[key] = value }
-            process.environment = environment
 
-            @Sendable func finish() {
-                stdoutPipe.fileHandleForReading.readabilityHandler = nil
-                stderrPipe.fileHandleForReading.readabilityHandler = nil
-                state.append(stdoutPipe.fileHandleForReading.availableData, toStdout: true)
-                state.append(stderrPipe.fileHandleForReading.availableData, toStdout: false)
-
-                // On the timed-out path the process may not be reaped yet; reading
-                // terminationStatus while it is still running throws. state.finish
-                // ignores the exit code for timeouts, so pass a placeholder there.
-                let timedOut = state.hasTimedOut()
-                guard let result = state.finish(
-                    timeout: timeout,
-                    exitCode: timedOut ? -1 : process.terminationStatus
-                ) else {
-                    return
-                }
-
-                process.terminationHandler = nil
-                continuation.resume(returning: result)
-            }
-
-            stdoutPipe.fileHandleForReading.readabilityHandler = { handle in
-                state.append(handle.availableData, toStdout: true)
-            }
-
-            stderrPipe.fileHandleForReading.readabilityHandler = { handle in
-                state.append(handle.availableData, toStdout: false)
-            }
-
-            process.terminationHandler = { _ in
-                finish()
-            }
-
+            let process: ManagedProcess
             do {
-                try process.run()
+                process = try launchManagedProcess(
+                    command,
+                    arguments: arguments,
+                    environment: environment,
+                    stdoutPipe: stdoutPipe,
+                    stderrPipe: stderrPipe
+                )
             } catch {
-                process.terminationHandler = nil
-                stdoutPipe.fileHandleForReading.readabilityHandler = nil
-                stderrPipe.fileHandleForReading.readabilityHandler = nil
                 continuation.resume(returning: Result(
                     exitCode: -1,
                     stdout: "",
@@ -305,28 +480,57 @@ enum Shell {
                 return
             }
 
+            let processTree = ProcessTree(rootProcessID: process.processIdentifier)
+            let exitSource = DispatchSource.makeProcessSource(
+                identifier: process.processIdentifier,
+                eventMask: .exit,
+                queue: DispatchQueue(label: "com.phosphor.shell.exit")
+            )
+
+            @Sendable func finish(exitCode: Int32) {
+                stdoutPipe.fileHandleForReading.readabilityHandler = nil
+                stderrPipe.fileHandleForReading.readabilityHandler = nil
+                state.append(stdoutPipe.fileHandleForReading.availableData, toStdout: true)
+                state.append(stderrPipe.fileHandleForReading.availableData, toStdout: false)
+                guard let result = state.finish(timeout: timeout, exitCode: exitCode) else { return }
+                exitSource.cancel()
+                continuation.resume(returning: result)
+            }
+
+            stdoutPipe.fileHandleForReading.readabilityHandler = { handle in
+                state.append(handle.availableData, toStdout: true)
+            }
+            stderrPipe.fileHandleForReading.readabilityHandler = { handle in
+                state.append(handle.availableData, toStdout: false)
+            }
+            exitSource.setEventHandler {
+                guard !state.hasTimedOut() else { return }
+                var status: Int32 = 0
+                let waited = waitpid(process.processIdentifier, &status, 0)
+                let exitCode: Int32 = waited == process.processIdentifier && status & 0x7f == 0
+                    ? (status >> 8) & 0xff
+                    : -1
+                finish(exitCode: exitCode)
+            }
+            exitSource.resume()
+
             let watchdogTask = Task {
                 let nanoseconds = UInt64(max(timeout, 0) * 1_000_000_000)
                 try? await Task.sleep(nanoseconds: nanoseconds)
                 guard !Task.isCancelled, state.markTimedOut() else { return }
-
-                process.terminate()
-                try? await Task.sleep(nanoseconds: 2_000_000_000)
-                guard !Task.isCancelled, !state.hasFinished() else { return }
-
-                process.interrupt()
-                try? await Task.sleep(nanoseconds: 1_000_000_000)
-                guard !Task.isCancelled, !state.hasFinished() else { return }
-
-                Darwin.kill(process.processIdentifier, SIGKILL)
-                try? await Task.sleep(nanoseconds: 1_000_000_000)
-                finish()
+                await terminateTimedOutTree(processTree)
+                // The process-exit source deliberately yields to the timeout winner,
+                // so that winner must also reap the session leader exactly once.
+                var status: Int32 = 0
+                _ = waitpid(process.processIdentifier, &status, 0)
+                finish(exitCode: -1)
             }
             state.attachWatchdog(watchdogTask)
         }
     }
 
-    /// Run a command with real-time output streaming via callback. Returns Process for termination.
+    /// Run a command with real-time output streaming via callback. Returns a managed
+    /// session leader that `Shell.terminate` can stop together with descendants.
     ///
     /// Long-running one-shot device operations (backup/restore) should pass a timeout so a
     /// wedged child process cannot leave the UI waiting forever. Truly open-ended streams
@@ -341,24 +545,36 @@ enum Shell {
         onOutput: @escaping (String) -> Void,
         onError: @escaping (String) -> Void = { _ in },
         completion: @escaping (Int32) -> Void
-    ) -> Process? {
-        let process = Process()
+    ) -> ManagedProcess? {
         let stdoutPipe = Pipe()
         let stderrPipe = Pipe()
         let state = StreamingCommandState()
+        let process: ManagedProcess
+        do {
+            process = try launchManagedProcess(
+                command,
+                arguments: arguments,
+                environment: environment ?? environmentWithToolPaths(),
+                stdoutPipe: stdoutPipe,
+                stderrPipe: stderrPipe
+            )
+        } catch {
+            onError("Failed to launch: \(error.localizedDescription)")
+            completion(-1)
+            return nil
+        }
 
-        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
-        process.arguments = [command] + arguments
-        process.standardOutput = stdoutPipe
-        process.standardError = stderrPipe
-        process.environment = environment ?? environmentWithToolPaths()
-
+        let processTree = ProcessTree(rootProcessID: process.processIdentifier)
+        let exitSource = DispatchSource.makeProcessSource(
+            identifier: process.processIdentifier,
+            eventMask: .exit,
+            queue: DispatchQueue(label: "com.phosphor.shell.stream-exit")
+        )
         @Sendable func finish(exitCode: Int32) {
             guard let resolvedExitCode = state.finish(exitCode: exitCode) else { return }
             stdoutPipe.fileHandleForReading.readabilityHandler = nil
             stderrPipe.fileHandleForReading.readabilityHandler = nil
-            process.terminationHandler = nil
-
+            exitSource.cancel()
             DispatchQueue.main.async { completion(resolvedExitCode) }
         }
 
@@ -368,49 +584,35 @@ enum Shell {
                 DispatchQueue.main.async { onOutput(str) }
             }
         }
-
         stderrPipe.fileHandleForReading.readabilityHandler = { handle in
             let data = handle.availableData
             if !data.isEmpty, let str = String(data: data, encoding: .utf8) {
                 DispatchQueue.main.async { onError(str) }
             }
         }
-
-        process.terminationHandler = { proc in
-            finish(exitCode: proc.terminationStatus)
+        exitSource.setEventHandler {
+            guard !state.hasTimedOut() else { return }
+            var status: Int32 = 0
+            let waited = waitpid(process.processIdentifier, &status, 0)
+            let exitCode: Int32 = waited == process.processIdentifier && status & 0x7f == 0
+                ? (status >> 8) & 0xff
+                : -1
+            finish(exitCode: exitCode)
         }
-
-        do {
-            try process.run()
-        } catch {
-            process.terminationHandler = nil
-            stdoutPipe.fileHandleForReading.readabilityHandler = nil
-            stderrPipe.fileHandleForReading.readabilityHandler = nil
-            onError("Failed to launch: \(error.localizedDescription)")
-            completion(-1)
-            return nil
-        }
+        exitSource.resume()
 
         if let timeout {
             let timeoutTask = Task {
                 let nanoseconds = UInt64(max(timeout, 0) * 1_000_000_000)
                 try? await Task.sleep(nanoseconds: nanoseconds)
                 guard !Task.isCancelled, state.markTimedOut() else { return }
-
-                let message = "Command timed out after \(Int(timeout))s"
-                DispatchQueue.main.async { onError(message) }
-                process.terminate()
-                try? await Task.sleep(nanoseconds: 2_000_000_000)
-                guard !Task.isCancelled, !state.hasFinished() else { return }
-
-                process.interrupt()
-                try? await Task.sleep(nanoseconds: 1_000_000_000)
-                guard !Task.isCancelled, !state.hasFinished() else { return }
-
-                Darwin.kill(process.processIdentifier, SIGKILL)
-                try? await Task.sleep(nanoseconds: 1_000_000_000)
+                DispatchQueue.main.async { onError("Command timed out after \(Int(timeout))s") }
+                await terminateTimedOutTree(processTree)
+                // The exit handler does not reap once timeout owns completion.
+                var status: Int32 = 0
+                _ = waitpid(process.processIdentifier, &status, 0)
                 guard !Task.isCancelled else { return }
-                finish(exitCode: -2)
+                finish(exitCode: -1)
             }
             state.setTimeoutTask(timeoutTask)
         }
@@ -418,16 +620,16 @@ enum Shell {
         return process
     }
 
-    /// Terminate a long-running child and escalate if it ignores graceful shutdown.
-    static func terminate(_ process: Process) {
-        process.terminate()
+    /// Terminate a long-running managed command and every descendant it has spawned.
+    static func terminate(_ process: ManagedProcess) {
+        guard process.processIdentifier > 0 else { return }
+        let processTree = ProcessTree(rootProcessID: process.processIdentifier)
         Task {
-            try? await Task.sleep(nanoseconds: 2_000_000_000)
-            guard process.isRunning else { return }
-            process.interrupt()
-            try? await Task.sleep(nanoseconds: 1_000_000_000)
-            guard process.isRunning else { return }
-            Darwin.kill(process.processIdentifier, SIGKILL)
+            terminateProcessTree(processTree, signal: SIGTERM)
+            if !(await waitForProcessTreeCleanup(processTree, timeout: 0.25)) {
+                terminateProcessTree(processTree, signal: SIGKILL)
+                _ = await waitForProcessTreeCleanup(processTree, timeout: 1)
+            }
         }
     }
 

--- a/Sources/Phosphor/ViewModels/BackupViewModel.swift
+++ b/Sources/Phosphor/ViewModels/BackupViewModel.swift
@@ -277,8 +277,10 @@ final class BackupViewModel: ObservableObject {
 
         let path = backup.path
         do {
-            try await Task.detached(priority: .userInitiated) {
-                try BackupUnlockStore.shared.unlock(backupPath: path, password: password)
+            try await Task.detached(priority: .userInitiated) { () throws -> Void in
+                // Keep the decryptor in BackupUnlockStore. Returning it from this
+                // detached task would cross the MainActor boundary with a non-Sendable value.
+                _ = try BackupUnlockStore.shared.unlock(backupPath: path, password: password)
             }.value
         } catch {
             unlockError = error.localizedDescription


### PR DESCRIPTION
## Summary

Hardens existing backup/export process boundaries where failures could destroy completed output, expose backup passwords, overwrite extracted media, or leave child processes running.

- stage archive output on the destination volume and publish only a completed archive
- serialize `pymobiledevice3` resolution without cache-reset/command-classification races
- keep `BackupDecryptor` inside the detached unlock operation
- fail closed when secure password-management tooling is unavailable instead of placing passwords in argv
- reserve, stage, and atomically publish collision-safe flattened photo exports
- run bounded commands in dedicated POSIX sessions and terminate/reap their complete process groups on timeout or cancellation

## Verification

- `python3 Scripts/regression/run.py` — 72 checks passed
- `swift build -c release` — passed without warnings
- executable parallel-photo reservation test passed
- executable TERM-ignoring late-fork process-group test passed
- executable timeout zombie-reaping probe returned `REAPED`
- `git diff --check` — passed

## Scope

This PR is based directly on upstream `main` and does not include features from other open PRs.
