### PR TITLE
fix: fail closed for unavailable message attachments

### DIFF
--- a/Scripts/regression/checks/message_export.py
+++ b/Scripts/regression/checks/message_export.py
@@ -1175,6 +1175,29 @@ def test_csv_exports_share_formula_safe_helper(root: Path) -> None:
         assert_contains(src, "CSVExport.row", f"{rel} should use the shared CSV escaping/formula-neutralization helper")
 
 
+def test_requested_original_attachments_fail_closed_when_unavailable(root: Path) -> None:
+    src = read(root, "Sources/Phosphor/Services/MessageExporter.swift")
+    items = re.search(r"private func originalAttachmentItems.*?(?=\n    private func|\n    ///|\Z)", src, re.S)
+    assert items is not None, "originalAttachmentItems should exist"
+    assert_contains(src, "enum MessageExportError", "exports should expose a typed attachment failure")
+    assert_contains(items.group(0), "throw MessageExportError.attachmentUnavailable", "requested originals must abort before transcript publication when a source attachment is unavailable")
+    assert "let sourcePath = resolveAttachmentDiskPath(filename: filename) else { continue }" not in items.group(0), (
+        "requested original attachments must not silently disappear from a completed export"
+    )
+
+
+def test_mbox_attachment_payloads_stream_without_whole_file_reads(root: Path) -> None:
+    src = read(root, "Sources/Phosphor/Services/MessageExporter.swift")
+    mbox = re.search(r"private func exportMbox.*?(?=\n    private func|\n    ///|\Z)", src, re.S)
+    assert mbox is not None, "exportMbox should exist"
+    assert_contains(mbox.group(0), "streamAttachmentAsBase64", "MBOX attachments should be streamed in bounded chunks")
+    assert "Data(contentsOf:" not in mbox.group(0), "MBOX must not load entire attachment files into memory"
+    helper = re.search(r"private func streamAttachmentAsBase64.*?(?=\n    private func|\n    ///|\Z)", src, re.S)
+    assert helper is not None, "streamAttachmentAsBase64 helper should exist"
+    assert_contains(helper.group(0), "57", "base64 stream chunks should be 57 bytes / 76 output characters")
+    assert_contains(helper.group(0), "cancellationCheck", "MBOX attachment streaming should be cancellable")
+
+
 def test_message_export_writers_check_cancellation_inside_long_loops(root: Path) -> None:
     src = read(root, "Sources/Phosphor/Services/MessageExporter.swift")
     assert_contains(src, "cancellationCheck: (() throws -> Void)?", "Message exports should accept a cancellation checkpoint")

--- a/Sources/Phosphor/Services/MessageExporter.swift
+++ b/Sources/Phosphor/Services/MessageExporter.swift
@@ -5,6 +5,17 @@ import CommonCrypto
 ///
 /// The sms.db is stored at HomeDomain/Library/SMS/sms.db in the backup.
 /// Its SHA-1 hash in Manifest.db is the famous "3d0d7e5fb2ce288813306e4d4636395e047a3d28".
+enum MessageExportError: LocalizedError {
+    case attachmentUnavailable(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .attachmentUnavailable(let filename):
+            return "Could not read requested attachment: \(filename)"
+        }
+    }
+}
+
 struct MessageExportOptions {
     var startDate: Date? = nil
     var endDate: Date? = nil
@@ -918,10 +929,13 @@ final class MessageExporter {
         for message in messages {
             try cancellationCheck?()
             for attachment in message.attachments where !attachment.isPluginPayload {
-                guard let filename = attachment.filename,
-                      !filename.isEmpty,
-                      seenFilenames.insert(filename).inserted,
-                      let sourcePath = resolveAttachmentDiskPath(filename: filename) else { continue }
+                guard let filename = attachment.filename, !filename.isEmpty else {
+                    throw MessageExportError.attachmentUnavailable(attachment.displayName)
+                }
+                guard seenFilenames.insert(filename).inserted else { continue }
+                guard let sourcePath = resolveAttachmentDiskPath(filename: filename) else {
+                    throw MessageExportError.attachmentUnavailable(filename)
+                }
                 items.append(.init(
                     key: filename,
                     displayName: attachment.displayName,
@@ -1128,16 +1142,16 @@ final class MessageExporter {
 
             let body = msg.text ?? ""
             let inlineAttachments = msg.attachments.filter { !$0.isPluginPayload }
-            let embeddedAttachments: [(attachment: MessageAttachment, diskPath: String, data: Data)] = includeAttachments
-                ? inlineAttachments.compactMap { attachment in
-                    guard let filename = attachment.filename,
-                          let diskPath = resolveAttachmentDiskPath(filename: filename),
-                          let data = try? Data(contentsOf: URL(fileURLWithPath: diskPath)) else {
-                        return nil
+            var embeddedAttachments: [(attachment: MessageAttachment, diskPath: String)] = []
+            if includeAttachments {
+                for attachment in inlineAttachments {
+                    guard let filename = attachment.filename, !filename.isEmpty,
+                          let diskPath = resolveAttachmentDiskPath(filename: filename) else {
+                        throw MessageExportError.attachmentUnavailable(attachment.displayName)
                     }
-                    return (attachment, diskPath, data)
+                    embeddedAttachments.append((attachment, diskPath))
                 }
-                : []
+            }
 
             if !embeddedAttachments.isEmpty {
                 let boundary = "----=_Phosphor_\(mboxToken(msg.guid))"
@@ -1167,7 +1181,12 @@ final class MessageExporter {
                     append("Content-Type: \(mime); name=\"\(headerEncode(name))\"\(crlf)")
                     append("Content-Disposition: attachment; filename=\"\(headerEncode(name))\"\(crlf)")
                     append("Content-Transfer-Encoding: base64\(crlf)\(crlf)")
-                    append(embedded.data.base64EncodedString(options: [.lineLength76Characters, .endLineWithCarriageReturn, .endLineWithLineFeed]))
+                    if let writeError { throw writeError }
+                    try streamAttachmentAsBase64(
+                        at: embedded.diskPath,
+                        to: handle,
+                        cancellationCheck: cancellationCheck
+                    )
                     append(crlf)
                 }
                 append("--\(boundary)--\(crlf)\(crlf)")
@@ -1190,6 +1209,24 @@ final class MessageExporter {
         }
 
         if let writeError { throw writeError }
+    }
+
+    /// Stream MIME base64 in 57-byte blocks: each block becomes one RFC-compliant
+    /// 76-character line while keeping attachment memory bounded.
+    private func streamAttachmentAsBase64(
+        at path: String,
+        to output: FileHandle,
+        cancellationCheck: (() throws -> Void)? = nil
+    ) throws {
+        let input = try FileHandle(forReadingFrom: URL(fileURLWithPath: path))
+        defer { try? input.close() }
+        let crlf = Data("\r\n".utf8)
+        while let chunk = try input.read(upToCount: 57), !chunk.isEmpty {
+            try cancellationCheck?()
+            try output.write(contentsOf: chunk.base64EncodedData())
+            try output.write(contentsOf: crlf)
+        }
+        try cancellationCheck?()
     }
 
     /// Mbox bodies must escape lines that start with `From ` so the delimiter remains unambiguous.


### PR DESCRIPTION
## Summary
- Rebuilds the remaining export hardening on current `main`, preserving the shipped transaction and immutable attachment-sidecar architecture.
- Stops requested-original attachment exports before publication when an attachment cannot be resolved or read.
- Streams MBOX attachment base64 in bounded 57-byte chunks instead of reading whole files.

## Verification
- `python3 Scripts/regression/run.py` (141 checks)
- `swift build`
- `swift build -c release`
- `bash Scripts/build.sh`
- Independent review: no correctness or security blockers.

Supersedes the stale branch implementation without reintroducing unsafe prefix-based sidecar cleanup.