### PR TITLE
fix: surface SQLite read failures

### DIFF
--- a/Scripts/regression/checks/sqlite_reader.py
+++ b/Scripts/regression/checks/sqlite_reader.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sqlite3
+import subprocess
+import tempfile
+
+
+def read(root: Path, rel: str) -> str:
+    return (root / rel).read_text()
+
+
+def make_corrupt_database(path: Path) -> None:
+    connection = sqlite3.connect(path)
+    connection.execute("PRAGMA page_size=1024")
+    connection.execute("PRAGMA journal_mode=DELETE")
+    connection.execute("CREATE TABLE records(id INTEGER PRIMARY KEY, value BLOB)")
+    for index in range(1, 501):
+        connection.execute("INSERT INTO records(value) VALUES (?)", (bytes([index % 251]) * 700,))
+    connection.commit()
+    connection.close()
+
+    page_size = 1024
+    page_count = path.stat().st_size // page_size
+    target_page = max(5, page_count // 2)
+    with path.open("r+b") as handle:
+        handle.seek((target_page - 1) * page_size)
+        handle.write(b"\0" * page_size)
+
+
+def test_sqlite_reader_throws_on_terminal_step_errors(root: Path) -> None:
+    source = root / "Sources/Phosphor/Utilities/SQLiteReader.swift"
+    probe = r'''
+import Foundation
+
+@main
+struct Probe {
+    static func main() throws {
+        let reader = try SQLiteReader(path: CommandLine.arguments[1])
+        do {
+            let rows = try reader.query("SELECT id, length(value) FROM records ORDER BY id")
+            print("ROWS|\(rows.count)")
+        } catch {
+            print("ERROR|\(error.localizedDescription)")
+        }
+    }
+}
+'''
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp = Path(temp_dir)
+        database = temp / "corrupt.sqlite"
+        make_corrupt_database(database)
+        probe_path = temp / "Probe.swift"
+        probe_path.write_text(probe)
+        executable = temp / "sqlite-step-probe"
+        compile_result = subprocess.run(
+            ["swiftc", "-parse-as-library", str(source), str(probe_path), "-lsqlite3", "-o", str(executable)],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        assert compile_result.returncode == 0, compile_result.stderr
+        result = subprocess.run([str(executable), str(database)], capture_output=True, text=True, timeout=15)
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.startswith("ERROR|"), (
+        "SQLiteReader must not silently return partial rows when sqlite3_step fails; " + result.stdout
+    )
+    assert "malformed" in result.stdout.lower(), result.stdout
+
+
+def test_sqlite_reader_copies_bound_text_and_checks_bind_failures(root: Path) -> None:
+    source = read(root, "Sources/Phosphor/Utilities/SQLiteReader.swift")
+    assert "SQLITE_TRANSIENT" in source, "bound strings must be copied for the statement lifetime"
+    assert "sqlite3_bind_text" in source and "bindFailed" in source, "bind return codes must be checked and typed"
+    assert "while true" in source and "SQLITE_DONE" in source, "query must distinguish DONE from terminal step errors"

--- a/Sources/Phosphor/Utilities/SQLiteReader.swift
+++ b/Sources/Phosphor/Utilities/SQLiteReader.swift
@@ -1,6 +1,8 @@
 import Foundation
 #if canImport(SQLite3)
 import SQLite3
+
+private let SQLITE_TRANSIENT = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
 #endif
 
 /// Lightweight SQLite wrapper for reading iOS backup databases.
@@ -13,12 +15,14 @@ final class SQLiteReader {
         case openFailed(String)
         case queryFailed(String)
         case prepareFailed(String)
+        case bindFailed(String)
 
         var errorDescription: String? {
             switch self {
             case .openFailed(let msg): return "SQLite open failed: \(msg)"
             case .queryFailed(let msg): return "SQLite query failed: \(msg)"
             case .prepareFailed(let msg): return "SQLite prepare failed: \(msg)"
+            case .bindFailed(let msg): return "SQLite bind failed: \(msg)"
             }
         }
     }
@@ -70,13 +74,24 @@ final class SQLiteReader {
 
         // Bind parameters
         for (index, param) in params.enumerated() {
-            sqlite3_bind_text(statement, Int32(index + 1), (param as NSString).utf8String, -1, nil)
+            let bindResult = param.withCString { pointer in
+                sqlite3_bind_text(statement, Int32(index + 1), pointer, -1, SQLITE_TRANSIENT)
+            }
+            guard bindResult == SQLITE_OK else {
+                throw SQLiteError.bindFailed(String(cString: sqlite3_errmsg(db)))
+            }
         }
 
         var rows: [[String: Any?]] = []
         let columnCount = sqlite3_column_count(statement)
 
-        while sqlite3_step(statement) == SQLITE_ROW {
+        while true {
+            let stepResult = sqlite3_step(statement)
+            if stepResult == SQLITE_DONE { break }
+            guard stepResult == SQLITE_ROW else {
+                throw SQLiteError.queryFailed(String(cString: sqlite3_errmsg(db)))
+            }
+
             var row: [String: Any?] = [:]
             for i in 0..<columnCount {
                 let name = String(cString: sqlite3_column_name(statement, i))


### PR DESCRIPTION
## Summary
- make SQLite text bindings own their bytes with `SQLITE_TRANSIENT`
- validate bind results and query setup failures
- throw on terminal `sqlite3_step` errors instead of returning accumulated partial rows
- add a corrupted-database regression that proves partial data is not reported as success

## Why
A database that failed after returning some rows could previously look like a successful but incomplete read. Search, export, and browsing callers need a real failure so they can report the problem instead of trusting partial data.

## Verification
- `python3 Scripts/regression/run.py`
- `swift build -Xswiftc -strict-concurrency=complete`
- `swift build -c release`
- `bash Scripts/build.sh`
- independent blocker review: PASS, no P0/P1 findings
- clean integration with the three companion branches: 79 regression checks, debug build, and release build passed
