### PR TITLE
fix: preserve Unified Search empty state

### DIFF
--- a/Scripts/regression/checks/unified_search.py
+++ b/Scripts/regression/checks/unified_search.py
@@ -406,10 +406,14 @@ enum UnifiedSearchService {
         sources: Set<UnifiedSearchSource>
     ) throws -> UnifiedSearchResponse {
         if query == "slow" {
-            for _ in 0..<100 {
-                try Task.checkCancellation()
-                Thread.sleep(forTimeInterval: 0.002)
-            }
+            // Deliberately ignore task cancellation and complete late. This proves
+            // the view model rejects a stale success instead of relying on a
+            // cooperative service to throw CancellationError.
+            Thread.sleep(forTimeInterval: 0.2)
+            return UnifiedSearchResponse(
+                results: [UnifiedSearchResult(id: "stale")],
+                sourceErrors: [:]
+            )
         }
         return UnifiedSearchResponse(results: [], sourceErrors: [:])
     }

--- a/Scripts/regression/checks/unified_search.py
+++ b/Scripts/regression/checks/unified_search.py
@@ -356,10 +356,15 @@ def test_unified_search_ui_ignores_stale_results_and_exports_selection(root: Pat
 
     assert "searchOperationID" in vm
     assert "searchOperationID == operationID" in vm
+    assert "hasCompletedSearch" in vm, "typing a query must not make the initial UI claim that a search returned no results"
+    assert "invalidateSearchState()" in vm, "query/source changes must clear stale search results"
+    assert "viewModel.hasCompletedSearch" in view, "empty-state copy must reflect completed search state, not merely non-empty query text"
     assert "Task.detached" in vm, "backup database search must not run on the main actor"
     assert "withTaskCancellationHandler" in vm
     assert "worker.cancel()" in vm
-    assert vm.count("results = []") >= 3, "backup changes, new searches, and cancellation must invalidate old results"
+    assert vm.count("invalidateSearchState()") >= 4, "query, source, backup, and cancellation changes must invalidate stale results"
+    invalidation = vm.split("private func invalidateSearchState()", 1)[1]
+    assert "results = []" in invalidation and "sourceErrors = [:]" in invalidation
     assert "selectedResultIDs" in vm
     assert "Export Selected" in view
     assert "Unified Search" in sidebar
@@ -370,6 +375,99 @@ def test_unified_search_ui_ignores_stale_results_and_exports_selection(root: Pat
     empty_results_branch = view.split("} else if viewModel.results.isEmpty {", 1)[1].split("} else {", 1)[0]
     assert "!viewModel.sourceErrors.isEmpty" in empty_results_branch
     assert "sourceWarnings" in empty_results_branch, "zero-result source failures must remain visible"
+
+
+def test_unified_search_empty_state_tracks_completed_search_behaviorally(root: Path) -> None:
+    support = r'''
+import Foundation
+
+struct BackupInfo: Sendable {
+    let id: String
+    let path: String
+}
+
+enum UnifiedSearchSource: CaseIterable, Hashable, Sendable {
+    case files
+}
+
+struct UnifiedSearchResult: Identifiable, Sendable {
+    let id: String
+}
+
+struct UnifiedSearchResponse: Sendable {
+    let results: [UnifiedSearchResult]
+    let sourceErrors: [UnifiedSearchSource: String]
+}
+
+enum UnifiedSearchService {
+    static func search(
+        query: String,
+        backupPath: String,
+        sources: Set<UnifiedSearchSource>
+    ) throws -> UnifiedSearchResponse {
+        if query == "slow" {
+            for _ in 0..<100 {
+                try Task.checkCancellation()
+                Thread.sleep(forTimeInterval: 0.002)
+            }
+        }
+        return UnifiedSearchResponse(results: [], sourceErrors: [:])
+    }
+}
+'''
+    probe = r'''
+import Foundation
+
+@main
+struct Probe {
+    @MainActor
+    static func main() async {
+        let viewModel = UnifiedSearchViewModel()
+        viewModel.chooseBackup(BackupInfo(id: "backup", path: "/backup"))
+
+        viewModel.query = "none"
+        print("TYPED|\(viewModel.hasCompletedSearch)|\(viewModel.results.count)")
+
+        viewModel.search()
+        while viewModel.isSearching { await Task.yield() }
+        print("COMPLETED|\(viewModel.hasCompletedSearch)|\(viewModel.results.count)")
+
+        viewModel.query = "changed"
+        print("CHANGED|\(viewModel.hasCompletedSearch)|\(viewModel.results.count)")
+
+        viewModel.query = "slow"
+        viewModel.search()
+        viewModel.query = "replacement"
+        try? await Task.sleep(nanoseconds: 300_000_000)
+        print("STALE|\(viewModel.hasCompletedSearch)|\(viewModel.isSearching)|\(viewModel.results.count)")
+    }
+}
+'''
+    with tempfile.TemporaryDirectory() as temp_dir:
+        temp = Path(temp_dir)
+        support_path = temp / "Support.swift"
+        support_path.write_text(support)
+        probe_path = temp / "Probe.swift"
+        probe_path.write_text(probe)
+        executable = temp / "unified-search-state-probe"
+        compile_result = subprocess.run(
+            [
+                "swiftc", "-parse-as-library",
+                str(root / "Sources/Phosphor/ViewModels/UnifiedSearchViewModel.swift"),
+                str(support_path), str(probe_path), "-o", str(executable),
+            ],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        assert compile_result.returncode == 0, compile_result.stderr
+        result = subprocess.run([str(executable)], capture_output=True, text=True, timeout=10)
+
+    assert result.returncode == 0, result.stderr
+    assert "TYPED|false|0" in result.stdout, result.stdout
+    assert "COMPLETED|true|0" in result.stdout, result.stdout
+    assert "CHANGED|false|0" in result.stdout, result.stdout
+    assert "STALE|false|false|0" in result.stdout, result.stdout
 
 
 def test_unified_search_requires_an_explicit_backup(root: Path) -> None:

--- a/Sources/Phosphor/ViewModels/UnifiedSearchViewModel.swift
+++ b/Sources/Phosphor/ViewModels/UnifiedSearchViewModel.swift
@@ -2,13 +2,24 @@ import Foundation
 
 @MainActor
 final class UnifiedSearchViewModel: ObservableObject {
-    @Published var query = ""
+    @Published var query = "" {
+        didSet {
+            guard query != oldValue else { return }
+            invalidateSearchState()
+        }
+    }
     @Published var selectedBackup: BackupInfo?
-    @Published var enabledSources = Set(UnifiedSearchSource.allCases)
+    @Published var enabledSources = Set(UnifiedSearchSource.allCases) {
+        didSet {
+            guard enabledSources != oldValue else { return }
+            invalidateSearchState()
+        }
+    }
     @Published private(set) var results: [UnifiedSearchResult] = []
     @Published private(set) var sourceErrors: [UnifiedSearchSource: String] = [:]
     @Published var selectedResultIDs = Set<UnifiedSearchResult.ID>()
     @Published private(set) var isSearching = false
+    @Published private(set) var hasCompletedSearch = false
     @Published private(set) var errorMessage: String?
 
     private var searchTask: Task<Void, Never>?
@@ -24,14 +35,8 @@ final class UnifiedSearchViewModel: ObservableObject {
 
     func chooseBackup(_ backup: BackupInfo?) {
         guard selectedBackup?.path != backup?.path else { return }
-        searchTask?.cancel()
-        searchOperationID = nil
+        invalidateSearchState()
         selectedBackup = backup
-        results = []
-        sourceErrors = [:]
-        selectedResultIDs = []
-        errorMessage = nil
-        isSearching = false
     }
 
     func search() {
@@ -54,6 +59,7 @@ final class UnifiedSearchViewModel: ObservableObject {
         searchOperationID = operationID
         let sources = enabledSources
         isSearching = true
+        hasCompletedSearch = false
         errorMessage = nil
         results = []
         sourceErrors = [:]
@@ -83,10 +89,12 @@ final class UnifiedSearchViewModel: ObservableObject {
 
             guard !Task.isCancelled, searchOperationID == operationID else { return }
             isSearching = false
+            searchTask = nil
             switch outcome {
             case .success(let response):
                 results = response.results
                 sourceErrors = response.sourceErrors
+                hasCompletedSearch = true
             case .failure(let failure):
                 if !Task.isCancelled && failure.message != "Search cancelled." {
                     errorMessage = failure.message
@@ -96,13 +104,19 @@ final class UnifiedSearchViewModel: ObservableObject {
     }
 
     func cancel() {
+        invalidateSearchState()
+    }
+
+    private func invalidateSearchState() {
         searchTask?.cancel()
         searchTask = nil
         searchOperationID = nil
         isSearching = false
+        hasCompletedSearch = false
         results = []
         sourceErrors = [:]
         selectedResultIDs = []
+        errorMessage = nil
     }
 
     func selectAllVisible() {

--- a/Sources/Phosphor/Views/Search/UnifiedSearchView.swift
+++ b/Sources/Phosphor/Views/Search/UnifiedSearchView.swift
@@ -144,11 +144,11 @@ struct UnifiedSearchView: View {
                     Divider()
                 }
                 ContentUnavailableView(
-                    viewModel.query.isEmpty ? "Search This Backup" : "No Results",
+                    viewModel.hasCompletedSearch ? "No Results" : "Search This Backup",
                     systemImage: "text.magnifyingglass",
-                    description: Text(viewModel.query.isEmpty
-                        ? "Enter at least two characters, choose the sources, and press Search."
-                        : "No matching results were returned by the sources that could be searched.")
+                    description: Text(viewModel.hasCompletedSearch
+                        ? "No matching results were returned by the sources that could be searched."
+                        : "Enter at least two characters, choose the sources, and press Search.")
                 )
             }
         } else {


### PR DESCRIPTION
## Summary
- keep the initial Unified Search guidance visible while a query is only being typed
- show “No Results” only after a successful completed search
- invalidate stale results and in-flight work when the query, sources, backup, or cancellation state changes
- add a compiled behavioral regression for typed, completed-empty, changed-query, and stale-completion transitions

## Verification
- `python3 Scripts/regression/run.py` — 155 checks passed
- `swift build`
- `swift build -c release`
- `bash Scripts/build.sh`
- live macOS UI verification against an actual backup
- independent exact-diff P0/P1 review — PASS
