### PR TITLE
fix: preserve same-named music exports

### DIFF
--- a/Scripts/regression/checks/music_extraction.py
+++ b/Scripts/regression/checks/music_extraction.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+import tempfile
+
+
+def read(root: Path, rel: str) -> str:
+    return (root / rel).read_text()
+
+
+def test_collision_safe_publisher_preserves_existing_files_and_all_outputs(root: Path) -> None:
+    helper = root / "Sources/Phosphor/Utilities/CollisionSafeFilePublisher.swift"
+    assert helper.exists(), "collision-safe publication helper must exist"
+
+    probe = r'''
+import Foundation
+
+struct ProbeFailure: Error {}
+
+@main
+struct Probe {
+    static func main() async throws {
+        let directory = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("phosphor-music-publisher-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let existing = directory.appendingPathComponent("Track.m4a")
+        try Data("existing".utf8).write(to: existing)
+
+        let first = try CollisionSafeFilePublisher.publish(preferredFilename: "Track.m4a", in: directory) { staging in
+            try Data("one".utf8).write(to: staging)
+        }
+        let second = try CollisionSafeFilePublisher.publish(preferredFilename: "Track.m4a", in: directory) { staging in
+            try Data("two".utf8).write(to: staging)
+        }
+        let freshDestination = directory.appendingPathComponent("Fresh.m4a")
+        var visibleBeforeWriterFinished = false
+        let fresh = try CollisionSafeFilePublisher.publish(preferredFilename: "Fresh.m4a", in: directory) { staging in
+            visibleBeforeWriterFinished = FileManager.default.fileExists(atPath: freshDestination.path)
+            try Data("fresh".utf8).write(to: staging)
+        }
+        do {
+            _ = try CollisionSafeFilePublisher.publish(preferredFilename: "Track.m4a", in: directory) { _ in
+                throw ProbeFailure()
+            }
+        } catch {}
+
+        let names = try FileManager.default.contentsOfDirectory(atPath: directory.path).sorted()
+        let contents = try names.map { name in
+            String(decoding: try Data(contentsOf: directory.appendingPathComponent(name)), as: UTF8.self)
+        }
+        print("NAMES|" + names.joined(separator: ","))
+        print("CONTENTS|" + contents.sorted().joined(separator: ","))
+        print("RETURNED|\(first.lastPathComponent)|\(second.lastPathComponent)")
+        print("ATOMIC|\(visibleBeforeWriterFinished)|\(fresh.lastPathComponent)")
+
+        let cancelFinal = directory.appendingPathComponent("Cancelled.m4a")
+        let started = DispatchSemaphore(value: 0)
+        let release = DispatchSemaphore(value: 0)
+        let task = Task.detached {
+            try CollisionSafeFilePublisher.publish(preferredFilename: "Cancelled.m4a", in: directory) { staging in
+                try Data("partial".utf8).write(to: staging)
+                started.signal()
+                release.wait()
+            }
+        }
+        started.wait()
+        task.cancel()
+        release.signal()
+        _ = try? await task.value
+        let leftovers = try FileManager.default.contentsOfDirectory(atPath: directory.path)
+            .filter { $0.hasPrefix(".phosphor-") }
+        print("CANCEL|\(FileManager.default.fileExists(atPath: cancelFinal.path))|\(leftovers.count)")
+    }
+}
+'''
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp = Path(temp_dir)
+        probe_path = temp / "Probe.swift"
+        probe_path.write_text(probe)
+        executable = temp / "publisher-probe"
+        compile_result = subprocess.run(
+            ["swiftc", "-parse-as-library", str(helper), str(probe_path), "-o", str(executable)],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        assert compile_result.returncode == 0, compile_result.stderr
+        result = subprocess.run([str(executable)], capture_output=True, text=True, timeout=10)
+
+    assert result.returncode == 0, result.stderr
+    assert "NAMES|Fresh.m4a,Track (2).m4a,Track (3).m4a,Track.m4a" in result.stdout, result.stdout
+    assert "CONTENTS|existing,fresh,one,two" in result.stdout, result.stdout
+    assert "RETURNED|Track (2).m4a|Track (3).m4a" in result.stdout, result.stdout
+    assert "ATOMIC|false|Fresh.m4a" in result.stdout, "final name must stay absent until the writer succeeds"
+    assert "CANCEL|false|0" in result.stdout, "cancelled copies must leave neither a final file nor staging data"
+
+
+def test_music_extraction_uses_collision_safe_atomic_publication(root: Path) -> None:
+    manager = read(root, "Sources/Phosphor/Services/MusicTransferManager.swift")
+    view = read(root, "Sources/Phosphor/Views/Music/MusicView.swift")
+    helper = read(root, "Sources/Phosphor/Utilities/CollisionSafeFilePublisher.swift")
+    assert "CollisionSafeFilePublisher.publish" in manager
+    assert "try manifest.extractFile(entry, to: staging.path)" in manager
+    assert "Task.checkCancellation()" in manager
+    assert "lastError = nil" in manager, "a successful retry must clear an earlier extraction error"
+    assert "catch {}" not in manager, "track extraction failures must not be swallowed"
+    assert "appendingPathComponent(track.filename)" not in manager, "same-named tracks must not target the same path"
+    assert "Task.detached" in manager and "withTaskCancellationHandler" in manager
+    assert "try Task.checkCancellation()" in manager, "cancellation during a copy must prevent final publication"
+    assert "renamex_np" in helper and "RENAME_EXCL" in helper
+    assert "Darwin.open" not in helper, "publication must not expose a zero-byte final reservation"
+    assert "extractionTask" in view and ".cancel()" in view
+    assert "Music Extraction" in view and "extracted" in view

--- a/Sources/Phosphor/Services/MusicTransferManager.swift
+++ b/Sources/Phosphor/Services/MusicTransferManager.swift
@@ -11,7 +11,7 @@ final class MusicTransferManager: ObservableObject {
     @Published var transferProgress: Double = 0
     @Published var lastError: String?
 
-    struct MusicTrack: Identifiable, Hashable {
+    struct MusicTrack: Identifiable, Hashable, Sendable {
         let id: String
         let filename: String
         let relativePath: String
@@ -125,30 +125,99 @@ final class MusicTransferManager: ObservableObject {
 
     // MARK: - Extract from Backup
 
-    func extractTracks(_ selectedTracks: [MusicTrack], from backupPath: String, to destination: String) async -> Int {
+    struct ExtractionOutcome: Sendable {
+        let extracted: Int
+        let total: Int
+        let processed: Int
+        let cancelled: Bool
+        let lastError: String?
+    }
+
+    func extractTracks(
+        _ selectedTracks: [MusicTrack],
+        from backupPath: String,
+        to destination: String
+    ) async -> ExtractionOutcome {
+        lastError = nil
+        transferProgress = 0
+        let worker = Task.detached(priority: .userInitiated) {
+            Self.performExtraction(selectedTracks, from: backupPath, to: destination)
+        }
+        let outcome = await withTaskCancellationHandler {
+            await worker.value
+        } onCancel: {
+            worker.cancel()
+        }
+        lastError = outcome.lastError
+        if outcome.total > 0 {
+            transferProgress = Double(outcome.processed) / Double(outcome.total)
+        }
+        return outcome
+    }
+
+    private nonisolated static func performExtraction(
+        _ selectedTracks: [MusicTrack],
+        from backupPath: String,
+        to destination: String
+    ) -> ExtractionOutcome {
         let fm = FileManager.default
-        try? fm.createDirectory(atPath: destination, withIntermediateDirectories: true)
+        do {
+            try fm.createDirectory(atPath: destination, withIntermediateDirectories: true)
+        } catch {
+            return ExtractionOutcome(
+                extracted: 0, total: selectedTracks.count, processed: 0, cancelled: false,
+                lastError: "Could not prepare the destination folder: \(error.localizedDescription)"
+            )
+        }
 
         do {
+            try Task.checkCancellation()
             let manifest = try BackupManifest(backupPath: backupPath)
+            let destinationURL = URL(fileURLWithPath: destination, isDirectory: true)
             var extracted = 0
+            var processed = 0
+            var lastFailure: String?
 
-            for (index, track) in selectedTracks.enumerated() {
+            for track in selectedTracks {
                 let entry = BackupManifest.FileEntry(
                     id: track.id, domain: track.domain, relativePath: track.relativePath,
                     flags: 1, size: track.size
                 )
-                let destPath = (destination as NSString).appendingPathComponent(track.filename)
                 do {
-                    try manifest.extractFile(entry, to: destPath)
+                    try Task.checkCancellation()
+                    _ = try CollisionSafeFilePublisher.publish(
+                        preferredFilename: track.filename,
+                        in: destinationURL
+                    ) { staging in
+                        try Task.checkCancellation()
+                        try manifest.extractFile(entry, to: staging.path)
+                        try Task.checkCancellation()
+                    }
                     extracted += 1
-                } catch {}
-                transferProgress = Double(index + 1) / Double(selectedTracks.count)
+                } catch is CancellationError {
+                    return ExtractionOutcome(
+                        extracted: extracted, total: selectedTracks.count, processed: processed,
+                        cancelled: true, lastError: "Music extraction was cancelled."
+                    )
+                } catch {
+                    lastFailure = "Failed to extract \(track.filename): \(error.localizedDescription)"
+                }
+                processed += 1
             }
-            return extracted
+            return ExtractionOutcome(
+                extracted: extracted, total: selectedTracks.count, processed: processed,
+                cancelled: false, lastError: lastFailure
+            )
+        } catch is CancellationError {
+            return ExtractionOutcome(
+                extracted: 0, total: selectedTracks.count, processed: 0,
+                cancelled: true, lastError: "Music extraction was cancelled."
+            )
         } catch {
-            lastError = error.localizedDescription
-            return 0
+            return ExtractionOutcome(
+                extracted: 0, total: selectedTracks.count, processed: 0,
+                cancelled: false, lastError: error.localizedDescription
+            )
         }
     }
 

--- a/Sources/Phosphor/Utilities/CollisionSafeFilePublisher.swift
+++ b/Sources/Phosphor/Utilities/CollisionSafeFilePublisher.swift
@@ -1,0 +1,63 @@
+import Darwin
+import Foundation
+
+/// Publishes one generated/extracted file without overwriting an existing user
+/// file or exposing a partially written destination. The writer uses a hidden
+/// sibling staging file; `renamex_np(..., RENAME_EXCL)` makes the finished file
+/// visible atomically and retries suffixes if another process wins the name.
+enum CollisionSafeFilePublisher {
+    static func publish(
+        preferredFilename: String,
+        in directory: URL,
+        writer: (URL) throws -> Void
+    ) throws -> URL {
+        let fm = FileManager.default
+        try fm.createDirectory(at: directory, withIntermediateDirectories: true)
+
+        let staging = directory.appendingPathComponent(".phosphor-\(UUID().uuidString).tmp")
+        var published = false
+        defer {
+            if !published { try? fm.removeItem(at: staging) }
+        }
+
+        try writer(staging)
+        try Task.checkCancellation()
+
+        var info = stat()
+        guard lstat(staging.path, &info) == 0 else {
+            throw CocoaError(.fileNoSuchFile)
+        }
+        guard (info.st_mode & S_IFMT) == S_IFREG else {
+            throw CocoaError(.fileReadUnsupportedScheme)
+        }
+
+        let name = filenameParts(preferredFilename)
+        for index in 1...100_000 {
+            let suffix = index == 1 ? "" : " (\(index))"
+            let candidateName = name.ext.isEmpty
+                ? "\(name.stem)\(suffix)"
+                : "\(name.stem)\(suffix).\(name.ext)"
+            let candidate = directory.appendingPathComponent(candidateName)
+            let result = staging.path.withCString { source in
+                candidate.path.withCString { destination in
+                    renamex_np(source, destination, UInt32(RENAME_EXCL))
+                }
+            }
+            if result == 0 {
+                published = true
+                return candidate
+            }
+            let code = errno
+            if code == EEXIST { continue }
+            throw POSIXError(POSIXErrorCode(rawValue: code) ?? .EIO)
+        }
+        throw POSIXError(.EEXIST)
+    }
+
+    private static func filenameParts(_ preferredFilename: String) -> (stem: String, ext: String) {
+        let requested = URL(fileURLWithPath: preferredFilename).lastPathComponent
+        let filename = requested.isEmpty || requested == "." || requested == ".." ? "Track" : requested
+        let filenameURL = URL(fileURLWithPath: filename)
+        return (filenameURL.deletingPathExtension().lastPathComponent, filenameURL.pathExtension)
+    }
+}

--- a/Sources/Phosphor/Views/Music/MusicView.swift
+++ b/Sources/Phosphor/Views/Music/MusicView.swift
@@ -8,6 +8,9 @@ struct MusicView: View {
     @StateObject private var musicManager = MusicTransferManager()
     @State private var activeTab: MusicTab = .backup
     @State private var selectedTracks: Set<String> = []
+    @State private var extractionTask: Task<Void, Never>?
+    @State private var extractionMessage = ""
+    @State private var showExtractionResult = false
 
     enum MusicTab: String, CaseIterable {
         case backup = "From Backup"
@@ -30,6 +33,12 @@ struct MusicView: View {
             if let backup = backupVM.selectedBackup {
                 Task { await musicManager.loadMusicFromBackup(backupPath: backup.path) }
             }
+        }
+        .onDisappear { extractionTask?.cancel() }
+        .alert("Music Extraction", isPresented: $showExtractionResult) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(extractionMessage)
         }
     }
 
@@ -54,7 +63,12 @@ struct MusicView: View {
             .labelsHidden()
             .frame(width: 260)
 
-            if !selectedTracks.isEmpty {
+            if extractionTask != nil {
+                ProgressView().controlSize(.small)
+                Button("Cancel Extraction", role: .cancel) {
+                    extractionTask?.cancel()
+                }
+            } else if !selectedTracks.isEmpty {
                 Button("Extract (\(selectedTracks.count))") { extractSelected() }
                     .buttonStyle(.borderedProminent)
                     .tint(.brandAccent)
@@ -213,9 +227,21 @@ struct MusicView: View {
               let backup = backupVM.selectedBackup else { return }
 
         let tracks = musicManager.tracks.filter { selectedTracks.contains($0.id) }
-        Task {
-            let count = await musicManager.extractTracks(tracks, from: backup.path, to: url.path)
-            if count > 0 { NSWorkspace.shared.open(url) }
+        extractionTask?.cancel()
+        extractionTask = Task {
+            let outcome = await musicManager.extractTracks(tracks, from: backup.path, to: url.path)
+            extractionTask = nil
+
+            var summary = "\(outcome.extracted) of \(outcome.total) tracks extracted."
+            if outcome.cancelled {
+                summary += " Extraction was cancelled."
+            }
+            if let failure = outcome.lastError, !failure.isEmpty {
+                summary += "\n\n\(failure)"
+            }
+            extractionMessage = summary
+            showExtractionResult = true
+            if outcome.extracted > 0 { NSWorkspace.shared.open(url) }
         }
     }
 


### PR DESCRIPTION
## Summary
- preserve every selected track when source basenames collide or destination files already exist
- write to hidden sibling staging files and atomically publish with `renamex_np(..., RENAME_EXCL)` suffix retry
- reject non-regular staged outputs and clean staging data on writer failure or cancellation
- run backup extraction off the main actor with explicit cancellation propagation and post-copy/pre-publish checks
- retain a cancellable UI task and report accurate N-of-M success, partial failure, or cancellation outcomes

## Verification
- 66 regression checks passed
- behavioral publication probe: final name absent until successful publication; cancellation leaves no final/staging file
- independent concurrency probe: 12 concurrent same-name writers produced 12 distinct complete outputs, with 0 visible final files while writers were paused
- `swift build -Xswiftc -strict-concurrency=complete`
- `swift build -c release`
- `bash Scripts/build.sh`
- independent blocker review: PASS, no P0/P1 findings
- clean four-branch integration: 79 regression checks, debug build, and release build passed
