### PR TITLE
feat: compare backup snapshots

### DIFF
--- a/Scripts/regression/checks/backup_comparison.py
+++ b/Scripts/regression/checks/backup_comparison.py
@@ -1,0 +1,230 @@
+from __future__ import annotations
+
+from pathlib import Path
+import plistlib
+import subprocess
+import tempfile
+
+
+def read(root: Path, rel: str) -> str:
+    return (root / rel).read_text()
+
+
+def test_backup_comparison_engine_classifies_snapshot_changes_behaviorally(root: Path) -> None:
+    model = root / "Sources/Phosphor/Models/BackupComparison.swift"
+    assert model.exists(), "BackupComparison model/engine must exist"
+
+    probe = r'''
+import Foundation
+
+@main
+struct Probe {
+    static func main() {
+        let old = [
+            BackupComparisonRecord(fileID: "stable", domain: "HomeDomain", relativePath: "same.txt", flags: 1, size: 5, modifiedTime: 10),
+            BackupComparisonRecord(fileID: "changed", domain: "HomeDomain", relativePath: "changed.txt", flags: 1, size: 5, modifiedTime: 10),
+            BackupComparisonRecord(fileID: "removed", domain: "CameraRollDomain", relativePath: "old.jpg", flags: 1, size: 8, modifiedTime: 10),
+        ]
+        let new = [
+            BackupComparisonRecord(fileID: "stable", domain: "HomeDomain", relativePath: "same.txt", flags: 1, size: 5, modifiedTime: 10),
+            BackupComparisonRecord(fileID: "changed", domain: "HomeDomain", relativePath: "changed.txt", flags: 1, size: 9, modifiedTime: 11),
+            BackupComparisonRecord(fileID: "added", domain: "CameraRollDomain", relativePath: "new.jpg", flags: 1, size: 12, modifiedTime: 12),
+        ]
+        let result = BackupComparisonEngine.compare(older: old, newer: new)
+        print("COUNTS|\(result.addedCount)|\(result.modifiedCount)|\(result.removedCount)|\(result.unchangedCount)")
+        print("ORDER|" + result.changes.map { "\($0.kind.rawValue):\($0.relativePath)" }.joined(separator: ","))
+
+        let manyNew = (0..<4).map {
+            BackupComparisonRecord(fileID: "new-\($0)", domain: "HomeDomain", relativePath: "new-\($0).txt", flags: 1, size: 1, modifiedTime: 1)
+        }
+        let capped = BackupComparisonEngine.compare(older: [], newer: manyNew, displayLimitPerKind: 2)
+        print("CAP|\(capped.addedCount)|\(capped.changes.count)|\(capped.hasHiddenChanges)")
+
+        var oldIterator = old.sorted { $0.cursorOrderKey < $1.cursorOrderKey }.makeIterator()
+        var newIterator = new.sorted { $0.cursorOrderKey < $1.cursorOrderKey }.makeIterator()
+        let streamed = try! BackupComparisonEngine.compareOrdered(
+            nextOlder: { oldIterator.next() },
+            nextNewer: { newIterator.next() }
+        )
+        print("STREAM|\(streamed.addedCount)|\(streamed.modifiedCount)|\(streamed.removedCount)|\(streamed.unchangedCount)")
+
+        let oversizedOld = BackupComparisonRecord(fileID: "large", domain: "HomeDomain", relativePath: "large.bin", flags: 1, size: 0, modifiedTime: nil, metadataComplete: false)
+        let oversizedNew = BackupComparisonRecord(fileID: "large", domain: "HomeDomain", relativePath: "large.bin", flags: 1, size: 0, modifiedTime: nil, metadataComplete: false)
+        let conservative = BackupComparisonEngine.compare(older: [oversizedOld], newer: [oversizedNew])
+        print("INCOMPLETE|\(conservative.modifiedCount)|\(conservative.unchangedCount)")
+    }
+}
+'''
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp = Path(temp_dir)
+        probe_path = temp / "Probe.swift"
+        probe_path.write_text(probe)
+        executable = temp / "backup-comparison-probe"
+        compile_result = subprocess.run(
+            ["swiftc", "-parse-as-library", str(model), str(probe_path), "-o", str(executable)],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        assert compile_result.returncode == 0, compile_result.stderr
+        result = subprocess.run([str(executable)], capture_output=True, text=True, timeout=10)
+
+    assert result.returncode == 0, result.stderr
+    assert "COUNTS|1|1|1|1" in result.stdout, result.stdout
+    assert "ORDER|added:new.jpg,modified:changed.txt,removed:old.jpg" in result.stdout, result.stdout
+    assert "CAP|4|2|true" in result.stdout, result.stdout
+    assert "STREAM|1|1|1|1" in result.stdout, result.stdout
+    assert "INCOMPLETE|1|0" in result.stdout, result.stdout
+
+
+def test_backup_comparison_uses_manifest_metadata_off_main_actor(root: Path) -> None:
+    manifest = read(root, "Sources/Phosphor/Utilities/BackupManifest.swift")
+    model = read(root, "Sources/Phosphor/Models/BackupComparison.swift")
+    service = read(root, "Sources/Phosphor/Services/BackupComparisonService.swift")
+    view = read(root, "Sources/Phosphor/Views/Backup/BackupComparisonView.swift")
+    time_machine = read(root, "Sources/Phosphor/Views/Backup/BackupTimeMachineView.swift")
+
+    assert "final class ComparisonCursor" in manifest
+    assert "func makeComparisonCursor()" in manifest
+    assert "func comparisonRecords() throws -> [BackupComparisonRecord]" not in manifest
+    assert "CASE WHEN length(file)" in manifest and "maximumMetadataBlobBytes" in manifest
+    assert "flags = 1" in manifest, "comparison should report regular files, not directories or links"
+    assert "makeComparisonCursor" in service
+    assert "BackupComparisonEngine.compareOrdered" in service
+    assert "Task.checkCancellation()" in model, "streaming merge must stop promptly when dismissed"
+    assert "Task.detached" in view, "large manifest comparisons must not block SwiftUI's main actor"
+    assert "comparisonOperationID" in view, "stale comparison completions must be ignored"
+    assert "comparisonTask" in view and ".cancel()" in view, "dismissed/replaced comparisons must cancel background work"
+    assert "Task.checkCancellation()" in manifest and "sqlite3_step" in manifest, "manifest scans must be bounded and cancellation-aware"
+    assert "status == SQLITE_DONE" in manifest and "status == SQLITE_ROW" in manifest
+    assert "SQLITE_OPEN_READONLY" in manifest, "comparison cursor must not mutate a backup manifest"
+    assert "Compare Backups" in time_machine, "Time Machine must expose the comparison flow"
+    assert "BackupComparisonView" in time_machine, "the comparison UI must be reachable"
+    assert "BackupUnlockStore.shared" in view and "BackupPasswordKeychain" in view
+    assert "Unlock Encrypted Backup" in view
+
+
+def test_backup_comparison_rejects_mismatched_devices(root: Path) -> None:
+    service = read(root, "Sources/Phosphor/Services/BackupComparisonService.swift")
+    view = read(root, "Sources/Phosphor/Views/Backup/BackupComparisonView.swift")
+    assert "case differentDevices" in service
+    assert "older.udid == newer.udid" in service
+    assert "fileResourceIdentifier" in service and "volumeIdentifier" in service
+    assert "resolvingSymlinksInPath" in service
+    assert "case invalidChronology" in service and "olderDate < newerDate" in service
+    assert "($0.lastBackupDate ?? .distantFuture) < newerDate" in view
+    assert "Same device" in view or "same device" in view
+
+
+def test_backup_comparison_decodes_uid_backed_modification_dates(root: Path) -> None:
+    crypto = root / "Sources/Phosphor/Utilities/BackupCrypto.swift"
+    plist_parser = root / "Sources/Phosphor/Utilities/PlistParser.swift"
+    model = root / "Sources/Phosphor/Models/BackupComparison.swift"
+    probe = r'''
+import Foundation
+
+@main
+struct Probe {
+    static func main() throws {
+        let oldRecord = BackupFileRecord(fileBlob: try Data(contentsOf: URL(fileURLWithPath: CommandLine.arguments[1])))!
+        let newRecord = BackupFileRecord(fileBlob: try Data(contentsOf: URL(fileURLWithPath: CommandLine.arguments[2])))!
+        let old = BackupComparisonRecord(fileID: "same", domain: "HomeDomain", relativePath: "same.txt", flags: 1, size: oldRecord.size, modifiedTime: oldRecord.modifiedTime)
+        let new = BackupComparisonRecord(fileID: "same", domain: "HomeDomain", relativePath: "same.txt", flags: 1, size: newRecord.size, modifiedTime: newRecord.modifiedTime)
+        let result = BackupComparisonEngine.compare(older: [old], newer: [new])
+        print("DATES|\(oldRecord.modifiedTime ?? -1)|\(newRecord.modifiedTime ?? -1)")
+        print("COUNTS|\(result.modifiedCount)|\(result.unchangedCount)")
+    }
+}
+'''
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp = Path(temp_dir)
+        blobs = []
+        for index, reference_time in enumerate((100.0, 200.0)):
+            blob = temp / f"record-{index}.plist"
+            blob.write_bytes(
+                plistlib.dumps(
+                    {
+                        "$objects": [
+                            "$null",
+                            {
+                                "ProtectionClass": 1,
+                                "Size": 5,
+                                "LastModified": plistlib.UID(2),
+                            },
+                            {"NS.time": reference_time},
+                        ],
+                        "$top": {"root": plistlib.UID(1)},
+                        "$version": 100000,
+                        "$archiver": "NSKeyedArchiver",
+                    },
+                    fmt=plistlib.FMT_BINARY,
+                )
+            )
+            blobs.append(blob)
+        probe_path = temp / "Probe.swift"
+        probe_path.write_text(probe)
+        executable = temp / "backup-date-probe"
+        compile_result = subprocess.run(
+            ["swiftc", "-parse-as-library", str(crypto), str(plist_parser), str(model), str(probe_path), "-o", str(executable)],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        assert compile_result.returncode == 0, compile_result.stderr
+        result = subprocess.run(
+            [str(executable), str(blobs[0]), str(blobs[1])],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+
+    assert result.returncode == 0, result.stderr
+    assert "DATES|978307300.0|978307400.0" in result.stdout, result.stdout
+    assert "COUNTS|1|0" in result.stdout, result.stdout
+
+
+def test_backup_operation_gate_covers_all_manager_instances(root: Path) -> None:
+    coordinator = root / "Sources/Phosphor/Services/BackupOperationCoordinator.swift"
+    manager = read(root, "Sources/Phosphor/Services/BackupManager.swift")
+    service = read(root, "Sources/Phosphor/Services/BackupComparisonService.swift")
+    view = read(root, "Sources/Phosphor/Views/Backup/BackupComparisonView.swift")
+    assert coordinator.exists()
+    assert manager.count("BackupOperationCoordinator.shared.beginBackup()") >= 2
+    assert "BackupOperationCoordinator.shared.beginComparison()" in service
+    assert "backupOperationStateDidChange" in view and "backupOperationActive" in view
+
+    probe = r'''
+import Foundation
+
+@main
+struct Probe {
+    static func main() {
+        let coordinator = BackupOperationCoordinator.shared
+        let backup = coordinator.beginBackup()!
+        print("BACKUP_BLOCKS_COMPARE|\(coordinator.beginComparison() == nil)")
+        coordinator.endBackup(backup)
+        let comparison = coordinator.beginComparison()!
+        print("COMPARE_BLOCKS_BACKUP|\(coordinator.beginBackup() == nil)")
+        coordinator.endComparison(comparison)
+        print("RELEASED|\(coordinator.beginBackup() != nil)")
+    }
+}
+'''
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp = Path(temp_dir)
+        probe_path = temp / "Probe.swift"
+        probe_path.write_text(probe)
+        executable = temp / "backup-operation-gate-probe"
+        compile_result = subprocess.run(
+            ["swiftc", "-parse-as-library", str(coordinator), str(probe_path), "-o", str(executable)],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        assert compile_result.returncode == 0, compile_result.stderr
+        result = subprocess.run([str(executable)], capture_output=True, text=True, timeout=10)
+
+    assert result.returncode == 0, result.stderr
+    assert "BACKUP_BLOCKS_COMPARE|true" in result.stdout
+    assert "COMPARE_BLOCKS_BACKUP|true" in result.stdout
+    assert "RELEASED|true" in result.stdout

--- a/Sources/Phosphor/Models/BackupComparison.swift
+++ b/Sources/Phosphor/Models/BackupComparison.swift
@@ -1,0 +1,216 @@
+import Foundation
+
+/// Compact metadata used to compare one manifest entry across two backups.
+struct BackupComparisonRecord: Hashable, Sendable {
+    let fileID: String
+    let domain: String
+    let relativePath: String
+    let flags: Int
+    let size: Int
+    let modifiedTime: TimeInterval?
+    let metadataDigest: Data
+    let metadataComplete: Bool
+
+    init(
+        fileID: String,
+        domain: String,
+        relativePath: String,
+        flags: Int,
+        size: Int,
+        modifiedTime: TimeInterval?,
+        metadataDigest: Data = Data(),
+        metadataComplete: Bool = true
+    ) {
+        self.fileID = fileID
+        self.domain = domain
+        self.relativePath = relativePath
+        self.flags = flags
+        self.size = size
+        self.modifiedTime = modifiedTime
+        self.metadataDigest = metadataDigest
+        self.metadataComplete = metadataComplete
+    }
+
+    var key: String { "\(domain)\u{1F}\(relativePath)" }
+    var cursorOrderKey: String { "\(fileID)\u{1F}\(domain)\u{1F}\(relativePath)" }
+
+    fileprivate func hasSameMetadata(as other: BackupComparisonRecord) -> Bool {
+        metadataComplete && other.metadataComplete
+            && flags == other.flags
+            && size == other.size
+            && modifiedTime == other.modifiedTime
+            && metadataDigest == other.metadataDigest
+    }
+}
+
+enum BackupChangeKind: String, CaseIterable, Sendable {
+    case added
+    case modified
+    case removed
+
+    fileprivate var sortOrder: Int {
+        switch self {
+        case .added: return 0
+        case .modified: return 1
+        case .removed: return 2
+        }
+    }
+}
+
+struct BackupComparisonChange: Identifiable, Hashable, Sendable {
+    let kind: BackupChangeKind
+    let before: BackupComparisonRecord?
+    let after: BackupComparisonRecord?
+
+    var id: String { "\(kind.rawValue):\(record.key)" }
+    var record: BackupComparisonRecord { after ?? before! }
+    var domain: String { record.domain }
+    var relativePath: String { record.relativePath }
+    var fileName: String { (relativePath as NSString).lastPathComponent }
+    var sizeDelta: Int { (after?.size ?? 0) - (before?.size ?? 0) }
+}
+
+struct BackupComparisonResult: Sendable {
+    /// Deterministic, per-kind bounded sample used by the UI. Aggregate counts
+    /// remain exact even when a very large manifest diff is truncated.
+    let changes: [BackupComparisonChange]
+    let addedCount: Int
+    let modifiedCount: Int
+    let removedCount: Int
+    let unchangedCount: Int
+
+    var totalChanges: Int { addedCount + modifiedCount + removedCount }
+    var hasHiddenChanges: Bool { totalChanges > changes.count }
+}
+
+enum BackupComparisonEngine {
+    static func compare(
+        older: [BackupComparisonRecord],
+        newer: [BackupComparisonRecord],
+        displayLimitPerKind: Int = 2_000
+    ) -> BackupComparisonResult {
+        let oldByKey = Dictionary(older.map { ($0.key, $0) }, uniquingKeysWith: { first, _ in first })
+        let newByKey = Dictionary(newer.map { ($0.key, $0) }, uniquingKeysWith: { first, _ in first })
+        let keys = Set(oldByKey.keys).union(newByKey.keys).sorted()
+        let limit = max(0, displayLimitPerKind)
+
+        var added: [BackupComparisonChange] = []
+        var modified: [BackupComparisonChange] = []
+        var removed: [BackupComparisonChange] = []
+        var addedCount = 0
+        var modifiedCount = 0
+        var removedCount = 0
+        var unchangedCount = 0
+
+        for key in keys {
+            let before = oldByKey[key]
+            let after = newByKey[key]
+            switch (before, after) {
+            case (nil, let after?):
+                addedCount += 1
+                if added.count < limit {
+                    added.append(BackupComparisonChange(kind: .added, before: nil, after: after))
+                }
+            case (let before?, nil):
+                removedCount += 1
+                if removed.count < limit {
+                    removed.append(BackupComparisonChange(kind: .removed, before: before, after: nil))
+                }
+            case (let before?, let after?):
+                if before.hasSameMetadata(as: after) {
+                    unchangedCount += 1
+                } else {
+                    modifiedCount += 1
+                    if modified.count < limit {
+                        modified.append(BackupComparisonChange(kind: .modified, before: before, after: after))
+                    }
+                }
+            case (nil, nil):
+                break
+            }
+        }
+
+        return BackupComparisonResult(
+            changes: added + modified + removed,
+            addedCount: addedCount,
+            modifiedCount: modifiedCount,
+            removedCount: removedCount,
+            unchangedCount: unchangedCount
+        )
+    }
+
+    /// Merge two manifest cursors ordered by the indexed manifest `fileID`.
+    /// The file ID is deterministically derived from `(domain, relativePath)`;
+    /// domain/path remain the logical identity displayed and filtered by the UI.
+    /// Only exact counters and the bounded UI samples are kept; callers never
+    /// need to materialize either complete manifest in memory.
+    static func compareOrdered(
+        nextOlder: () throws -> BackupComparisonRecord?,
+        nextNewer: () throws -> BackupComparisonRecord?,
+        displayLimitPerKind: Int = 2_000
+    ) throws -> BackupComparisonResult {
+        let limit = max(0, displayLimitPerKind)
+        var before = try nextOlder()
+        var after = try nextNewer()
+        var added: [BackupComparisonChange] = []
+        var modified: [BackupComparisonChange] = []
+        var removed: [BackupComparisonChange] = []
+        var addedCount = 0
+        var modifiedCount = 0
+        var removedCount = 0
+        var unchangedCount = 0
+
+        while before != nil || after != nil {
+            try Task.checkCancellation()
+            switch (before, after) {
+            case (nil, let current?):
+                addedCount += 1
+                if added.count < limit {
+                    added.append(BackupComparisonChange(kind: .added, before: nil, after: current))
+                }
+                after = try nextNewer()
+            case (let current?, nil):
+                removedCount += 1
+                if removed.count < limit {
+                    removed.append(BackupComparisonChange(kind: .removed, before: current, after: nil))
+                }
+                before = try nextOlder()
+            case (let old?, let new?):
+                if old.cursorOrderKey < new.cursorOrderKey {
+                    removedCount += 1
+                    if removed.count < limit {
+                        removed.append(BackupComparisonChange(kind: .removed, before: old, after: nil))
+                    }
+                    before = try nextOlder()
+                } else if new.cursorOrderKey < old.cursorOrderKey {
+                    addedCount += 1
+                    if added.count < limit {
+                        added.append(BackupComparisonChange(kind: .added, before: nil, after: new))
+                    }
+                    after = try nextNewer()
+                } else {
+                    if old.hasSameMetadata(as: new) {
+                        unchangedCount += 1
+                    } else {
+                        modifiedCount += 1
+                        if modified.count < limit {
+                            modified.append(BackupComparisonChange(kind: .modified, before: old, after: new))
+                        }
+                    }
+                    before = try nextOlder()
+                    after = try nextNewer()
+                }
+            case (nil, nil):
+                break
+            }
+        }
+
+        return BackupComparisonResult(
+            changes: added + modified + removed,
+            addedCount: addedCount,
+            modifiedCount: modifiedCount,
+            removedCount: removedCount,
+            unchangedCount: unchangedCount
+        )
+    }
+}

--- a/Sources/Phosphor/Models/BackupInfo.swift
+++ b/Sources/Phosphor/Models/BackupInfo.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Represents an iOS backup stored on disk.
-struct BackupInfo: Identifiable, Hashable {
+struct BackupInfo: Identifiable, Hashable, Sendable {
     let id: String // backup directory name (usually UDID or UDID+timestamp)
     let path: String
     let deviceName: String

--- a/Sources/Phosphor/Services/BackupComparisonService.swift
+++ b/Sources/Phosphor/Services/BackupComparisonService.swift
@@ -1,0 +1,84 @@
+import Foundation
+
+enum BackupComparisonError: LocalizedError {
+    case sameBackup
+    case differentDevices
+    case backupInProgress
+    case invalidChronology
+
+    var errorDescription: String? {
+        switch self {
+        case .sameBackup:
+            return "Choose two different backups to compare."
+        case .differentDevices:
+            return "Backups must belong to the same device before they can be compared."
+        case .backupInProgress:
+            return "Wait for the active backup to finish before comparing snapshots."
+        case .invalidChronology:
+            return "Choose an older dated snapshot on the left and a newer snapshot on the right."
+        }
+    }
+}
+
+enum BackupComparisonService {
+    static func compare(older: BackupInfo, newer: BackupInfo) throws -> BackupComparisonResult {
+        let olderIdentity = try filesystemIdentity(for: older.path)
+        let newerIdentity = try filesystemIdentity(for: newer.path)
+        guard olderIdentity != newerIdentity else { throw BackupComparisonError.sameBackup }
+        guard !older.udid.isEmpty, older.udid == newer.udid else {
+            throw BackupComparisonError.differentDevices
+        }
+        guard let olderDate = older.lastBackupDate,
+              let newerDate = newer.lastBackupDate,
+              olderDate < newerDate else {
+            throw BackupComparisonError.invalidChronology
+        }
+        guard let operationToken = BackupOperationCoordinator.shared.beginComparison() else {
+            throw BackupComparisonError.backupInProgress
+        }
+        defer { BackupOperationCoordinator.shared.endComparison(operationToken) }
+
+        let olderManifest = try BackupManifest(backupPath: older.path)
+        let newerManifest = try BackupManifest(backupPath: newer.path)
+        let olderCursor = try olderManifest.makeComparisonCursor()
+        let newerCursor = try newerManifest.makeComparisonCursor()
+        return try BackupComparisonEngine.compareOrdered(
+            nextOlder: { try olderCursor.next() },
+            nextNewer: { try newerCursor.next() }
+        )
+    }
+
+    private struct FilesystemIdentity: Equatable {
+        let canonicalPath: String
+        let volumeIdentifier: String?
+        let fileResourceIdentifier: String?
+
+        static func == (lhs: FilesystemIdentity, rhs: FilesystemIdentity) -> Bool {
+            if lhs.canonicalPath == rhs.canonicalPath { return true }
+            guard let lhsVolume = lhs.volumeIdentifier,
+                  let rhsVolume = rhs.volumeIdentifier,
+                  let lhsFile = lhs.fileResourceIdentifier,
+                  let rhsFile = rhs.fileResourceIdentifier else { return false }
+            return lhsVolume == rhsVolume && lhsFile == rhsFile
+        }
+    }
+
+    private static func filesystemIdentity(for path: String) throws -> FilesystemIdentity {
+        let url = URL(fileURLWithPath: path, isDirectory: true)
+            .standardizedFileURL
+            .resolvingSymlinksInPath()
+        let values = try url.resourceValues(forKeys: [
+            .isDirectoryKey,
+            .volumeIdentifierKey,
+            .fileResourceIdentifierKey,
+        ])
+        guard values.isDirectory == true else {
+            throw CocoaError(.fileReadUnsupportedScheme)
+        }
+        return FilesystemIdentity(
+            canonicalPath: url.path,
+            volumeIdentifier: values.volumeIdentifier.map(String.init(describing:)),
+            fileResourceIdentifier: values.fileResourceIdentifier.map(String.init(describing:))
+        )
+    }
+}

--- a/Sources/Phosphor/Services/BackupManager.swift
+++ b/Sources/Phosphor/Services/BackupManager.swift
@@ -481,6 +481,15 @@ final class BackupManager: ObservableObject {
         preferNetwork: Bool = false,
         onProgress: @escaping (String) -> Void
     ) async -> Bool {
+        guard let coordinatorToken = BackupOperationCoordinator.shared.beginBackup() else {
+            let message = "Wait for the active backup comparison to finish, then try the backup again."
+            backupProgress = "Backup paused"
+            lastError = message
+            onProgress(message)
+            return false
+        }
+        defer { BackupOperationCoordinator.shared.endBackup(coordinatorToken) }
+
         isCreatingBackup = true
         let operationID = beginCancellableOperation()
         backupProgress = "Starting backup..."
@@ -696,6 +705,15 @@ final class BackupManager: ObservableObject {
         preferNetwork: Bool = false,
         onProgress: @escaping (String) -> Void
     ) async -> Bool {
+        guard let coordinatorToken = BackupOperationCoordinator.shared.beginBackup() else {
+            let message = "Wait for the active backup comparison to finish, then try the backup again."
+            backupProgress = "Backup paused"
+            lastError = message
+            onProgress(message)
+            return false
+        }
+        defer { BackupOperationCoordinator.shared.endBackup(coordinatorToken) }
+
         isCreatingBackup = true
         let operationID = beginCancellableOperation()
         backupProgress = "Starting incremental backup..."

--- a/Sources/Phosphor/Services/BackupOperationCoordinator.swift
+++ b/Sources/Phosphor/Services/BackupOperationCoordinator.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+extension Notification.Name {
+    static let backupOperationStateDidChange = Notification.Name("Phosphor.BackupOperationStateDidChange")
+}
+
+/// Process-wide read/write gate for backup manifests. Backup creation is a
+/// writer; comparison is a reader over two snapshots. They must never overlap,
+/// even when creation was started by a scheduler or clone flow with its own
+/// `BackupManager` instance.
+final class BackupOperationCoordinator: @unchecked Sendable {
+    static let shared = BackupOperationCoordinator()
+
+    private let lock = NSLock()
+    private var backupTokens: Set<UUID> = []
+    private var comparisonTokens: Set<UUID> = []
+
+    private init() {}
+
+    var hasActiveBackup: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return !backupTokens.isEmpty
+    }
+
+    func beginBackup() -> UUID? {
+        lock.lock()
+        guard comparisonTokens.isEmpty else {
+            lock.unlock()
+            return nil
+        }
+        let token = UUID()
+        backupTokens.insert(token)
+        lock.unlock()
+        postStateChanged()
+        return token
+    }
+
+    func endBackup(_ token: UUID) {
+        lock.lock()
+        let changed = backupTokens.remove(token) != nil
+        lock.unlock()
+        if changed { postStateChanged() }
+    }
+
+    func beginComparison() -> UUID? {
+        lock.lock()
+        defer { lock.unlock() }
+        guard backupTokens.isEmpty else { return nil }
+        let token = UUID()
+        comparisonTokens.insert(token)
+        return token
+    }
+
+    func endComparison(_ token: UUID) {
+        lock.lock()
+        comparisonTokens.remove(token)
+        lock.unlock()
+    }
+
+    private func postStateChanged() {
+        DispatchQueue.main.async {
+            NotificationCenter.default.post(name: .backupOperationStateDidChange, object: nil)
+        }
+    }
+}

--- a/Sources/Phosphor/Utilities/BackupCrypto.swift
+++ b/Sources/Phosphor/Utilities/BackupCrypto.swift
@@ -348,6 +348,7 @@ struct BackupFileRecord {
     let protectionClass: Int
     let wrappedKey: Data?
     let size: Int
+    let modifiedTime: TimeInterval?
 
     /// Length of a wrapped file key: a 4-byte little-endian protection class
     /// plus the 40-byte RFC 3394 wrapping of a 32-byte AES key.
@@ -363,6 +364,8 @@ struct BackupFileRecord {
 
         protectionClass = (fileObject["ProtectionClass"] as? NSNumber)?.intValue ?? 0
         size = (fileObject["Size"] as? NSNumber)?.intValue ?? 0
+        let rawModified = fileObject["LastModified"] ?? fileObject["MTime"]
+        modifiedTime = Self.modifiedTime(from: rawModified, objects: objects)
         if fileObject["EncryptionKey"] == nil {
             wrappedKey = nil
         } else {
@@ -370,5 +373,45 @@ struct BackupFileRecord {
                 .compactMap { $0["NS.data"] as? Data }
                 .first { $0.count == Self.wrappedKeyLength }
         }
+    }
+
+    /// Decode an NSDate stored through an NSKeyedArchiver UID without invoking
+    /// NSKeyedUnarchiver on backup-controlled data. `NS.time` is measured from
+    /// Apple's 2001 reference date; direct numeric manifest values retain their
+    /// historical interpretation as Unix timestamps.
+    private static func modifiedTime(from rawValue: Any?, objects: [Any]) -> TimeInterval? {
+        if let date = rawValue as? Date { return date.timeIntervalSince1970 }
+        if let number = rawValue as? NSNumber { return number.doubleValue }
+
+        guard let rawValue,
+              let index = archiveObjectIndex(from: rawValue),
+              objects.indices.contains(index) else { return nil }
+        let resolved = objects[index]
+        if let date = resolved as? Date { return date.timeIntervalSince1970 }
+        if let dictionary = resolved as? [String: Any],
+           let referenceTime = dictionary["NS.time"] as? NSNumber {
+            return referenceTime.doubleValue + Date.timeIntervalBetween1970AndReferenceDate
+        }
+        if let number = resolved as? NSNumber { return number.doubleValue }
+        return nil
+    }
+
+    /// PropertyListSerialization exposes binary-plist UID values as the opaque
+    /// CFKeyedArchiverUID type. Support its stable description plus the CF$UID
+    /// dictionary shape used by XML/plist tooling, while rejecting arbitrary
+    /// strings and out-of-range values.
+    private static func archiveObjectIndex(from value: Any) -> Int? {
+        if let dictionary = value as? [String: Any],
+           let number = dictionary["CF$UID"] as? NSNumber,
+           number.intValue >= 0 {
+            return number.intValue
+        }
+        let description = String(describing: value)
+        guard description.contains("CFKeyedArchiverUID"),
+              let marker = description.range(of: "{value = "),
+              let end = description[marker.upperBound...].firstIndex(of: "}") else { return nil }
+        let digits = description[marker.upperBound..<end]
+        guard !digits.isEmpty, digits.allSatisfy(\.isNumber) else { return nil }
+        return Int(digits)
     }
 }

--- a/Sources/Phosphor/Utilities/BackupManifest.swift
+++ b/Sources/Phosphor/Utilities/BackupManifest.swift
@@ -1,4 +1,6 @@
 import Foundation
+import CommonCrypto
+import SQLite3
 
 /// Parses iOS backup Manifest.db to browse backup contents.
 /// The Manifest.db contains a "Files" table mapping domain/relativePath to SHA-1 hashed filenames.
@@ -301,6 +303,120 @@ final class BackupManifest {
     /// Get total file count.
     func totalFileCount() throws -> Int {
         try db.rowCount(for: "Files")
+    }
+
+    /// Ordered, bounded cursor used by backup comparison. It steps one indexed
+    /// manifest row at a time, caps metadata BLOB reads, and checks SQLite's
+    /// terminal status instead of accepting partial rows as a successful scan.
+    final class ComparisonCursor {
+        static let maximumMetadataBlobBytes = 256 * 1_024
+
+        private let connection: OpaquePointer
+        private let statement: OpaquePointer
+
+        fileprivate init(databasePath: String) throws {
+            var opened: OpaquePointer?
+            let openStatus = sqlite3_open_v2(
+                databasePath, &opened,
+                SQLITE_OPEN_READONLY | SQLITE_OPEN_NOMUTEX,
+                nil
+            )
+            guard openStatus == SQLITE_OK, let opened else {
+                let error = Self.databaseError(connection: opened, operation: "open")
+                if let opened { sqlite3_close(opened) }
+                throw error
+            }
+
+            let sql = """
+                SELECT fileID, domain, relativePath, flags,
+                       CASE WHEN length(file) <= \(Self.maximumMetadataBlobBytes)
+                            THEN file ELSE NULL END AS boundedFile,
+                       length(file) AS metadataLength
+                FROM Files
+                WHERE flags = 1
+                  AND domain IS NOT NULL
+                  AND relativePath IS NOT NULL
+                  AND fileID IS NOT NULL
+                ORDER BY fileID
+            """
+            var prepared: OpaquePointer?
+            let prepareStatus = sqlite3_prepare_v2(opened, sql, -1, &prepared, nil)
+            guard prepareStatus == SQLITE_OK, let prepared else {
+                let error = Self.databaseError(connection: opened, operation: "prepare")
+                if let prepared { sqlite3_finalize(prepared) }
+                sqlite3_close(opened)
+                throw error
+            }
+            connection = opened
+            statement = prepared
+        }
+
+        deinit {
+            sqlite3_finalize(statement)
+            sqlite3_close(connection)
+        }
+
+        func next() throws -> BackupComparisonRecord? {
+            try Task.checkCancellation()
+            let status = sqlite3_step(statement)
+            if status == SQLITE_DONE { return nil }
+            guard status == SQLITE_ROW else {
+                throw Self.databaseError(connection: connection, operation: "step")
+            }
+
+            guard let fileID = Self.text(statement, column: 0),
+                  let domain = Self.text(statement, column: 1),
+                  let relativePath = Self.text(statement, column: 2) else {
+                throw Self.databaseError(connection: connection, operation: "decode")
+            }
+            let blob = Self.data(statement, column: 4)
+            let metadata = blob.flatMap(BackupFileRecord.init(fileBlob:))
+            return BackupComparisonRecord(
+                fileID: fileID,
+                domain: domain,
+                relativePath: relativePath,
+                flags: Int(sqlite3_column_int64(statement, 3)),
+                size: metadata?.size ?? 0,
+                modifiedTime: metadata?.modifiedTime,
+                metadataDigest: blob.map(Self.sha256) ?? Data(),
+                metadataComplete: sqlite3_column_type(statement, 4) != SQLITE_NULL
+            )
+        }
+
+        private static func text(_ statement: OpaquePointer, column: Int32) -> String? {
+            guard let bytes = sqlite3_column_text(statement, column) else { return nil }
+            return String(cString: bytes)
+        }
+
+        private static func data(_ statement: OpaquePointer, column: Int32) -> Data? {
+            guard sqlite3_column_type(statement, column) != SQLITE_NULL else { return nil }
+            let count = Int(sqlite3_column_bytes(statement, column))
+            guard count > 0 else { return Data() }
+            guard let bytes = sqlite3_column_blob(statement, column) else { return nil }
+            return Data(bytes: bytes, count: count)
+        }
+
+        private static func databaseError(connection: OpaquePointer?, operation: String) -> Error {
+            let message = connection.flatMap(sqlite3_errmsg).map(String.init(cString:))
+                ?? "Unknown SQLite error"
+            return NSError(
+                domain: "Phosphor.BackupComparison",
+                code: Int(connection.map(sqlite3_errcode) ?? SQLITE_ERROR),
+                userInfo: [NSLocalizedDescriptionKey: "Backup comparison could not \(operation) the manifest: \(message)"]
+            )
+        }
+
+        private static func sha256(_ data: Data) -> Data {
+            var digest = [UInt8](repeating: 0, count: Int(CC_SHA256_DIGEST_LENGTH))
+            data.withUnsafeBytes { bytes in
+                _ = CC_SHA256(bytes.baseAddress, CC_LONG(data.count), &digest)
+            }
+            return Data(digest)
+        }
+    }
+
+    func makeComparisonCursor() throws -> ComparisonCursor {
+        try ComparisonCursor(databasePath: db.path)
     }
 
     /// Build a directory tree structure from file entries.

--- a/Sources/Phosphor/Views/Backup/BackupComparisonView.swift
+++ b/Sources/Phosphor/Views/Backup/BackupComparisonView.swift
@@ -1,0 +1,553 @@
+import SwiftUI
+
+struct BackupComparisonView: View {
+    @EnvironmentObject private var backupVM: BackupViewModel
+    @Environment(\.dismiss) private var dismiss
+
+    let initiallySelected: BackupInfo?
+
+    @State private var olderID = ""
+    @State private var newerID = ""
+    @State private var result: BackupComparisonResult?
+    @State private var selectedKind: BackupChangeKind?
+    @State private var query = ""
+    @State private var isComparing = false
+    @State private var errorMessage: String?
+    @State private var comparisonOperationID: UUID?
+    @State private var comparisonTask: Task<Void, Never>?
+    @State private var unlockPreparationTask: Task<Void, Never>?
+    @State private var unlockTask: Task<Void, Never>?
+    @State private var pendingUnlock: BackupInfo?
+    @State private var unlockPassword = ""
+    @State private var rememberPassword = false
+    @State private var isUnlocking = false
+    @State private var unlockError: String?
+    @State private var backupOperationActive = BackupOperationCoordinator.shared.hasActiveBackup
+
+    private struct ComparisonFailure: Error, Sendable {
+        let message: String
+    }
+
+    private var sortedBackups: [BackupInfo] {
+        backupVM.backups.sorted {
+            ($0.lastBackupDate ?? .distantPast) < ($1.lastBackupDate ?? .distantPast)
+        }
+    }
+
+    private var datedBackups: [BackupInfo] {
+        sortedBackups.filter { $0.lastBackupDate != nil }
+    }
+
+    private var newerBackup: BackupInfo? {
+        sortedBackups.first { $0.path == newerID }
+    }
+
+    private var matchingBackups: [BackupInfo] {
+        guard let newerBackup, let newerDate = newerBackup.lastBackupDate else { return [] }
+        return datedBackups.filter {
+            $0.udid == newerBackup.udid
+                && $0.path != newerBackup.path
+                && ($0.lastBackupDate ?? .distantFuture) < newerDate
+        }
+    }
+
+    private var olderBackup: BackupInfo? {
+        matchingBackups.first { $0.path == olderID }
+    }
+
+    private var visibleChanges: [BackupComparisonChange] {
+        guard let result else { return [] }
+        return result.changes.filter { change in
+            if let selectedKind, change.kind != selectedKind { return false }
+            guard !query.isEmpty else { return true }
+            return change.relativePath.localizedCaseInsensitiveContains(query)
+                || change.domain.localizedCaseInsensitiveContains(query)
+        }
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            Divider()
+            selectors
+            Divider()
+            content
+        }
+        .frame(minWidth: 760, minHeight: 560)
+        .onAppear {
+            backupOperationActive = BackupOperationCoordinator.shared.hasActiveBackup
+            chooseDefaults()
+        }
+        .onReceive(NotificationCenter.default.publisher(for: .backupOperationStateDidChange)) { _ in
+            backupOperationActive = BackupOperationCoordinator.shared.hasActiveBackup
+        }
+        .onChange(of: olderID) { _, _ in resetComparison() }
+        .onChange(of: newerID) { _, _ in
+            reconcileOlderSelection()
+            resetComparison()
+        }
+        .sheet(item: $pendingUnlock) { backup in
+            unlockSheet(for: backup)
+        }
+        .onDisappear {
+            comparisonTask?.cancel()
+            unlockPreparationTask?.cancel()
+            unlockTask?.cancel()
+        }
+    }
+
+    private var header: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 3) {
+                Text("Compare Backups")
+                    .font(.title2.weight(.semibold))
+                Text("See files added, removed, or changed in manifest metadata between two snapshots of the same device.")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+            Button("Done") { dismiss() }
+                .keyboardShortcut(.cancelAction)
+        }
+        .padding()
+    }
+
+    private var selectors: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 14) {
+                backupPicker("Older snapshot", selection: $olderID, backups: matchingBackups)
+                Image(systemName: "arrow.right")
+                    .foregroundStyle(.secondary)
+                backupPicker("Newer snapshot", selection: $newerID, backups: datedBackups)
+                Spacer()
+                Button {
+                    prepareComparison()
+                } label: {
+                    if isComparing {
+                        ProgressView().controlSize(.small)
+                    } else {
+                        Label("Compare", systemImage: "arrow.left.arrow.right")
+                    }
+                }
+                .buttonStyle(.borderedProminent)
+                .disabled(backupOperationActive || backupVM.isCreating || isComparing || olderBackup == nil || newerBackup == nil || olderID == newerID)
+            }
+
+            if matchingBackups.isEmpty {
+                Label("Choose a newer snapshot with an earlier dated backup from the same device.", systemImage: "info.circle")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            if backupOperationActive {
+                Label("Wait for the active backup to finish before comparing snapshots.", systemImage: "externaldrive.badge.timemachine")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+            }
+            if let errorMessage {
+                Label(errorMessage, systemImage: "exclamationmark.triangle.fill")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+            }
+        }
+        .padding()
+    }
+
+    private func backupPicker(
+        _ title: String,
+        selection: Binding<String>,
+        backups: [BackupInfo]
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(title).font(.caption).foregroundStyle(.secondary)
+            Picker(title, selection: selection) {
+                Text("Choose Backup").tag("")
+                ForEach(backups) { backup in
+                    Text("\(backup.deviceName) — \(backup.dateString)").tag(backup.path)
+                }
+            }
+            .labelsHidden()
+            .frame(minWidth: 230)
+        }
+    }
+
+    private func unlockSheet(for backup: BackupInfo) -> some View {
+        VStack(alignment: .leading, spacing: 14) {
+            HStack(spacing: 12) {
+                Image(systemName: "lock.fill")
+                    .font(.title2)
+                    .foregroundStyle(.orange)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Unlock Encrypted Backup")
+                        .font(.headline)
+                    Text("\(backup.displayName) • \(backup.relativeDate)")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            Text("Enter the local backup password to compare these snapshots. Phosphor derives the keys on this Mac.")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            SecureField("Backup password", text: $unlockPassword)
+                .textFieldStyle(.roundedBorder)
+                .onSubmit(submitUnlock)
+                .disabled(isUnlocking)
+
+            Toggle("Remember this password in my Keychain", isOn: $rememberPassword)
+                .toggleStyle(.checkbox)
+                .font(.caption)
+                .disabled(isUnlocking)
+
+            if let unlockError {
+                Label(unlockError, systemImage: "exclamationmark.triangle.fill")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            HStack {
+                if isUnlocking {
+                    ProgressView().controlSize(.small)
+                    Text("Deriving keys…")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+                Button("Cancel", role: .cancel) { cancelUnlock() }
+                    .keyboardShortcut(.cancelAction)
+                Button("Unlock", action: submitUnlock)
+                    .buttonStyle(.borderedProminent)
+                    .disabled(unlockPassword.isEmpty || isUnlocking)
+                    .keyboardShortcut(.defaultAction)
+            }
+        }
+        .padding(20)
+        .frame(width: 430)
+        .onAppear {
+            unlockPassword = ""
+            rememberPassword = false
+            unlockError = nil
+        }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if let result {
+            VStack(spacing: 0) {
+                summary(result)
+                Divider()
+                HStack {
+                    Picker("Change type", selection: $selectedKind) {
+                        Text("All Changes").tag(BackupChangeKind?.none)
+                        ForEach(BackupChangeKind.allCases, id: \.self) { kind in
+                            Text(label(for: kind)).tag(Optional(kind))
+                        }
+                    }
+                    .pickerStyle(.segmented)
+                    .frame(maxWidth: 380)
+                    Spacer()
+                    TextField("Filter paths", text: $query)
+                        .textFieldStyle(.roundedBorder)
+                        .frame(width: 240)
+                }
+                .padding()
+
+                if visibleChanges.isEmpty {
+                    ContentUnavailableView(
+                        query.isEmpty ? "No Changes" : "No Matching Changes",
+                        systemImage: "checkmark.circle",
+                        description: Text(query.isEmpty ? "These snapshots contain the same manifest metadata." : "Try a different path filter.")
+                    )
+                } else {
+                    VStack(spacing: 0) {
+                        List(visibleChanges) { change in
+                            changeRow(change)
+                        }
+                        .listStyle(.inset)
+                        if result.hasHiddenChanges {
+                            Divider()
+                            Text("Showing a bounded sample of \(result.changes.count.formatted()) changes. Summary counts include the complete comparison.")
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                                .frame(maxWidth: .infinity, alignment: .leading)
+                                .padding(.horizontal)
+                                .padding(.vertical, 8)
+                        }
+                    }
+                }
+            }
+        } else if isComparing {
+            VStack(spacing: 12) {
+                ProgressView()
+                Text("Comparing manifest metadata…")
+                    .foregroundStyle(.secondary)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else {
+            ContentUnavailableView(
+                "Choose Two Backups",
+                systemImage: "clock.arrow.2.circlepath",
+                description: Text("Select an older and newer snapshot from the same device, then choose Compare.")
+            )
+        }
+    }
+
+    private func summary(_ result: BackupComparisonResult) -> some View {
+        HStack(spacing: 12) {
+            summaryCard("Added", count: result.addedCount, color: .green)
+            summaryCard("Metadata Changed", count: result.modifiedCount, color: .orange)
+            summaryCard("Removed", count: result.removedCount, color: .red)
+            summaryCard("Unchanged", count: result.unchangedCount, color: .secondary)
+        }
+        .padding()
+    }
+
+    private func summaryCard(_ title: String, count: Int, color: Color) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(count.formatted()).font(.title2.weight(.semibold))
+            Text(title).font(.caption).foregroundStyle(color)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(12)
+        .background(color.opacity(0.08), in: RoundedRectangle(cornerRadius: 10))
+    }
+
+    private func changeRow(_ change: BackupComparisonChange) -> some View {
+        HStack(spacing: 12) {
+            Image(systemName: icon(for: change.kind))
+                .foregroundStyle(color(for: change.kind))
+                .frame(width: 22)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(change.fileName.isEmpty ? change.relativePath : change.fileName)
+                    .font(.body.weight(.medium))
+                Text("\(change.domain)/\(change.relativePath)")
+                    .font(.caption.monospaced())
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+            Spacer()
+            if change.kind == .modified, change.sizeDelta != 0 {
+                Text(change.sizeDelta > 0 ? "+\(change.sizeDelta.formattedFileSize)" : change.sizeDelta.formattedFileSize)
+                    .font(.caption.monospacedDigit())
+                    .foregroundStyle(.secondary)
+            }
+            Text(label(for: change.kind))
+                .font(.caption.weight(.medium))
+                .foregroundStyle(color(for: change.kind))
+        }
+        .padding(.vertical, 3)
+    }
+
+    private func icon(for kind: BackupChangeKind) -> String {
+        switch kind {
+        case .added: return "plus.circle.fill"
+        case .modified: return "pencil.circle.fill"
+        case .removed: return "minus.circle.fill"
+        }
+    }
+
+    private func label(for kind: BackupChangeKind) -> String {
+        switch kind {
+        case .added: return "Added"
+        case .modified: return "Metadata Changed"
+        case .removed: return "Removed"
+        }
+    }
+
+    private func color(for kind: BackupChangeKind) -> Color {
+        switch kind {
+        case .added: return .green
+        case .modified: return .orange
+        case .removed: return .red
+        }
+    }
+
+    private func chooseDefaults() {
+        guard !datedBackups.isEmpty else { return }
+        let selected = initiallySelected.flatMap { initial in
+            datedBackups.first { $0.path == initial.path }
+        } ?? datedBackups.last
+        newerID = selected?.path ?? ""
+        reconcileOlderSelection()
+    }
+
+    private func reconcileOlderSelection() {
+        guard newerBackup != nil else {
+            olderID = ""
+            return
+        }
+        if matchingBackups.contains(where: { $0.path == olderID }) { return }
+        olderID = matchingBackups.last?.path ?? ""
+    }
+
+    private func resetComparison() {
+        comparisonTask?.cancel()
+        unlockPreparationTask?.cancel()
+        unlockTask?.cancel()
+        comparisonTask = nil
+        unlockPreparationTask = nil
+        unlockTask = nil
+        comparisonOperationID = nil
+        pendingUnlock = nil
+        isComparing = false
+        isUnlocking = false
+        result = nil
+        errorMessage = nil
+        unlockError = nil
+    }
+
+    private func lockedBackups(older: BackupInfo, newer: BackupInfo) -> [BackupInfo] {
+        [older, newer].filter {
+            $0.isEncrypted && !BackupUnlockStore.shared.isUnlocked($0.path)
+        }
+    }
+
+    private func prepareComparison() {
+        guard let olderBackup, let newerBackup else { return }
+        guard !BackupOperationCoordinator.shared.hasActiveBackup else {
+            backupOperationActive = true
+            errorMessage = "Wait for the active backup to finish before comparing snapshots."
+            return
+        }
+        comparisonTask?.cancel()
+        unlockPreparationTask?.cancel()
+        result = nil
+        errorMessage = nil
+        unlockError = nil
+
+        let locked = lockedBackups(older: olderBackup, newer: newerBackup)
+        guard !locked.isEmpty else {
+            startComparison(older: olderBackup, newer: newerBackup)
+            return
+        }
+
+        isComparing = true
+        unlockPreparationTask = Task {
+            let worker = Task.detached(priority: .userInitiated) { () -> BackupInfo? in
+                for backup in locked {
+                    guard !Task.isCancelled else { return nil }
+                    guard let password = BackupPasswordKeychain.password(for: backup.path) else {
+                        return backup
+                    }
+                    do {
+                        try BackupUnlockStore.shared.unlock(backupPath: backup.path, password: password)
+                    } catch {
+                        BackupPasswordKeychain.delete(backupPath: backup.path)
+                        return backup
+                    }
+                }
+                return nil
+            }
+            let stillLocked = await withTaskCancellationHandler {
+                await worker.value
+            } onCancel: {
+                worker.cancel()
+            }
+            guard !Task.isCancelled else { return }
+            unlockPreparationTask = nil
+            isComparing = false
+            if let stillLocked {
+                pendingUnlock = stillLocked
+            } else {
+                startComparison(older: olderBackup, newer: newerBackup)
+            }
+        }
+    }
+
+    private func submitUnlock() {
+        guard !unlockPassword.isEmpty,
+              !isUnlocking,
+              let olderBackup,
+              let newerBackup else { return }
+        let password = unlockPassword
+        let remember = rememberPassword
+        let locked = lockedBackups(older: olderBackup, newer: newerBackup)
+        guard !locked.isEmpty else {
+            pendingUnlock = nil
+            startComparison(older: olderBackup, newer: newerBackup)
+            return
+        }
+
+        isUnlocking = true
+        unlockError = nil
+        unlockTask?.cancel()
+        unlockTask = Task {
+            let worker = Task.detached(priority: .userInitiated) {
+                do {
+                    for backup in locked {
+                        try Task.checkCancellation()
+                        try BackupUnlockStore.shared.unlock(backupPath: backup.path, password: password)
+                    }
+                    return Result<Void, ComparisonFailure>.success(())
+                } catch {
+                    return .failure(ComparisonFailure(message: error.localizedDescription))
+                }
+            }
+            let outcome = await withTaskCancellationHandler {
+                await worker.value
+            } onCancel: {
+                worker.cancel()
+            }
+            guard !Task.isCancelled else { return }
+            unlockTask = nil
+            isUnlocking = false
+            switch outcome {
+            case .success:
+                if remember {
+                    for backup in locked {
+                        BackupPasswordKeychain.save(password: password, backupPath: backup.path)
+                    }
+                }
+                pendingUnlock = nil
+                startComparison(older: olderBackup, newer: newerBackup)
+            case .failure(let failure):
+                unlockError = failure.message
+            }
+        }
+    }
+
+    private func cancelUnlock() {
+        unlockTask?.cancel()
+        unlockTask = nil
+        pendingUnlock = nil
+        isUnlocking = false
+        isComparing = false
+        unlockError = nil
+    }
+
+    private func startComparison(older olderBackup: BackupInfo, newer newerBackup: BackupInfo) {
+        comparisonTask?.cancel()
+        let operationID = UUID()
+        comparisonOperationID = operationID
+        isComparing = true
+        result = nil
+        errorMessage = nil
+
+        comparisonTask = Task {
+            let worker = Task.detached(priority: .userInitiated) {
+                do {
+                    return Result<BackupComparisonResult, ComparisonFailure>.success(
+                        try BackupComparisonService.compare(older: olderBackup, newer: newerBackup)
+                    )
+                } catch {
+                    return .failure(ComparisonFailure(message: error.localizedDescription))
+                }
+            }
+            let outcome = await withTaskCancellationHandler {
+                await worker.value
+            } onCancel: {
+                worker.cancel()
+            }
+            guard !Task.isCancelled else { return }
+            guard comparisonOperationID == operationID else { return }
+            comparisonTask = nil
+            isComparing = false
+            switch outcome {
+            case .success(let comparison): result = comparison
+            case .failure(let failure): errorMessage = failure.message
+            }
+        }
+    }
+}

--- a/Sources/Phosphor/Views/Backup/BackupTimeMachineView.swift
+++ b/Sources/Phosphor/Views/Backup/BackupTimeMachineView.swift
@@ -13,6 +13,7 @@ struct BackupTimeMachineView: View {
     @State private var pendingRestore: RestoreRequest?
     @State private var restoreProgress: String?
     @State private var isRestoring = false
+    @State private var showComparison = false
     @State private var starPositions: [StarParticle] = generateStars(count: 120)
 
     private struct RestoreRequest {
@@ -89,6 +90,10 @@ struct BackupTimeMachineView: View {
         } message: { request in
             Text("Restore \(request.targetName) from \(request.backup.dateString)? The device will restart, and this cannot be undone.")
         }
+        .sheet(isPresented: $showComparison) {
+            BackupComparisonView(initiallySelected: selectedBackup)
+                .environmentObject(backupVM)
+        }
     }
 
     private var restoreConfirmationPresented: Binding<Bool> {
@@ -96,6 +101,11 @@ struct BackupTimeMachineView: View {
             get: { pendingRestore != nil },
             set: { if !$0 { pendingRestore = nil } }
         )
+    }
+
+    private var selectedBackup: BackupInfo? {
+        guard backupVM.backups.indices.contains(selectedIndex) else { return nil }
+        return backupVM.backups[selectedIndex]
     }
 
     // MARK: - Star Field
@@ -212,6 +222,14 @@ struct BackupTimeMachineView: View {
                         .buttonStyle(.bordered)
                         .controlSize(.small)
                         .tint(.white)
+
+                        Button("Compare Backups") {
+                            showComparison = true
+                        }
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
+                        .tint(.white)
+                        .disabled(backupVM.isCreating || backupVM.backups.filter { $0.udid == backup.udid }.count < 2)
                     }
                     .padding(.top, 4)
                 }
@@ -270,6 +288,18 @@ struct BackupTimeMachineView: View {
 
             // Navigation arrows
             HStack {
+                Button {
+                    backupVM.loadBackups()
+                    selectedIndex = min(selectedIndex, max(0, backupVM.backups.count - 1))
+                } label: {
+                    Image(systemName: "arrow.clockwise.circle.fill")
+                        .font(.system(size: 24))
+                        .foregroundStyle(.white.opacity(0.8))
+                }
+                .buttonStyle(.plain)
+                .help("Refresh Backups")
+                .disabled(backupVM.isCreating)
+
                 Button {
                     withAnimation(.spring(response: 0.4, dampingFraction: 0.8)) {
                         selectedIndex = max(0, selectedIndex - 1)


### PR DESCRIPTION
## Summary
- add a read-only Backup Comparison sheet to the existing Time Machine backup view
- compare two dated snapshots from the same device with deterministic added, removed, metadata-changed, and unchanged counts
- stream ordered regular-file manifest metadata through a cancellation-aware read-only SQLite cursor, retaining only bounded UI samples
- reject filesystem aliases, cross-device pairs, same snapshots, and reversed or unknown chronology
- support encrypted snapshots through remembered credentials and an in-flow password unlock sequence
- serialize comparison against full and incremental backup creation across every BackupManager owner

## Correctness and safety
- decode UID-backed NSKeyedArchiver `LastModified` NSDate values without invoking NSKeyedUnarchiver on backup-controlled data
- require explicit SQLite `SQLITE_DONE`; manifest failures abort instead of presenting partial totals as complete
- cap metadata BLOB reads and conservatively classify oversized/incomplete metadata as changed
- perform manifest scanning and merge work off the main actor with cancellation and operation-identity guards
- comparison never extracts, restores, or modifies backup payloads

## Verification
- 69 regression checks passed, including compiled streaming-engine, operation-gate, and UID-backed date fixtures
- `swift build -Xswiftc -strict-concurrency=complete`
- `swift build -c release`
- `bash Scripts/build.sh`
- independent final blocker review: PASS, no P0/P1 findings
- clean four-branch integration: 79 regression checks, debug build, and release build passed

## UI validation note
The app bundle builds and launches, but this macOS session has not provided reliable Accessibility/screenshot capture for Phosphor windows. Behavioral probes, package builds, and combined integration checks are green.
