### PR TITLE
feat: add unified backup search

### DIFF
--- a/Scripts/regression/checks/sqlite_reader.py
+++ b/Scripts/regression/checks/sqlite_reader.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sqlite3
+import subprocess
+import tempfile
+
+
+def read(root: Path, rel: str) -> str:
+    return (root / rel).read_text()
+
+
+def make_corrupt_database(path: Path) -> None:
+    connection = sqlite3.connect(path)
+    connection.execute("PRAGMA page_size=1024")
+    connection.execute("PRAGMA journal_mode=DELETE")
+    connection.execute("CREATE TABLE records(id INTEGER PRIMARY KEY, value BLOB)")
+    for index in range(1, 501):
+        connection.execute("INSERT INTO records(value) VALUES (?)", (bytes([index % 251]) * 700,))
+    connection.commit()
+    connection.close()
+
+    page_size = 1024
+    page_count = path.stat().st_size // page_size
+    target_page = max(5, page_count // 2)
+    with path.open("r+b") as handle:
+        handle.seek((target_page - 1) * page_size)
+        handle.write(b"\0" * page_size)
+
+
+def test_sqlite_reader_throws_on_terminal_step_errors(root: Path) -> None:
+    source = root / "Sources/Phosphor/Utilities/SQLiteReader.swift"
+    probe = r'''
+import Foundation
+
+@main
+struct Probe {
+    static func main() throws {
+        let reader = try SQLiteReader(path: CommandLine.arguments[1])
+        do {
+            let rows = try reader.query("SELECT id, length(value) FROM records ORDER BY id")
+            print("ROWS|\(rows.count)")
+        } catch {
+            print("ERROR|\(error.localizedDescription)")
+        }
+    }
+}
+'''
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp = Path(temp_dir)
+        database = temp / "corrupt.sqlite"
+        make_corrupt_database(database)
+        probe_path = temp / "Probe.swift"
+        probe_path.write_text(probe)
+        executable = temp / "sqlite-step-probe"
+        compile_result = subprocess.run(
+            ["swiftc", "-parse-as-library", str(source), str(probe_path), "-lsqlite3", "-o", str(executable)],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        assert compile_result.returncode == 0, compile_result.stderr
+        result = subprocess.run([str(executable), str(database)], capture_output=True, text=True, timeout=15)
+
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.startswith("ERROR|"), (
+        "SQLiteReader must not silently return partial rows when sqlite3_step fails; " + result.stdout
+    )
+    assert "malformed" in result.stdout.lower(), result.stdout
+
+
+def test_sqlite_reader_copies_bound_text_and_checks_bind_failures(root: Path) -> None:
+    source = read(root, "Sources/Phosphor/Utilities/SQLiteReader.swift")
+    assert "SQLITE_TRANSIENT" in source, "bound strings must be copied for the statement lifetime"
+    assert "sqlite3_bind_text" in source and "bindFailed" in source, "bind return codes must be checked and typed"
+    assert "while true" in source and "SQLITE_DONE" in source, "query must distinguish DONE from terminal step errors"

--- a/Scripts/regression/checks/unified_search.py
+++ b/Scripts/regression/checks/unified_search.py
@@ -1,0 +1,380 @@
+from __future__ import annotations
+
+from pathlib import Path
+import sqlite3
+import subprocess
+import tempfile
+
+
+def read(root: Path, rel: str) -> str:
+    return (root / rel).read_text()
+
+
+def test_unified_search_export_is_deterministic_and_formula_safe(root: Path) -> None:
+    model = root / "Sources/Phosphor/Models/UnifiedSearchResult.swift"
+    exporter = root / "Sources/Phosphor/Services/UnifiedSearchExporter.swift"
+    csv_helper = root / "Sources/Phosphor/Utilities/CSVExport.swift"
+    assert model.exists(), "UnifiedSearchResult must exist"
+    assert exporter.exists(), "UnifiedSearchExporter must exist"
+
+    probe = r'''
+import Foundation
+
+@main
+struct Probe {
+    static func main() throws {
+        let results = [
+            UnifiedSearchResult(source: .notes, sourceID: "2", title: "=formula", subtitle: "Folder", snippet: "second", date: nil),
+            UnifiedSearchResult(source: .messages, sourceID: "1", title: "Alice", subtitle: "Message", snippet: "first", date: Date(timeIntervalSince1970: 10)),
+        ]
+        let csv = UnifiedSearchExporter.csvData(results: results)
+        let json = try UnifiedSearchExporter.jsonData(results: results)
+        print("CSV|" + String(decoding: csv, as: UTF8.self).replacingOccurrences(of: "\n", with: "<NL>"))
+        let decoded = try JSONSerialization.jsonObject(with: json) as! [[String: Any]]
+        print("JSON|\(decoded.count)|\(decoded[0]["source"] as! String)|\(decoded[1]["source"] as! String)")
+        print("PRIVATE_IDS|\(decoded.contains { $0["source_id"] != nil })")
+    }
+}
+'''
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp = Path(temp_dir)
+        probe_path = temp / "Probe.swift"
+        probe_path.write_text(probe)
+        executable = temp / "unified-search-export-probe"
+        compile_result = subprocess.run(
+            ["swiftc", "-parse-as-library", str(csv_helper), str(model), str(exporter), str(probe_path), "-o", str(executable)],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        assert compile_result.returncode == 0, compile_result.stderr
+        result = subprocess.run([str(executable)], capture_output=True, text=True, timeout=10)
+
+    assert result.returncode == 0, result.stderr
+    assert "CSV|Source,Title,Subtitle,Snippet,Date<NL>" in result.stdout, result.stdout
+    assert "'=formula" in result.stdout, "spreadsheet formula prefixes must be neutralized"
+    assert "JSON|2|messages|notes" in result.stdout, "exports must use stable chronological/source ordering"
+    assert "PRIVATE_IDS|false" in result.stdout, "JSON must not expose backup hashes or database row identifiers"
+
+
+def test_unified_search_covers_backup_data_sources(root: Path) -> None:
+    service = read(root, "Sources/Phosphor/Services/UnifiedSearchService.swift")
+    model = read(root, "Sources/Phosphor/Models/UnifiedSearchResult.swift")
+    notes = read(root, "Sources/Phosphor/Services/NotesExtractor.swift")
+    contacts = read(root, "Sources/Phosphor/Services/ContactsExtractor.swift")
+    safari = read(root, "Sources/Phosphor/Services/SafariExtractor.swift")
+    calls = read(root, "Sources/Phosphor/Services/CallLogExtractor.swift")
+    for case in ["messages", "whatsApp", "notes", "contacts", "callLog", "safari", "files"]:
+        assert f"case {case}" in model, f"missing unified search source {case}"
+    for adapter in [
+        "MessageExporter", "WhatsAppExporter", "NotesExtractor", "ContactsExtractor",
+        "CallLogExtractor", "SafariExtractor", "BackupManifest",
+    ]:
+        assert adapter in service, f"UnifiedSearchService must search {adapter}"
+    assert "Task.checkCancellation()" in service, "source fan-in must be cancellable between expensive adapters"
+    assert "sourceErrors" in service, "one unavailable source must not hide results from healthy sources"
+    assert "error.localizedDescription" not in service, "source failures must not expose backup paths or private identifiers"
+    assert "case lockedBackup" in service and "case invalidBackup" in service
+    assert "BackupManifest.ManifestError" in service, "search should preflight locked/incomplete backups once"
+    assert "searchNotes(normalized, limit: limitPerSource)" in service
+    assert "searchContacts(normalized, limit: limitPerSource)" in service
+    assert "searchBookmarks(normalized, limit: limitPerSource)" in service
+    assert "searchHistory(normalized, limit: limitPerSource)" in service
+    safari_block = service.split("if sources.contains(.safari)", 1)[1].split("try attempt(.files)", 1)[0]
+    assert "try attempt(.safari)" not in service
+    assert safari_block.count("} catch is CancellationError {") == 2
+    assert safari_block.count("sourceErrors[.safari]") == 2
+    assert safari_block.index("searchBookmarks") < safari_block.index("searchHistory")
+    assert "func searchNotes(_ query: String, limit: Int" in notes
+    assert "ZHTMLSTRING" not in notes.split("func searchNotes(_ query: String, limit: Int", 1)[1], "search must not load full note HTML"
+    assert "func searchContacts(_ query: String, limit: Int" in contacts
+    assert "func searchBookmarks(_ query: String, limit: Int" in safari
+    assert "func searchHistory(_ query: String, limit: Int" in safari
+    assert "searchCallLog(normalized, limit: limitPerSource)" in service
+    assert "func searchCallLog(_ query: String, limit: Int" in calls
+    assert "WHERE \\(predicate)" in calls and "LIMIT \\(boundedLimit)" in calls
+    assert "interleave(bookmarks, history, limit: limitPerSource)" in service
+    assert '"source_id"' not in read(root, "Sources/Phosphor/Services/UnifiedSearchExporter.swift")
+
+
+def test_unified_search_warns_and_drops_partial_corrupt_safari_history(root: Path) -> None:
+    support = r'''
+import Foundation
+
+extension Date {
+    var shortString: String { "" }
+    var iso8601String: String { "" }
+}
+
+enum MessageExportFormat { case csv, json, text }
+enum CSVExport { static func row(_ values: [String]) -> String { "" } }
+
+struct StubMessage {
+    let id = 1
+    let senderLabel = ""
+    let service = ""
+    let displayText = ""
+    let date: Date? = nil
+    let isFromMe = false
+    let senderJid: String? = nil
+}
+final class MessageExporter {
+    init(backupPath: String) throws {}
+    func searchMessages(_ query: String, limit: Int) throws -> [StubMessage] { [] }
+}
+final class WhatsAppExporter {
+    init(backupPath: String) throws {}
+    func searchMessages(_ query: String, limit: Int) throws -> [StubMessage] { [] }
+}
+
+struct StubNote {
+    let id = 1
+    let displayTitle = ""
+    let folderName = ""
+    let snippet = ""
+    let modifiedDate: Date? = nil
+}
+final class NotesExtractor {
+    init(backupPath: String) throws {}
+    func searchNotes(_ query: String, limit: Int) throws -> [StubNote] { [] }
+}
+
+struct StubContact {
+    let id = 1
+    let phoneNumbers: [String] = []
+    let emails: [String] = []
+    let fullName = ""
+    let organization = ""
+    let createdDate: Date? = nil
+}
+final class ContactsExtractor {
+    init(backupPath: String) throws {}
+    func searchContacts(_ query: String, limit: Int) throws -> [StubContact] { [] }
+}
+
+struct StubCallType { let label = "" }
+struct StubCall {
+    let id = 1
+    let address = ""
+    let callType = StubCallType()
+    let durationString = ""
+    let date: Date? = nil
+}
+final class CallLogExtractor {
+    init(backupPath: String) throws {}
+    func searchCallLog(_ query: String, limit: Int) throws -> [StubCall] { [] }
+}
+
+enum UnifiedSearchExporter {
+    static func ordered(_ results: [UnifiedSearchResult]) -> [UnifiedSearchResult] { results }
+}
+
+final class BackupManifest {
+    enum ManifestError: Error { case backupEncrypted, manifestMissing, manifestUnreadable }
+    struct FileEntry {
+        let id: String
+        let isFile: Bool
+        let relativePath: String
+        let domain: String
+        let fileName: String
+        let diskPath: String
+    }
+
+    private let backupPath: String
+    init(backupPath: String) throws { self.backupPath = backupPath }
+
+    func search(_ query: String, limit: Int = 250) throws -> [FileEntry] {
+        let name: String
+        if query.contains("Bookmarks.db") { name = "Bookmarks.db" }
+        else if query.contains("History.db") { name = "History.db" }
+        else { return [] }
+        return [FileEntry(
+            id: name,
+            isFile: true,
+            relativePath: "Library/Safari/\(name)",
+            domain: "HomeDomain",
+            fileName: name,
+            diskPath: (backupPath as NSString).appendingPathComponent(name)
+        )]
+    }
+
+    func readablePath(for entry: FileEntry) throws -> String { entry.diskPath }
+}
+'''
+    probe = r'''
+import Foundation
+
+@main
+struct Probe {
+    static func main() throws {
+        let response = try UnifiedSearchService.search(
+            query: "needle",
+            backupPath: CommandLine.arguments[1],
+            sources: Set([.safari]),
+            limitPerSource: 1_000
+        )
+        let bookmarkCount = response.results.filter { $0.sourceID.hasPrefix("bookmark-") }.count
+        let historyCount = response.results.filter { $0.sourceID.hasPrefix("history-") }.count
+        let warning = response.sourceErrors[.safari] ?? "missing"
+        print("BOOKMARKS|\(bookmarkCount)")
+        print("HISTORY|\(historyCount)")
+        print("WARNING|\(warning)")
+        print("PRIVATE|\(warning.contains(CommandLine.arguments[1]))")
+    }
+}
+'''
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp = Path(temp_dir)
+        bookmarks = temp / "Bookmarks.db"
+        connection = sqlite3.connect(bookmarks)
+        connection.execute(
+            "CREATE TABLE bookmarks(id INTEGER PRIMARY KEY, title TEXT, url TEXT, order_index INTEGER, parent INTEGER)"
+        )
+        connection.execute("INSERT INTO bookmarks VALUES (1, 'Folder', NULL, 0, NULL)")
+        connection.execute("INSERT INTO bookmarks VALUES (2, 'needle bookmark', 'https://example.invalid', 1, 1)")
+        connection.commit()
+        connection.close()
+
+        history = temp / "History.db"
+        connection = sqlite3.connect(history)
+        connection.execute("PRAGMA page_size=1024")
+        connection.execute("PRAGMA journal_mode=DELETE")
+        connection.execute(
+            "CREATE TABLE history_items(id INTEGER PRIMARY KEY, url TEXT, title TEXT, visit_count INTEGER)"
+        )
+        connection.execute("CREATE TABLE history_visits(history_item INTEGER, visit_time REAL)")
+        for index in range(1, 2_001):
+            connection.execute(
+                "INSERT INTO history_items VALUES (?, ?, ?, 1)",
+                (index, f"https://example.invalid/{index}", f"needle-{index}-" + ("x" * 700)),
+            )
+            connection.execute("INSERT INTO history_visits VALUES (?, ?)", (index, float(index)))
+        connection.commit()
+        connection.close()
+        page_size = 1024
+        page_count = history.stat().st_size // page_size
+        with history.open("r+b") as handle:
+            handle.seek((max(10, page_count // 3) - 1) * page_size)
+            handle.write(b"\0" * page_size)
+
+        support_path = temp / "Support.swift"
+        support_path.write_text(support)
+        probe_path = temp / "Probe.swift"
+        probe_path.write_text(probe)
+        executable = temp / "unified-search-corrupt-source-probe"
+        compile_result = subprocess.run(
+            [
+                "swiftc", "-parse-as-library",
+                str(root / "Sources/Phosphor/Utilities/SQLiteReader.swift"),
+                str(root / "Sources/Phosphor/Models/UnifiedSearchResult.swift"),
+                str(root / "Sources/Phosphor/Services/SafariExtractor.swift"),
+                str(root / "Sources/Phosphor/Services/UnifiedSearchService.swift"),
+                str(support_path), str(probe_path), "-lsqlite3", "-o", str(executable),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=90,
+        )
+        assert compile_result.returncode == 0, compile_result.stderr
+        result = subprocess.run([str(executable), str(temp)], capture_output=True, text=True, timeout=30)
+
+    assert result.returncode == 0, result.stderr
+    assert "BOOKMARKS|1" in result.stdout, result.stdout
+    assert "HISTORY|0" in result.stdout, "corrupt history rows must not be published as complete: " + result.stdout
+    assert "WARNING|Some Safari data could not be searched in the selected backup." in result.stdout, result.stdout
+    assert "PRIVATE|false" in result.stdout, "source warnings must not expose backup paths: " + result.stdout
+
+
+def test_call_log_search_queries_before_limiting(root: Path) -> None:
+    probe = r'''
+import Foundation
+
+extension Int { var formattedFileSize: String { String(self) } }
+extension Date { var shortString: String { "" } }
+enum CSVExport { static func row(_ values: [String]) -> String { "" } }
+
+final class BackupManifest {
+    struct FileEntry { let isFile = false }
+    init(backupPath: String) throws {}
+    func search(_ query: String) throws -> [FileEntry] { [] }
+    func readablePath(for entry: FileEntry) throws -> String { "" }
+}
+
+@main
+struct Probe {
+    static func main() throws {
+        let extractor = try CallLogExtractor(databasePath: CommandLine.arguments[1])
+        let found = try extractor.searchCallLog("needle", limit: 10)
+        print("FOUND|\(found.count)|\(found.first?.address ?? "")")
+    }
+}
+'''
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp = Path(temp_dir)
+        database = temp / "calls.sqlite"
+        connection = sqlite3.connect(database)
+        connection.execute(
+            "CREATE TABLE ZCALLRECORD (Z_PK INTEGER, ZADDRESS TEXT, ZDATE REAL, "
+            "ZDURATION REAL, ZCALLTYPE INTEGER, ZISO_COUNTRY_CODE TEXT)"
+        )
+        connection.executemany(
+            "INSERT INTO ZCALLRECORD VALUES (?, ?, ?, 0, 1, 'US')",
+            [(index, f"recent-{index}", float(index)) for index in range(2, 1_102)],
+        )
+        connection.execute("INSERT INTO ZCALLRECORD VALUES (1, 'needle', 1, 0, 1, 'US')")
+        connection.commit()
+        connection.close()
+
+        probe_path = temp / "Probe.swift"
+        probe_path.write_text(probe)
+        executable = temp / "call-search-probe"
+        compile_result = subprocess.run(
+            [
+                "swiftc", "-parse-as-library",
+                str(root / "Sources/Phosphor/Utilities/SQLiteReader.swift"),
+                str(root / "Sources/Phosphor/Models/MediaItem.swift"),
+                str(root / "Sources/Phosphor/Services/CallLogExtractor.swift"),
+                str(probe_path), "-lsqlite3", "-o", str(executable),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        assert compile_result.returncode == 0, compile_result.stderr
+        result = subprocess.run([str(executable), str(database)], capture_output=True, text=True, timeout=10)
+
+    assert result.returncode == 0, result.stderr
+    assert "FOUND|1|needle" in result.stdout, result.stdout
+
+
+def test_unified_search_ui_ignores_stale_results_and_exports_selection(root: Path) -> None:
+    vm = read(root, "Sources/Phosphor/ViewModels/UnifiedSearchViewModel.swift")
+    view = read(root, "Sources/Phosphor/Views/Search/UnifiedSearchView.swift")
+    sidebar = read(root, "Sources/Phosphor/Views/SidebarView.swift")
+    content = read(root, "Sources/Phosphor/Views/ContentView.swift")
+    app = read(root, "Sources/Phosphor/App/PhosphorApp.swift")
+
+    assert "searchOperationID" in vm
+    assert "searchOperationID == operationID" in vm
+    assert "Task.detached" in vm, "backup database search must not run on the main actor"
+    assert "withTaskCancellationHandler" in vm
+    assert "worker.cancel()" in vm
+    assert vm.count("results = []") >= 3, "backup changes, new searches, and cancellation must invalidate old results"
+    assert "selectedResultIDs" in vm
+    assert "Export Selected" in view
+    assert "Unified Search" in sidebar
+    assert "UnifiedSearchView" in content
+    assert "@EnvironmentObject private var viewModel: UnifiedSearchViewModel" in view
+    assert "@StateObject private var unifiedSearchVM = UnifiedSearchViewModel()" in app
+    assert ".environmentObject(unifiedSearchVM)" in app
+    empty_results_branch = view.split("} else if viewModel.results.isEmpty {", 1)[1].split("} else {", 1)[0]
+    assert "!viewModel.sourceErrors.isEmpty" in empty_results_branch
+    assert "sourceWarnings" in empty_results_branch, "zero-result source failures must remain visible"
+
+
+def test_unified_search_requires_an_explicit_backup(root: Path) -> None:
+    vm = read(root, "Sources/Phosphor/ViewModels/UnifiedSearchViewModel.swift")
+    view = read(root, "Sources/Phosphor/Views/Search/UnifiedSearchView.swift")
+    assert "selectedBackup" in vm
+    assert "No Backup Selected" in view
+    assert "Choose Backup" in view or "backupPicker" in view

--- a/Sources/Phosphor/App/PhosphorApp.swift
+++ b/Sources/Phosphor/App/PhosphorApp.swift
@@ -36,6 +36,7 @@ struct PhosphorApp: App {
     @NSApplicationDelegateAdaptor(PhosphorAppDelegate.self) private var appDelegate
     @StateObject private var deviceVM = DeviceViewModel()
     @StateObject private var backupVM = BackupViewModel()
+    @StateObject private var unifiedSearchVM = UnifiedSearchViewModel()
     @StateObject private var scheduler = BackupScheduler()
     @AppStorage("phosphor.hasCompletedOnboarding") private var hasCompletedOnboarding = false
 
@@ -51,6 +52,7 @@ struct PhosphorApp: App {
             ContentView()
                 .environmentObject(deviceVM)
                 .environmentObject(backupVM)
+                .environmentObject(unifiedSearchVM)
                 .frame(minWidth: 960, minHeight: 640)
                 .onAppear {
                     Task {

--- a/Sources/Phosphor/Models/BackupInfo.swift
+++ b/Sources/Phosphor/Models/BackupInfo.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Represents an iOS backup stored on disk.
-struct BackupInfo: Identifiable, Hashable {
+struct BackupInfo: Identifiable, Hashable, Sendable {
     let id: String // backup directory name (usually UDID or UDID+timestamp)
     let path: String
     let deviceName: String

--- a/Sources/Phosphor/Models/UnifiedSearchResult.swift
+++ b/Sources/Phosphor/Models/UnifiedSearchResult.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+enum UnifiedSearchSource: String, CaseIterable, Codable, Hashable, Sendable {
+    case messages
+    case whatsApp
+    case notes
+    case contacts
+    case callLog
+    case safari
+    case files
+
+    var label: String {
+        switch self {
+        case .messages: return "Messages"
+        case .whatsApp: return "WhatsApp"
+        case .notes: return "Notes"
+        case .contacts: return "Contacts"
+        case .callLog: return "Call Log"
+        case .safari: return "Safari"
+        case .files: return "Files"
+        }
+    }
+
+    var icon: String {
+        switch self {
+        case .messages: return "message.fill"
+        case .whatsApp: return "bubble.left.and.text.bubble.right.fill"
+        case .notes: return "note.text"
+        case .contacts: return "person.crop.circle"
+        case .callLog: return "phone"
+        case .safari: return "safari"
+        case .files: return "doc.text.magnifyingglass"
+        }
+    }
+}
+
+struct UnifiedSearchResult: Identifiable, Hashable, Sendable {
+    let source: UnifiedSearchSource
+    let sourceID: String
+    let title: String
+    let subtitle: String
+    let snippet: String
+    let date: Date?
+
+    var id: String { "\(source.rawValue):\(sourceID)" }
+}
+
+struct UnifiedSearchResponse: Sendable {
+    let results: [UnifiedSearchResult]
+    let sourceErrors: [UnifiedSearchSource: String]
+}

--- a/Sources/Phosphor/Services/CallLogExtractor.swift
+++ b/Sources/Phosphor/Services/CallLogExtractor.swift
@@ -53,6 +53,56 @@ final class CallLogExtractor {
         return []
     }
 
+    /// Search the entire call database before applying the result limit.
+    /// This avoids hiding an older exact match behind a fixed recent-call window.
+    func searchCallLog(_ query: String, limit: Int = 250) throws -> [CallLogEntry] {
+        let normalized = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !normalized.isEmpty else { return [] }
+        let boundedLimit = max(1, min(limit, 1_000))
+        let pattern = "%\(normalized)%"
+        let matchingTypes = [
+            CallLogEntry.CallType.incoming,
+            .outgoing,
+            .missed,
+        ].filter { $0.label.localizedCaseInsensitiveContains(normalized) }
+        let tables = try db.tableNames()
+
+        if tables.contains("ZCALLRECORD") {
+            var predicate = "ZADDRESS LIKE ? COLLATE NOCASE"
+            if !matchingTypes.isEmpty {
+                predicate += " OR ZCALLTYPE IN (\(matchingTypes.map { String($0.rawValue) }.joined(separator: ",")))"
+            }
+            let rows = try db.query("""
+                SELECT Z_PK, ZADDRESS, ZDATE, ZDURATION, ZCALLTYPE, ZISO_COUNTRY_CODE
+                FROM ZCALLRECORD
+                WHERE \(predicate)
+                ORDER BY ZDATE DESC, Z_PK DESC
+                LIMIT \(boundedLimit)
+            """, params: [pattern])
+            return modernEntries(from: rows)
+        }
+
+        if tables.contains("call") {
+            var legacyFlags: [Int] = []
+            if matchingTypes.contains(.incoming) { legacyFlags.append(4) }
+            if matchingTypes.contains(.outgoing) { legacyFlags.append(5) }
+            var predicate = "address LIKE ? COLLATE NOCASE"
+            if !legacyFlags.isEmpty {
+                predicate += " OR flags IN (\(legacyFlags.map(String.init).joined(separator: ",")))"
+            }
+            let rows = try db.query("""
+                SELECT ROWID, address, date, duration, flags
+                FROM call
+                WHERE \(predicate)
+                ORDER BY date DESC, ROWID DESC
+                LIMIT \(boundedLimit)
+            """, params: [pattern])
+            return legacyEntries(from: rows)
+        }
+
+        return []
+    }
+
     private func getModernCallLog(limit: Int) throws -> [CallLogEntry] {
         let sql = """
             SELECT
@@ -67,8 +117,11 @@ final class CallLogExtractor {
             LIMIT \(limit)
         """
 
-        let rows = try db.query(sql)
-        return rows.compactMap { row -> CallLogEntry? in
+        return modernEntries(from: try db.query(sql))
+    }
+
+    private func modernEntries(from rows: [[String: Any?]]) -> [CallLogEntry] {
+        rows.compactMap { row -> CallLogEntry? in
             guard let pk = row["Z_PK"] as? Int,
                   let address = row["ZADDRESS"] as? String else { return nil }
 
@@ -103,8 +156,11 @@ final class CallLogExtractor {
             LIMIT \(limit)
         """
 
-        let rows = try db.query(sql)
-        return rows.compactMap { row -> CallLogEntry? in
+        return legacyEntries(from: try db.query(sql))
+    }
+
+    private func legacyEntries(from rows: [[String: Any?]]) -> [CallLogEntry] {
+        rows.compactMap { row -> CallLogEntry? in
             guard let rowId = row["ROWID"] as? Int,
                   let address = row["address"] as? String else { return nil }
 

--- a/Sources/Phosphor/Services/ContactsExtractor.swift
+++ b/Sources/Phosphor/Services/ContactsExtractor.swift
@@ -111,6 +111,71 @@ final class ContactsExtractor {
         return contacts
     }
 
+    /// Search contacts in SQLite before materializing rows. The result and
+    /// phone/email fan-out are bounded by `limit` so unified search cannot load
+    /// an entire address book for one query.
+    func searchContacts(_ query: String, limit: Int = 250) throws -> [Contact] {
+        let knownHash = "31bb7ba8914766d4ba40d6dfb6113c8b614be442"
+        var dbPath = manifest.isDecrypting ? "" : "\(backupPath)/\(knownHash.prefix(2))/\(knownHash)"
+        if !FileManager.default.fileExists(atPath: dbPath) {
+            guard let entry = try manifest.files(matching: "%AddressBook.sqlitedb").first(where: { $0.domain == "HomeDomain" }) else {
+                throw NSError(domain: "Phosphor", code: 404, userInfo: [NSLocalizedDescriptionKey: "AddressBook database not found in backup"])
+            }
+            dbPath = try manifest.readablePath(for: entry)
+        }
+
+        let db = try SQLiteReader(path: dbPath)
+        guard try db.tableNames().contains("ABPerson") else {
+            throw NSError(domain: "Phosphor", code: 500, userInfo: [NSLocalizedDescriptionKey: "Invalid AddressBook database"])
+        }
+
+        let boundedLimit = max(1, min(limit, 1_000))
+        let pattern = "%\(query)%"
+        let persons = try db.query("""
+            SELECT DISTINCT p.ROWID, p.First, p.Last, p.Organization, p.CreationDate
+            FROM ABPerson p
+            LEFT JOIN ABMultiValue mv ON mv.record_id = p.ROWID AND mv.property IN (3, 4)
+            WHERE p.First LIKE ? COLLATE NOCASE
+               OR p.Last LIKE ? COLLATE NOCASE
+               OR p.Organization LIKE ? COLLATE NOCASE
+               OR mv.value LIKE ? COLLATE NOCASE
+            ORDER BY COALESCE(p.First, '') || COALESCE(p.Last, '') || COALESCE(p.Organization, '')
+            LIMIT \(boundedLimit)
+        """, params: [pattern, pattern, pattern, pattern])
+
+        let ids = persons.compactMap { $0["ROWID"] as? Int }
+        guard !ids.isEmpty else { return [] }
+        let idList = ids.map(String.init).joined(separator: ",")
+        let phoneRows = try db.query("SELECT record_id, value FROM ABMultiValue WHERE property = 3 AND record_id IN (\(idList)) ORDER BY record_id")
+        let emailRows = try db.query("SELECT record_id, value FROM ABMultiValue WHERE property = 4 AND record_id IN (\(idList)) ORDER BY record_id")
+
+        var phones: [Int: [String]] = [:]
+        for row in phoneRows {
+            if let id = row["record_id"] as? Int, let value = row["value"] as? String {
+                phones[id, default: []].append(value)
+            }
+        }
+        var emails: [Int: [String]] = [:]
+        for row in emailRows {
+            if let id = row["record_id"] as? Int, let value = row["value"] as? String {
+                emails[id, default: []].append(value)
+            }
+        }
+
+        return persons.compactMap { row in
+            guard let id = row["ROWID"] as? Int else { return nil }
+            return Contact(
+                id: id,
+                firstName: (row["First"] as? String) ?? "",
+                lastName: (row["Last"] as? String) ?? "",
+                organization: (row["Organization"] as? String) ?? "",
+                phoneNumbers: phones[id] ?? [],
+                emails: emails[id] ?? [],
+                createdDate: (row["CreationDate"] as? Double).map { Date(timeIntervalSinceReferenceDate: $0) }
+            )
+        }
+    }
+
     /// Get contact count without loading all data.
     func getContactCount() throws -> Int {
         let knownHash = "31bb7ba8914766d4ba40d6dfb6113c8b614be442"

--- a/Sources/Phosphor/Services/NotesExtractor.swift
+++ b/Sources/Phosphor/Services/NotesExtractor.swift
@@ -265,12 +265,80 @@ final class NotesExtractor {
 
     // MARK: - Search
 
-    func searchNotes(_ query: String) throws -> [Note] {
-        let allNotes = try getNotes()
-        let q = query.lowercased()
-        return allNotes.filter {
-            $0.title.lowercased().contains(q) || $0.snippet.lowercased().contains(q)
+    func searchNotes(_ query: String, limit: Int = 250) throws -> [Note] {
+        let tables = try db.tableNames()
+        let boundedLimit = max(1, min(limit, 1_000))
+        let pattern = "%\(query)%"
+
+        if tables.contains("ZICCLOUDSYNCINGOBJECT") {
+            let rows = try db.query("""
+                SELECT
+                    n.Z_PK,
+                    n.ZTITLE1,
+                    n.ZSNIPPET,
+                    n.ZCREATIONDATE3,
+                    n.ZMODIFICATIONDATE1,
+                    n.ZISPINNED,
+                    n.ZISPASSWORDPROTECTED,
+                    n.ZHASCHECKLIST,
+                    COALESCE(f.ZTITLE2, 'Notes') as folder_name
+                FROM ZICCLOUDSYNCINGOBJECT n
+                LEFT JOIN ZICCLOUDSYNCINGOBJECT f ON n.ZFOLDER = f.Z_PK
+                WHERE n.ZTITLE1 IS NOT NULL
+                  AND (n.ZTITLE1 LIKE ? COLLATE NOCASE OR n.ZSNIPPET LIKE ? COLLATE NOCASE)
+                ORDER BY n.ZMODIFICATIONDATE1 DESC
+                LIMIT \(boundedLimit)
+            """, params: [pattern, pattern])
+            return rows.compactMap { row in
+                guard let pk = row["Z_PK"] as? Int else { return nil }
+                return Note(
+                    id: pk,
+                    title: (row["ZTITLE1"] as? String) ?? "",
+                    snippet: (row["ZSNIPPET"] as? String) ?? "",
+                    htmlBody: nil,
+                    createdDate: (row["ZCREATIONDATE3"] as? Double).map { Date(timeIntervalSinceReferenceDate: $0) },
+                    modifiedDate: (row["ZMODIFICATIONDATE1"] as? Double).map { Date(timeIntervalSinceReferenceDate: $0) },
+                    folderName: (row["folder_name"] as? String) ?? "Notes",
+                    isPinned: (row["ZISPINNED"] as? Int) == 1,
+                    isLocked: (row["ZISPASSWORDPROTECTED"] as? Int) == 1,
+                    hasChecklist: (row["ZHASCHECKLIST"] as? Int) == 1
+                )
+            }
         }
+
+        if tables.contains("ZNOTEBODY") {
+            let rows = try db.query("""
+                SELECT
+                    n.Z_PK,
+                    n.ZTITLE,
+                    n.ZSUMMARY,
+                    n.ZCREATIONDATE,
+                    n.ZMODIFICATIONDATE,
+                    COALESCE(s.ZTITLE, 'Notes') as folder_name
+                FROM ZNOTE n
+                LEFT JOIN ZSTORE s ON n.ZSTORE = s.Z_PK
+                WHERE n.ZTITLE LIKE ? COLLATE NOCASE OR n.ZSUMMARY LIKE ? COLLATE NOCASE
+                ORDER BY n.ZMODIFICATIONDATE DESC
+                LIMIT \(boundedLimit)
+            """, params: [pattern, pattern])
+            return rows.compactMap { row in
+                guard let pk = row["Z_PK"] as? Int else { return nil }
+                return Note(
+                    id: pk,
+                    title: (row["ZTITLE"] as? String) ?? "",
+                    snippet: (row["ZSUMMARY"] as? String) ?? "",
+                    htmlBody: nil,
+                    createdDate: (row["ZCREATIONDATE"] as? Double).map { Date(timeIntervalSinceReferenceDate: $0) },
+                    modifiedDate: (row["ZMODIFICATIONDATE"] as? Double).map { Date(timeIntervalSinceReferenceDate: $0) },
+                    folderName: (row["folder_name"] as? String) ?? "Notes",
+                    isPinned: false,
+                    isLocked: false,
+                    hasChecklist: false
+                )
+            }
+        }
+
+        throw NotesError.unsupportedSchema(tables: tables)
     }
 
     // MARK: - Export

--- a/Sources/Phosphor/Services/SafariExtractor.swift
+++ b/Sources/Phosphor/Services/SafariExtractor.swift
@@ -144,6 +144,80 @@ final class SafariExtractor {
         }
     }
 
+    func searchBookmarks(_ query: String, limit: Int = 250) throws -> [Bookmark] {
+        let manifest = try BackupManifest(backupPath: backupPath)
+        let candidates = try manifest.search("Bookmarks.db", limit: 20)
+        guard let entry = candidates.first(where: {
+            $0.isFile && $0.relativePath.contains("Safari") && $0.relativePath.hasSuffix("Bookmarks.db")
+        }) else {
+            throw NSError(domain: "Phosphor", code: 404,
+                          userInfo: [NSLocalizedDescriptionKey: "Safari Bookmarks.db not found"])
+        }
+        let db = try SQLiteReader(path: manifest.readablePath(for: entry))
+        let boundedLimit = max(1, min(limit, 1_000))
+        let pattern = "%\(query)%"
+        let rows = try db.query("""
+            SELECT b.id, b.title, b.url, b.order_index,
+                   COALESCE(p.title, '') as parent_title
+            FROM bookmarks b
+            LEFT JOIN bookmarks p ON b.parent = p.id
+            WHERE b.url IS NOT NULL AND b.url != ''
+              AND (b.title LIKE ? COLLATE NOCASE
+                   OR b.url LIKE ? COLLATE NOCASE
+                   OR p.title LIKE ? COLLATE NOCASE)
+            ORDER BY b.parent, b.order_index
+            LIMIT \(boundedLimit)
+        """, params: [pattern, pattern, pattern])
+        return rows.compactMap { row in
+            guard let id = row["id"] as? Int else { return nil }
+            return Bookmark(
+                id: id,
+                title: (row["title"] as? String) ?? "",
+                url: (row["url"] as? String) ?? "",
+                parentTitle: (row["parent_title"] as? String) ?? "Bookmarks",
+                orderIndex: (row["order_index"] as? Int) ?? 0
+            )
+        }
+    }
+
+    func searchHistory(_ query: String, limit: Int = 250) throws -> [HistoryItem] {
+        let manifest = try BackupManifest(backupPath: backupPath)
+        let candidates = try manifest.search("History.db", limit: 20)
+        guard let entry = candidates.first(where: {
+            $0.isFile && $0.relativePath.contains("Safari") && $0.relativePath.hasSuffix("History.db")
+        }) else {
+            throw NSError(domain: "Phosphor", code: 404,
+                          userInfo: [NSLocalizedDescriptionKey: "Safari History.db not found"])
+        }
+        let db = try SQLiteReader(path: manifest.readablePath(for: entry))
+        let boundedLimit = max(1, min(limit, 1_000))
+        let pattern = "%\(query)%"
+        let rows = try db.query("""
+            SELECT hi.id, hi.url, COALESCE(hi.title, '') as title,
+                   hi.visit_count, hv.visit_time
+            FROM history_items hi
+            LEFT JOIN (
+                SELECT history_item, MAX(visit_time) as visit_time
+                FROM history_visits
+                GROUP BY history_item
+            ) hv ON hv.history_item = hi.id
+            WHERE hi.url LIKE ? COLLATE NOCASE OR hi.title LIKE ? COLLATE NOCASE
+            ORDER BY hv.visit_time DESC
+            LIMIT \(boundedLimit)
+        """, params: [pattern, pattern])
+        return rows.compactMap { row in
+            guard let id = row["id"] as? Int, let url = row["url"] as? String else { return nil }
+            let date = (row["visit_time"] as? Double).map { Date(timeIntervalSinceReferenceDate: $0) }
+            return HistoryItem(
+                id: id,
+                url: url,
+                title: (row["title"] as? String) ?? "",
+                visitCount: (row["visit_count"] as? Int) ?? 1,
+                lastVisitDate: date
+            )
+        }
+    }
+
     // MARK: - Export
 
     func exportBookmarks(to path: String) throws {

--- a/Sources/Phosphor/Services/UnifiedSearchExporter.swift
+++ b/Sources/Phosphor/Services/UnifiedSearchExporter.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+enum UnifiedSearchExporter {
+    private static func iso8601(_ date: Date?) -> String {
+        guard let date else { return "" }
+        return ISO8601DateFormatter().string(from: date)
+    }
+
+    static func ordered(_ results: [UnifiedSearchResult]) -> [UnifiedSearchResult] {
+        results.sorted { lhs, rhs in
+            switch (lhs.date, rhs.date) {
+            case (let left?, let right?) where left != right:
+                return left > right
+            case (_?, nil):
+                return true
+            case (nil, _?):
+                return false
+            default:
+                if lhs.source.rawValue != rhs.source.rawValue {
+                    return lhs.source.rawValue < rhs.source.rawValue
+                }
+                if lhs.title != rhs.title {
+                    return lhs.title.localizedStandardCompare(rhs.title) == .orderedAscending
+                }
+                return lhs.sourceID < rhs.sourceID
+            }
+        }
+    }
+
+    static func csvData(results: [UnifiedSearchResult]) -> Data {
+        var output = "Source,Title,Subtitle,Snippet,Date\n"
+        for result in ordered(results) {
+            output += CSVExport.row([
+                result.source.label,
+                result.title,
+                result.subtitle,
+                result.snippet,
+                iso8601(result.date),
+            ])
+        }
+        return Data(output.utf8)
+    }
+
+    static func jsonData(results: [UnifiedSearchResult]) throws -> Data {
+        let payload = ordered(results).map { result in
+            [
+                "source": result.source.rawValue,
+                "title": result.title,
+                "subtitle": result.subtitle,
+                "snippet": result.snippet,
+                "date": iso8601(result.date),
+            ]
+        }
+        return try JSONSerialization.data(withJSONObject: payload, options: [.prettyPrinted, .sortedKeys])
+    }
+
+    static func writeCSV(results: [UnifiedSearchResult], to url: URL) throws {
+        try csvData(results: results).write(to: url, options: .atomic)
+    }
+
+    static func writeJSON(results: [UnifiedSearchResult], to url: URL) throws {
+        try jsonData(results: results).write(to: url, options: .atomic)
+    }
+}

--- a/Sources/Phosphor/Services/UnifiedSearchService.swift
+++ b/Sources/Phosphor/Services/UnifiedSearchService.swift
@@ -1,0 +1,225 @@
+import Foundation
+
+enum UnifiedSearchError: LocalizedError, Sendable {
+    case lockedBackup
+    case invalidBackup
+
+    var errorDescription: String? {
+        switch self {
+        case .lockedBackup:
+            return "This backup is encrypted. Unlock it from Backups, then search again."
+        case .invalidBackup:
+            return "The selected backup is incomplete or unreadable. Choose a different backup or create a new one."
+        }
+    }
+}
+
+enum UnifiedSearchService {
+    static func search(
+        query: String,
+        backupPath: String,
+        sources: Set<UnifiedSearchSource> = Set(UnifiedSearchSource.allCases),
+        limitPerSource: Int = 250
+    ) throws -> UnifiedSearchResponse {
+        let normalized = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !normalized.isEmpty else {
+            return UnifiedSearchResponse(results: [], sourceErrors: [:])
+        }
+
+        do {
+            _ = try BackupManifest(backupPath: backupPath)
+        } catch let manifestError as BackupManifest.ManifestError {
+            switch manifestError {
+            case .backupEncrypted:
+                throw UnifiedSearchError.lockedBackup
+            case .manifestMissing, .manifestUnreadable:
+                throw UnifiedSearchError.invalidBackup
+            }
+        } catch {
+            throw UnifiedSearchError.invalidBackup
+        }
+
+        var results: [UnifiedSearchResult] = []
+        var sourceErrors: [UnifiedSearchSource: String] = [:]
+
+        func attempt(_ source: UnifiedSearchSource, _ operation: () throws -> [UnifiedSearchResult]) throws {
+            guard sources.contains(source) else { return }
+            try Task.checkCancellation()
+            do {
+                results.append(contentsOf: try operation().prefix(limitPerSource))
+            } catch is CancellationError {
+                throw CancellationError()
+            } catch {
+                sourceErrors[source] = "This source could not be searched in the selected backup."
+            }
+        }
+
+        try attempt(.messages) {
+            let exporter = try MessageExporter(backupPath: backupPath)
+            return try exporter.searchMessages(normalized, limit: limitPerSource).map { message in
+                UnifiedSearchResult(
+                    source: .messages,
+                    sourceID: String(message.id),
+                    title: message.senderLabel,
+                    subtitle: message.service.isEmpty ? "Message" : message.service,
+                    snippet: compact(message.displayText),
+                    date: message.date
+                )
+            }
+        }
+
+        try attempt(.whatsApp) {
+            let exporter = try WhatsAppExporter(backupPath: backupPath)
+            return try exporter.searchMessages(normalized, limit: limitPerSource).map { message in
+                let sender = message.isFromMe
+                    ? "Me"
+                    : (message.senderJid ?? "Unknown").replacingOccurrences(of: "@s.whatsapp.net", with: "")
+                return UnifiedSearchResult(
+                    source: .whatsApp,
+                    sourceID: String(message.id),
+                    title: sender,
+                    subtitle: "WhatsApp",
+                    snippet: compact(message.displayText),
+                    date: message.date
+                )
+            }
+        }
+
+        try attempt(.notes) {
+            try NotesExtractor(backupPath: backupPath).searchNotes(normalized, limit: limitPerSource).map { note in
+                UnifiedSearchResult(
+                    source: .notes,
+                    sourceID: String(note.id),
+                    title: note.displayTitle,
+                    subtitle: note.folderName,
+                    snippet: compact(note.snippet),
+                    date: note.modifiedDate
+                )
+            }
+        }
+
+        try attempt(.contacts) {
+            try ContactsExtractor(backupPath: backupPath).searchContacts(normalized, limit: limitPerSource).map { contact in
+                let details = (contact.phoneNumbers + contact.emails).joined(separator: " • ")
+                return UnifiedSearchResult(
+                    source: .contacts,
+                    sourceID: String(contact.id),
+                    title: contact.fullName.isEmpty ? "Unnamed Contact" : contact.fullName,
+                    subtitle: contact.organization.isEmpty ? "Contact" : contact.organization,
+                    snippet: compact(details),
+                    date: contact.createdDate
+                )
+            }
+        }
+
+        try attempt(.callLog) {
+            try CallLogExtractor(backupPath: backupPath).searchCallLog(normalized, limit: limitPerSource).map { call in
+                UnifiedSearchResult(
+                    source: .callLog,
+                    sourceID: String(call.id),
+                    title: call.address,
+                    subtitle: call.callType.label,
+                    snippet: call.durationString,
+                    date: call.date
+                )
+            }
+        }
+
+        if sources.contains(.safari) {
+            try Task.checkCancellation()
+            let extractor = SafariExtractor(backupPath: backupPath)
+            var bookmarks: [UnifiedSearchResult] = []
+            var history: [UnifiedSearchResult] = []
+
+            do {
+                bookmarks = try extractor.searchBookmarks(normalized, limit: limitPerSource).map { bookmark in
+                    UnifiedSearchResult(
+                        source: .safari,
+                        sourceID: "bookmark-\(bookmark.id)",
+                        title: bookmark.displayTitle,
+                        subtitle: "Bookmark • \(bookmark.parentTitle)",
+                        snippet: compact(bookmark.url),
+                        date: nil
+                    )
+                }
+            } catch is CancellationError {
+                throw CancellationError()
+            } catch {
+                sourceErrors[.safari] = "Some Safari data could not be searched in the selected backup."
+            }
+
+            try Task.checkCancellation()
+            do {
+                history = try extractor.searchHistory(normalized, limit: limitPerSource).map { item in
+                    UnifiedSearchResult(
+                        source: .safari,
+                        sourceID: "history-\(item.id)",
+                        title: item.displayTitle,
+                        subtitle: "History • \(item.visitCount) visits",
+                        snippet: compact(item.url),
+                        date: item.lastVisitDate
+                    )
+                }
+            } catch is CancellationError {
+                throw CancellationError()
+            } catch {
+                sourceErrors[.safari] = "Some Safari data could not be searched in the selected backup."
+            }
+
+            results.append(contentsOf: interleave(bookmarks, history, limit: limitPerSource))
+        }
+
+        try attempt(.files) {
+            let manifest = try BackupManifest(backupPath: backupPath)
+            return try manifest.search(normalized, limit: limitPerSource).map { entry in
+                UnifiedSearchResult(
+                    source: .files,
+                    sourceID: entry.id,
+                    title: entry.fileName.isEmpty ? entry.relativePath : entry.fileName,
+                    subtitle: entry.domain,
+                    snippet: compact(entry.relativePath),
+                    date: nil
+                )
+            }
+        }
+
+        try Task.checkCancellation()
+        return UnifiedSearchResponse(
+            results: UnifiedSearchExporter.ordered(results),
+            sourceErrors: sourceErrors
+        )
+    }
+
+    private static func matches(_ query: String, in values: [String]) -> Bool {
+        values.contains { $0.localizedCaseInsensitiveContains(query) }
+    }
+
+    /// Apply one shared Safari budget without allowing either bookmarks or
+    /// history to consume every retained slot when both have matches.
+    private static func interleave(
+        _ first: [UnifiedSearchResult],
+        _ second: [UnifiedSearchResult],
+        limit: Int
+    ) -> [UnifiedSearchResult] {
+        let boundedLimit = max(0, limit)
+        guard boundedLimit > 0 else { return [] }
+        var merged: [UnifiedSearchResult] = []
+        merged.reserveCapacity(min(boundedLimit, first.count + second.count))
+        var index = 0
+        while merged.count < boundedLimit && (index < first.count || index < second.count) {
+            if index < first.count { merged.append(first[index]) }
+            if merged.count < boundedLimit, index < second.count { merged.append(second[index]) }
+            index += 1
+        }
+        return merged
+    }
+
+    private static func compact(_ value: String, limit: Int = 240) -> String {
+        let singleLine = value
+            .replacingOccurrences(of: "\r\n", with: " ")
+            .replacingOccurrences(of: "\n", with: " ")
+            .replacingOccurrences(of: "\r", with: " ")
+        guard singleLine.count > limit else { return singleLine }
+        return String(singleLine.prefix(limit)) + "…"
+    }
+}

--- a/Sources/Phosphor/Utilities/BackupManifest.swift
+++ b/Sources/Phosphor/Utilities/BackupManifest.swift
@@ -247,9 +247,10 @@ final class BackupManifest {
     }
 
     /// Search files by name.
-    func search(_ query: String) throws -> [FileEntry] {
+    func search(_ query: String, limit: Int = 500) throws -> [FileEntry] {
+        let boundedLimit = max(1, min(limit, 5_000))
         let rows = try db.query(
-            "SELECT fileID, domain, relativePath, flags FROM Files WHERE relativePath LIKE ? ORDER BY relativePath LIMIT 500",
+            "SELECT fileID, domain, relativePath, flags FROM Files WHERE relativePath LIKE ? ORDER BY relativePath LIMIT \(boundedLimit)",
             params: ["%\(query)%"]
         )
         return rows.compactMap(parseFileEntry)

--- a/Sources/Phosphor/Utilities/SQLiteReader.swift
+++ b/Sources/Phosphor/Utilities/SQLiteReader.swift
@@ -1,6 +1,8 @@
 import Foundation
 #if canImport(SQLite3)
 import SQLite3
+
+private let SQLITE_TRANSIENT = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
 #endif
 
 /// Lightweight SQLite wrapper for reading iOS backup databases.
@@ -13,12 +15,14 @@ final class SQLiteReader {
         case openFailed(String)
         case queryFailed(String)
         case prepareFailed(String)
+        case bindFailed(String)
 
         var errorDescription: String? {
             switch self {
             case .openFailed(let msg): return "SQLite open failed: \(msg)"
             case .queryFailed(let msg): return "SQLite query failed: \(msg)"
             case .prepareFailed(let msg): return "SQLite prepare failed: \(msg)"
+            case .bindFailed(let msg): return "SQLite bind failed: \(msg)"
             }
         }
     }
@@ -70,13 +74,24 @@ final class SQLiteReader {
 
         // Bind parameters
         for (index, param) in params.enumerated() {
-            sqlite3_bind_text(statement, Int32(index + 1), (param as NSString).utf8String, -1, nil)
+            let bindResult = param.withCString { pointer in
+                sqlite3_bind_text(statement, Int32(index + 1), pointer, -1, SQLITE_TRANSIENT)
+            }
+            guard bindResult == SQLITE_OK else {
+                throw SQLiteError.bindFailed(String(cString: sqlite3_errmsg(db)))
+            }
         }
 
         var rows: [[String: Any?]] = []
         let columnCount = sqlite3_column_count(statement)
 
-        while sqlite3_step(statement) == SQLITE_ROW {
+        while true {
+            let stepResult = sqlite3_step(statement)
+            if stepResult == SQLITE_DONE { break }
+            guard stepResult == SQLITE_ROW else {
+                throw SQLiteError.queryFailed(String(cString: sqlite3_errmsg(db)))
+            }
+
             var row: [String: Any?] = [:]
             for i in 0..<columnCount {
                 let name = String(cString: sqlite3_column_name(statement, i))

--- a/Sources/Phosphor/Utilities/Theme.swift
+++ b/Sources/Phosphor/Utilities/Theme.swift
@@ -46,6 +46,7 @@ extension SidebarSection {
         case .backups: return .blue
         case .backupBrowser: return .purple
         case .timeMachine: return .teal
+        case .unifiedSearch: return .indigo
         case .messages: return .green
         case .whatsapp: return Color(red: 0.12, green: 0.75, blue: 0.36) // #1EBE5D-ish
         case .photos: return .orange

--- a/Sources/Phosphor/ViewModels/UnifiedSearchViewModel.swift
+++ b/Sources/Phosphor/ViewModels/UnifiedSearchViewModel.swift
@@ -1,0 +1,115 @@
+import Foundation
+
+@MainActor
+final class UnifiedSearchViewModel: ObservableObject {
+    @Published var query = ""
+    @Published var selectedBackup: BackupInfo?
+    @Published var enabledSources = Set(UnifiedSearchSource.allCases)
+    @Published private(set) var results: [UnifiedSearchResult] = []
+    @Published private(set) var sourceErrors: [UnifiedSearchSource: String] = [:]
+    @Published var selectedResultIDs = Set<UnifiedSearchResult.ID>()
+    @Published private(set) var isSearching = false
+    @Published private(set) var errorMessage: String?
+
+    private var searchTask: Task<Void, Never>?
+    private(set) var searchOperationID: UUID?
+
+    private struct SearchFailure: Error, Sendable {
+        let message: String
+    }
+
+    var selectedResults: [UnifiedSearchResult] {
+        results.filter { selectedResultIDs.contains($0.id) }
+    }
+
+    func chooseBackup(_ backup: BackupInfo?) {
+        guard selectedBackup?.path != backup?.path else { return }
+        searchTask?.cancel()
+        searchOperationID = nil
+        selectedBackup = backup
+        results = []
+        sourceErrors = [:]
+        selectedResultIDs = []
+        errorMessage = nil
+        isSearching = false
+    }
+
+    func search() {
+        let normalized = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let backup = selectedBackup else {
+            errorMessage = "Choose a backup before searching."
+            return
+        }
+        guard normalized.count >= 2 else {
+            errorMessage = "Enter at least two characters."
+            return
+        }
+        guard !enabledSources.isEmpty else {
+            errorMessage = "Choose at least one data source."
+            return
+        }
+
+        searchTask?.cancel()
+        let operationID = UUID()
+        searchOperationID = operationID
+        let sources = enabledSources
+        isSearching = true
+        errorMessage = nil
+        results = []
+        sourceErrors = [:]
+        selectedResultIDs = []
+
+        searchTask = Task {
+            let worker = Task.detached(priority: .userInitiated) {
+                do {
+                    return Result<UnifiedSearchResponse, SearchFailure>.success(
+                        try UnifiedSearchService.search(
+                            query: normalized,
+                            backupPath: backup.path,
+                            sources: sources
+                        )
+                    )
+                } catch is CancellationError {
+                    return .failure(SearchFailure(message: "Search cancelled."))
+                } catch {
+                    return .failure(SearchFailure(message: error.localizedDescription))
+                }
+            }
+            let outcome = await withTaskCancellationHandler {
+                await worker.value
+            } onCancel: {
+                worker.cancel()
+            }
+
+            guard !Task.isCancelled, searchOperationID == operationID else { return }
+            isSearching = false
+            switch outcome {
+            case .success(let response):
+                results = response.results
+                sourceErrors = response.sourceErrors
+            case .failure(let failure):
+                if !Task.isCancelled && failure.message != "Search cancelled." {
+                    errorMessage = failure.message
+                }
+            }
+        }
+    }
+
+    func cancel() {
+        searchTask?.cancel()
+        searchTask = nil
+        searchOperationID = nil
+        isSearching = false
+        results = []
+        sourceErrors = [:]
+        selectedResultIDs = []
+    }
+
+    func selectAllVisible() {
+        selectedResultIDs = Set(results.map(\.id))
+    }
+
+    func clearSelection() {
+        selectedResultIDs = []
+    }
+}

--- a/Sources/Phosphor/Views/ContentView.swift
+++ b/Sources/Phosphor/Views/ContentView.swift
@@ -126,6 +126,8 @@ struct ContentView: View {
             BackupBrowserView()
         case .timeMachine:
             BackupTimeMachineView(onBrowseBackup: { selectedSection = .backupBrowser })
+        case .unifiedSearch:
+            UnifiedSearchView()
         case .messages:
             MessageListView()
         case .whatsapp:

--- a/Sources/Phosphor/Views/Search/UnifiedSearchView.swift
+++ b/Sources/Phosphor/Views/Search/UnifiedSearchView.swift
@@ -1,0 +1,272 @@
+import AppKit
+import SwiftUI
+
+struct UnifiedSearchView: View {
+    @EnvironmentObject private var backupVM: BackupViewModel
+    @EnvironmentObject private var viewModel: UnifiedSearchViewModel
+    @State private var exportError: String?
+
+    private var selectedBackupID: Binding<String> {
+        Binding(
+            get: { viewModel.selectedBackup?.id ?? "" },
+            set: { id in
+                let backup = backupVM.backups.first { $0.id == id }
+                viewModel.chooseBackup(backup)
+            }
+        )
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+            if viewModel.selectedBackup == nil {
+                ContentUnavailableView(
+                    "No Backup Selected",
+                    systemImage: "externaldrive.badge.questionmark",
+                    description: Text("Choose Backup above to search Messages, WhatsApp, Notes, Contacts, calls, Safari, and files.")
+                )
+            } else {
+                resultsContent
+            }
+        }
+        .onAppear {
+            if viewModel.selectedBackup == nil {
+                viewModel.chooseBackup(backupVM.selectedBackup ?? backupVM.backups.first)
+            }
+        }
+        .onChange(of: backupVM.backups.map(\.path)) { _, paths in
+            if let selected = viewModel.selectedBackup, !paths.contains(selected.path) {
+                viewModel.chooseBackup(nil)
+            }
+        }
+        .alert("Export Failed", isPresented: Binding(
+            get: { exportError != nil },
+            set: { if !$0 { exportError = nil } }
+        )) {
+            Button("OK", role: .cancel) { exportError = nil }
+        } message: {
+            Text(exportError ?? "Unknown export error")
+        }
+    }
+
+    private var header: some View {
+        VStack(spacing: 12) {
+            HStack(spacing: 12) {
+                GradientIconTile(
+                    systemName: "magnifyingglass.circle.fill",
+                    color: .indigo,
+                    size: 34,
+                    iconSize: 17,
+                    cornerRadius: 9
+                )
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Unified Search").font(.title2.weight(.semibold))
+                    Text("Search across one backup without changing its contents.")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                Picker("Choose Backup", selection: selectedBackupID) {
+                    Text("Choose Backup").tag("")
+                    ForEach(backupVM.backups) { backup in
+                        Text("\(backup.deviceName) — \(backup.dateString)").tag(backup.id)
+                    }
+                }
+                .frame(width: 280)
+            }
+
+            HStack(spacing: 10) {
+                HStack(spacing: 8) {
+                    Image(systemName: "magnifyingglass").foregroundStyle(.secondary)
+                    TextField("Search names, messages, URLs, notes, and file paths", text: $viewModel.query)
+                        .textFieldStyle(.plain)
+                        .onSubmit { viewModel.search() }
+                    if !viewModel.query.isEmpty {
+                        Button {
+                            viewModel.query = ""
+                        } label: {
+                            Image(systemName: "xmark.circle.fill").foregroundStyle(.secondary)
+                        }
+                        .buttonStyle(.plain)
+                    }
+                }
+                .padding(.horizontal, 12)
+                .padding(.vertical, 9)
+                .background(.quaternary, in: RoundedRectangle(cornerRadius: 9))
+
+                Menu {
+                    ForEach(UnifiedSearchSource.allCases, id: \.self) { source in
+                        Toggle(source.label, isOn: Binding(
+                            get: { viewModel.enabledSources.contains(source) },
+                            set: { enabled in
+                                if enabled { viewModel.enabledSources.insert(source) }
+                                else { viewModel.enabledSources.remove(source) }
+                            }
+                        ))
+                    }
+                } label: {
+                    Label("Sources", systemImage: "line.3.horizontal.decrease.circle")
+                }
+                .menuStyle(.borderlessButton)
+                .fixedSize()
+
+                if viewModel.isSearching {
+                    Button("Cancel") { viewModel.cancel() }
+                } else {
+                    Button("Search") { viewModel.search() }
+                        .buttonStyle(.borderedProminent)
+                        .disabled(viewModel.selectedBackup == nil)
+                }
+            }
+        }
+        .padding()
+    }
+
+    @ViewBuilder
+    private var resultsContent: some View {
+        if viewModel.isSearching && viewModel.results.isEmpty {
+            VStack(spacing: 12) {
+                ProgressView()
+                Text("Searching selected backup…").foregroundStyle(.secondary)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else if let error = viewModel.errorMessage {
+            ContentUnavailableView(
+                "Search Unavailable",
+                systemImage: "exclamationmark.magnifyingglass",
+                description: Text(error)
+            )
+        } else if viewModel.results.isEmpty {
+            VStack(spacing: 0) {
+                if !viewModel.sourceErrors.isEmpty {
+                    sourceWarnings
+                    Divider()
+                }
+                ContentUnavailableView(
+                    viewModel.query.isEmpty ? "Search This Backup" : "No Results",
+                    systemImage: "text.magnifyingglass",
+                    description: Text(viewModel.query.isEmpty
+                        ? "Enter at least two characters, choose the sources, and press Search."
+                        : "No matching results were returned by the sources that could be searched.")
+                )
+            }
+        } else {
+            VStack(spacing: 0) {
+                resultToolbar
+                Divider()
+                if !viewModel.sourceErrors.isEmpty {
+                    sourceWarnings
+                    Divider()
+                }
+                List(viewModel.results, selection: $viewModel.selectedResultIDs) { result in
+                    resultRow(result).tag(result.id)
+                }
+                .listStyle(.inset)
+            }
+        }
+    }
+
+    private var resultToolbar: some View {
+        HStack {
+            Text("\(viewModel.results.count) results")
+                .font(.subheadline.weight(.medium))
+            Spacer()
+            Button("Select All") { viewModel.selectAllVisible() }
+                .disabled(viewModel.selectedResultIDs.count == viewModel.results.count)
+            Button("Clear Selection") { viewModel.clearSelection() }
+                .disabled(viewModel.selectedResultIDs.isEmpty)
+            Menu("Export Selected") {
+                Button("CSV") { exportSelected(as: .csv) }
+                Button("JSON") { exportSelected(as: .json) }
+            }
+            .disabled(viewModel.selectedResultIDs.isEmpty)
+        }
+        .padding(.horizontal)
+        .padding(.vertical, 10)
+    }
+
+    private var sourceWarnings: some View {
+        HStack(alignment: .top, spacing: 8) {
+            Image(systemName: "exclamationmark.triangle.fill").foregroundStyle(.orange)
+            Text(viewModel.sourceErrors
+                .sorted { $0.key.label < $1.key.label }
+                .map { "\($0.key.label): \($0.value)" }
+                .joined(separator: "  •  "))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(2)
+            Spacer()
+        }
+        .padding(.horizontal)
+        .padding(.vertical, 8)
+        .background(Color.orange.opacity(0.06))
+    }
+
+    private func resultRow(_ result: UnifiedSearchResult) -> some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: result.source.icon)
+                .foregroundStyle(result.source.iconColor)
+                .frame(width: 24, height: 24)
+            VStack(alignment: .leading, spacing: 3) {
+                HStack {
+                    Text(result.title.isEmpty ? "Untitled" : result.title)
+                        .font(.body.weight(.medium))
+                        .lineLimit(1)
+                    Text(result.source.label)
+                        .font(.caption2.weight(.medium))
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(result.source.iconColor.opacity(0.12), in: Capsule())
+                    Spacer()
+                    if let date = result.date {
+                        Text(date.shortString)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+                if !result.subtitle.isEmpty {
+                    Text(result.subtitle).font(.caption).foregroundStyle(.secondary).lineLimit(1)
+                }
+                if !result.snippet.isEmpty {
+                    Text(result.snippet).font(.callout).lineLimit(2)
+                }
+            }
+        }
+        .padding(.vertical, 4)
+    }
+
+    private enum ExportKind {
+        case csv, json
+        var fileExtension: String { self == .csv ? "csv" : "json" }
+    }
+
+    private func exportSelected(as kind: ExportKind) {
+        let panel = NSSavePanel()
+        panel.nameFieldStringValue = "Phosphor Search Results.\(kind.fileExtension)"
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+        do {
+            switch kind {
+            case .csv: try UnifiedSearchExporter.writeCSV(results: viewModel.selectedResults, to: url)
+            case .json: try UnifiedSearchExporter.writeJSON(results: viewModel.selectedResults, to: url)
+            }
+            NSWorkspace.shared.activateFileViewerSelecting([url])
+        } catch {
+            exportError = error.localizedDescription
+        }
+    }
+}
+
+private extension UnifiedSearchSource {
+    var iconColor: Color {
+        switch self {
+        case .messages: return .blue
+        case .whatsApp: return .green
+        case .notes: return .yellow
+        case .contacts: return .cyan
+        case .callLog: return .orange
+        case .safari: return .indigo
+        case .files: return .gray
+        }
+    }
+}

--- a/Sources/Phosphor/Views/SidebarView.swift
+++ b/Sources/Phosphor/Views/SidebarView.swift
@@ -7,6 +7,7 @@ enum SidebarSection: String, CaseIterable, Identifiable {
     case backups
     case backupBrowser
     case timeMachine
+    case unifiedSearch
     case messages
     case whatsapp
     case photos
@@ -35,6 +36,7 @@ enum SidebarSection: String, CaseIterable, Identifiable {
         case .backups: return "Backups"
         case .backupBrowser: return "Backup Browser"
         case .timeMachine: return "Time Machine"
+        case .unifiedSearch: return "Unified Search"
         case .messages: return "Messages"
         case .whatsapp: return "WhatsApp"
         case .photos: return "Photos"
@@ -63,6 +65,7 @@ enum SidebarSection: String, CaseIterable, Identifiable {
         case .backups: return "externaldrive.fill"
         case .backupBrowser: return "folder.fill"
         case .timeMachine: return "clock.arrow.circlepath"
+        case .unifiedSearch: return "magnifyingglass.circle.fill"
         case .messages: return "message.fill"
         case .whatsapp: return "bubble.left.and.text.bubble.right.fill"
         case .photos: return "photo.on.rectangle.angled"
@@ -88,7 +91,7 @@ enum SidebarSection: String, CaseIterable, Identifiable {
         switch self {
         case .devices, .readiness: return .device
         case .backups, .backupBrowser, .timeMachine: return .backups
-        case .messages, .whatsapp, .photos, .apps, .notes, .callLog, .safari, .health, .music, .watch, .contacts, .calendar: return .data
+        case .unifiedSearch, .messages, .whatsapp, .photos, .apps, .notes, .callLog, .safari, .health, .music, .watch, .contacts, .calendar: return .data
         case .clone, .files, .diagnostics, .battery, .screenCapture, .location: return .tools
         }
     }
@@ -136,6 +139,7 @@ struct SidebarView: View {
             }
 
             Section("Data") {
+                sidebarRow(.unifiedSearch)
                 sidebarRow(.messages)
                 sidebarRow(.whatsapp)
                 sidebarRow(.photos)


### PR DESCRIPTION
## Summary
- add one Unified Search entry point for Messages, WhatsApp, Notes, Contacts, Call Log, Safari, and backup files
- keep search state app-owned across navigation, support source filters, and expose per-source partial failures even when no healthy source returns a hit
- run backup database work off the main actor with explicit worker cancellation and operation-ID stale-result guards
- use bounded SQL-backed searches, including full-database call-log and Safari-history predicates
- isolate Safari bookmark and history failures so an unavailable Bookmarks database cannot discard healthy History results
- export only selected results as deterministic, formula-safe CSV or privacy-safe JSON

## Reliability and privacy
- preflight the selected manifest so locked and incomplete backups produce actionable guidance instead of false “No Results” states
- new searches, backup changes, and cancellation invalidate old results and selections
- adapters query before limiting rather than loading whole databases or filtering only a recent window
- JSON omits internal SQLite row IDs and backup file hashes
- source failures use generic user-facing messages without paths, UDIDs, query text, or database details

## Dependency
The branch temporarily includes the exact #67 SQLite reliability commit as its first commit so this PR is safe to test or merge without accepting partial SQLite rows. Once #67 merges, this branch can be rebased onto updated `main` and the shared prerequisite commit dropped.

## Verification
- 72 regression checks passed, including corrupt-database terminal-step handling, compiled call-log (>1,100 newer rows), deterministic export, JSON privacy, cancellation, stale-state, zero-result warning visibility, and Safari failure-isolation checks
- `swift build -Xswiftc -strict-concurrency=complete`
- `swift build -c release`
- `bash Scripts/build.sh`
- independent final blocker review of exact head `cecb631`: PASS, no P0/P1 findings
- independent final blocker review: PASS, no P0/P1 findings
- clean four-branch integration: 79 regression checks, debug build, and release build passed

## UI validation note
The app bundle builds and launches, but this macOS session has not provided reliable Accessibility/screenshot capture for Phosphor windows. Behavioral probes, package builds, and combined integration checks are green.
