### PR TITLE
fix: point star history chart at star-history.dera.page

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,11 +298,11 @@ For encrypted backup issues, verify the device has a passcode set and that `pymo
 
 ## Star History
 
-<a href="https://star-history.com/#momenbasel/Phosphor&Date">
+<a href="https://star-history.dera.page/#momenbasel/Phosphor&type=Date">
   <picture>
-    <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/svg?repos=momenbasel/Phosphor&type=Date&theme=dark">
-    <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/svg?repos=momenbasel/Phosphor&type=Date">
-    <img alt="Star History Chart" src="https://api.star-history.com/svg?repos=momenbasel/Phosphor&type=Date" width="600">
+    <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=momenbasel/Phosphor&type=Date&theme=dark">
+    <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=momenbasel/Phosphor&type=Date">
+    <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=momenbasel/Phosphor&type=Date" width="600">
   </picture>
 </a>
 


### PR DESCRIPTION
The current star history chart is broken because it depends on the GitHub stargazer API restrictions. This switches the README chart to star-history.dera.page, an alternative that needs no API token and serves requests from a single domain. Only the chart is updated; the badge endpoint is left untouched.