### PR TITLE
Clarify Phosphor project description

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 <h1 align="center">Phosphor</h1>
 
 <p align="center">
-  <strong>Free and open-source iOS device manager for macOS.</strong><br>
+  <strong>Native iPhone, iPad, and iPod touch backup and data-management tools for macOS.</strong><br>
   <a href="https://github.com/momenbasel/Phosphor/releases/latest">Download</a> -
   <a href="https://momenbasel.github.io/Phosphor/">Website</a> -
   <a href="#features">Features</a> -
@@ -26,7 +26,7 @@
 
 ---
 
-Phosphor gives you complete control over your iPhone, iPad, and iPod touch without proprietary software, iCloud lock-in, or subscriptions. Built natively with SwiftUI and powered by [pymobiledevice3](https://github.com/doronz88/pymobiledevice3) with [libimobiledevice](https://libimobiledevice.org/) as fallback. Supports iOS 17-26+.
+Phosphor is a free and open-source macOS app for backing up iPhone, iPad, and iPod touch devices, browsing and restoring backup contents, exporting messages and photos, and managing apps—without subscriptions or iCloud lock-in. It is built natively with SwiftUI and powered by [pymobiledevice3](https://github.com/doronz88/pymobiledevice3), with [libimobiledevice](https://libimobiledevice.org/) as a fallback. Supports iOS 17-26+.
 
 ---
 


### PR DESCRIPTION
## Summary

Replaces the broad “iOS device manager” wording with a concrete description of what Phosphor does: device backups, backup browsing/restores, message and photo export, and app management.

The revised copy avoids the overbroad “complete control” claim while keeping the project's native, free/open-source, subscription-free positioning clear.

## Suggested GitHub About description

> Native, free and open-source iPhone and iPad manager for macOS: backups and restores, message/photo exports, and app management—without subscriptions or iCloud lock-in.

GitHub's repository About field is metadata and cannot be changed by a pull request; the text above is included for maintainers to apply when merging.

## Verification

- 64 regression checks passed
- `git diff --check` passed
