### PR TITLE
fix: support Personal and Business WhatsApp backups

### DIFF
--- a/Scripts/regression/checks/whatsapp_export.py
+++ b/Scripts/regression/checks/whatsapp_export.py
@@ -81,3 +81,37 @@ def test_whatsapp_exports_match_messages_export_controls(root: Path) -> None:
     assert_contains(app, ".environmentObject(whatsAppVM)", "WhatsApp view model must be app-owned")
     assert_contains(content, "if whatsAppVM.isExporting", "WhatsApp progress must remain visible outside its section")
     assert_contains(content, "whatsAppVM.cancelExport()", "Root WhatsApp progress needs the same cancel action as Messages")
+
+
+def test_whatsapp_personal_and_business_sources_are_deterministic_and_selectable(root: Path) -> None:
+    manifest = read(root, "Sources/Phosphor/Utilities/BackupManifest.swift")
+    exporter = read(root, "Sources/Phosphor/Services/WhatsAppExporter.swift")
+    view_model = read(root, "Sources/Phosphor/ViewModels/WhatsAppViewModel.swift")
+    view = read(root, "Sources/Phosphor/Views/WhatsApp/WhatsAppView.swift")
+
+    assert_contains(manifest, "enum WhatsAppSource", "Backup discovery needs explicit Personal and Business WhatsApp sources")
+    assert_contains(manifest, "func whatsAppDatabases()", "Backup discovery must return every supported WhatsApp database")
+    assert_contains(manifest, "ORDER BY", "WhatsApp source discovery must have a deterministic order")
+    assert_contains(manifest, "net.whatsapp.WhatsAppSMB", "WhatsApp Business must be discovered explicitly")
+    assert_contains(manifest, "relativePath = 'ChatStorage.sqlite'", "Root database name must match exactly")
+    assert_contains(manifest, "relativePath LIKE '%/ChatStorage.sqlite'", "Nested database basename must match exactly")
+    assert "relativePath LIKE '%ChatStorage.sqlite'" not in manifest, (
+        "database discovery must reject decoy names such as OldChatStorage.sqlite"
+    )
+    assert "domain LIKE '%whatsapp%'" not in manifest, "Discovery must not select an arbitrary ChatStorage.sqlite by broad domain match"
+
+    assert_contains(exporter, "source: BackupManifest.WhatsAppSource", "WhatsApp exporter must open the requested source")
+    assert_contains(exporter, "private let source", "Media resolution must retain the selected WhatsApp source")
+    assert_contains(exporter, "selectedSource.domains.contains($0.domain)", "Attachments must never cross Personal and Business domains")
+    assert "manifest.search(\"ChatStorage.sqlite\")" not in exporter, "Fallback search must not select an unrelated ChatStorage.sqlite"
+
+    assert_contains(view_model, "@Published private(set) var availableSources", "The view model must publish every discovered WhatsApp source")
+    assert_contains(view_model, "@Published private(set) var selectedSource", "The view model must retain the selected WhatsApp source")
+    assert_contains(view_model, "func selectSource", "Switching a source must reload chats from that source")
+    assert_contains(view_model, "sourceChanged", "Changing WhatsApp source must cancel and invalidate any export from the previous source")
+    assert_contains(view_model, "WhatsAppExporter(backupPath: backupPath, source: source)", "Browse and export must bind to the selected source")
+
+    assert_contains(view, "whatsAppVM.availableSources.count > 1", "UI source selection should only appear when both sources exist")
+    assert_contains(view, "Picker(\"WhatsApp\", selection:", "UI needs an explicit WhatsApp source picker")
+    assert_contains(view, "source.displayName", "UI must label Personal and Business sources explicitly")
+    assert_contains(view, ".onChange(of: whatsAppVM.selectedSource)", "Switching accounts must clear stale search filters")

--- a/Sources/Phosphor/Services/WhatsAppExporter.swift
+++ b/Sources/Phosphor/Services/WhatsAppExporter.swift
@@ -15,6 +15,7 @@ final class WhatsAppExporter {
 
     private let db: SQLiteReader
     private let manifest: BackupManifest?
+    private let source: BackupManifest.WhatsAppSource?
     private var mediaPathCache: [String: String] = [:]
     private var missingMediaPaths: Set<String> = []
 
@@ -79,38 +80,39 @@ final class WhatsAppExporter {
         }
     }
 
-    init(databasePath: String, manifest: BackupManifest? = nil) throws {
+    init(
+        databasePath: String,
+        manifest: BackupManifest? = nil,
+        source: BackupManifest.WhatsAppSource? = nil
+    ) throws {
         self.db = try SQLiteReader(path: databasePath)
         self.manifest = manifest
+        self.source = source
     }
 
-    /// Initialize from a backup by finding WhatsApp's ChatStorage.sqlite.
-    convenience init(backupPath: String) throws {
+    /// Initialize from a backup and a specific WhatsApp source. When callers do
+    /// not specify one, Personal is chosen first by BackupManifest's stable order.
+    convenience init(backupPath: String, source: BackupManifest.WhatsAppSource? = nil) throws {
         let manifest = try BackupManifest(backupPath: backupPath)
-
-        // Try AppDomainGroup first (newer WhatsApp versions)
-        if let entry = try manifest.whatsAppDatabase() {
-            let filePath = try manifest.readablePath(for: entry)
-            guard FileManager.default.fileExists(atPath: filePath) else {
-                throw NSError(domain: "Phosphor", code: 404,
-                              userInfo: [NSLocalizedDescriptionKey: "WhatsApp database file not found on disk"])
-            }
-            try self.init(databasePath: filePath, manifest: manifest)
-            return
+        let databases = try manifest.whatsAppDatabases()
+        let database = source.flatMap { requested in
+            databases.first { $0.source == requested }
+        } ?? (source == nil ? databases.first : nil)
+        guard let database else {
+            let label = source?.displayName ?? ""
+            throw NSError(
+                domain: "Phosphor",
+                code: 404,
+                userInfo: [NSLocalizedDescriptionKey: "\(label.isEmpty ? "WhatsApp" : label + " WhatsApp") ChatStorage.sqlite not found in backup."]
+            )
         }
 
-        // Try direct search
-        let candidates = try manifest.search("ChatStorage.sqlite")
-        for candidate in candidates where candidate.isFile {
-            let filePath = try manifest.readablePath(for: candidate)
-            if FileManager.default.fileExists(atPath: filePath) {
-                try self.init(databasePath: filePath, manifest: manifest)
-                return
-            }
+        let filePath = try manifest.readablePath(for: database.entry)
+        guard FileManager.default.fileExists(atPath: filePath) else {
+            throw NSError(domain: "Phosphor", code: 404,
+                          userInfo: [NSLocalizedDescriptionKey: "WhatsApp database file not found on disk"])
         }
-
-        throw NSError(domain: "Phosphor", code: 404,
-                      userInfo: [NSLocalizedDescriptionKey: "WhatsApp ChatStorage.sqlite not found in backup. Is WhatsApp installed?"])
+        try self.init(databasePath: filePath, manifest: manifest, source: database.source)
     }
 
     // MARK: - Chats
@@ -439,7 +441,7 @@ final class WhatsAppExporter {
     private func resolveMediaDiskPath(_ localPath: String) -> String? {
         if let cached = mediaPathCache[localPath] { return cached }
         if missingMediaPaths.contains(localPath) { return nil }
-        guard let manifest else { return nil }
+        guard let manifest, let selectedSource = source else { return nil }
 
         let normalized = localPath
             .replacingOccurrences(of: "file://", with: "")
@@ -448,7 +450,7 @@ final class WhatsAppExporter {
         let filename = (normalized as NSString).lastPathComponent
         let candidates = ((try? manifest.search(filename)) ?? []).filter {
             $0.isFile
-                && $0.domain.localizedCaseInsensitiveContains("whatsapp")
+                && selectedSource.domains.contains($0.domain)
                 && $0.fileName == filename
         }
         let exactEntry = candidates.first {

--- a/Sources/Phosphor/Utilities/BackupManifest.swift
+++ b/Sources/Phosphor/Utilities/BackupManifest.swift
@@ -347,12 +347,89 @@ final class BackupManifest {
         return rows.first.flatMap(parseFileEntry)
     }
 
-    /// Get WhatsApp ChatStorage.sqlite.
-    func whatsAppDatabase() throws -> FileEntry? {
+    enum WhatsAppSource: String, CaseIterable, Identifiable, Hashable {
+        case personal
+        case business
+
+        var id: String { rawValue }
+
+        var displayName: String {
+            switch self {
+            case .personal: return "Personal"
+            case .business: return "Business"
+            }
+        }
+
+        var domains: Set<String> {
+            switch self {
+            case .personal:
+                return [
+                    "AppDomainGroup-group.net.whatsapp.WhatsApp.shared",
+                    "AppDomain-net.whatsapp.WhatsApp"
+                ]
+            case .business:
+                return [
+                    "AppDomainGroup-group.net.whatsapp.WhatsAppSMB.shared",
+                    "AppDomain-net.whatsapp.WhatsAppSMB"
+                ]
+            }
+        }
+    }
+
+    struct WhatsAppDatabase: Identifiable, Hashable {
+        let source: WhatsAppSource
+        let entry: FileEntry
+
+        var id: String { entry.id }
+    }
+
+    /// Discover one ChatStorage.sqlite for each supported WhatsApp app, in a
+    /// stable order. App Group locations take precedence over legacy app-domain
+    /// copies so a source never changes merely because SQLite returned rows in a
+    /// different order.
+    func whatsAppDatabases() throws -> [WhatsAppDatabase] {
         let rows = try db.query(
-            "SELECT fileID, domain, relativePath, flags FROM Files WHERE relativePath LIKE '%ChatStorage.sqlite' AND domain LIKE '%whatsapp%'"
+            """
+            SELECT fileID, domain, relativePath, flags
+            FROM Files
+            WHERE flags = 1
+              AND (
+                relativePath = 'ChatStorage.sqlite'
+                OR relativePath LIKE '%/ChatStorage.sqlite'
+              )
+              AND domain IN (
+                'AppDomainGroup-group.net.whatsapp.WhatsApp.shared',
+                'AppDomain-net.whatsapp.WhatsApp',
+                'AppDomainGroup-group.net.whatsapp.WhatsAppSMB.shared',
+                'AppDomain-net.whatsapp.WhatsAppSMB'
+              )
+            ORDER BY CASE domain
+                WHEN 'AppDomainGroup-group.net.whatsapp.WhatsApp.shared' THEN 0
+                WHEN 'AppDomain-net.whatsapp.WhatsApp' THEN 1
+                WHEN 'AppDomainGroup-group.net.whatsapp.WhatsAppSMB.shared' THEN 2
+                WHEN 'AppDomain-net.whatsapp.WhatsAppSMB' THEN 3
+            END, relativePath, fileID
+            """
         )
-        return rows.first.flatMap(parseFileEntry)
+        var seen = Set<WhatsAppSource>()
+        return rows.compactMap(parseFileEntry).compactMap { entry in
+            let source: WhatsAppSource?
+            switch entry.domain {
+            case "AppDomainGroup-group.net.whatsapp.WhatsApp.shared", "AppDomain-net.whatsapp.WhatsApp":
+                source = .personal
+            case "AppDomainGroup-group.net.whatsapp.WhatsAppSMB.shared", "AppDomain-net.whatsapp.WhatsAppSMB":
+                source = .business
+            default:
+                source = nil
+            }
+            guard let source, seen.insert(source).inserted else { return nil }
+            return WhatsAppDatabase(source: source, entry: entry)
+        }
+    }
+
+    /// The deterministic default is Personal when it exists, then Business.
+    func whatsAppDatabase() throws -> FileEntry? {
+        try whatsAppDatabases().first?.entry
     }
 
     /// Get all photo files from Camera Roll.

--- a/Sources/Phosphor/ViewModels/WhatsAppViewModel.swift
+++ b/Sources/Phosphor/ViewModels/WhatsAppViewModel.swift
@@ -14,6 +14,8 @@ final class WhatsAppViewModel: ObservableObject {
     @Published var exportResult: MessageExportResult?
     @Published var showAlert = false
     @Published var alertMessage = ""
+    @Published private(set) var availableSources: [BackupManifest.WhatsAppSource] = []
+    @Published private(set) var selectedSource: BackupManifest.WhatsAppSource?
 
     private var exporter: WhatsAppExporter?
     private var backupPath: String?
@@ -29,6 +31,8 @@ final class WhatsAppViewModel: ObservableObject {
         exportOperationID = nil
         exporter = nil
         backupPath = nil
+        availableSources = []
+        selectedSource = nil
         chats = []
         selectedChat = nil
         messages = []
@@ -40,11 +44,17 @@ final class WhatsAppViewModel: ObservableObject {
         exportResult = nil
     }
 
-    func loadChats(from backupPath: String) {
-        if self.backupPath != backupPath {
+    func loadChats(from backupPath: String, source requestedSource: BackupManifest.WhatsAppSource? = nil) {
+        let isNewBackup = self.backupPath != backupPath
+        let sourceChanged = requestedSource != nil && requestedSource != selectedSource
+        if isNewBackup || sourceChanged {
             exportTask?.cancel()
             exportOperationID = nil
             isExporting = false
+        }
+        if isNewBackup {
+            availableSources = []
+            selectedSource = nil
         }
         self.backupPath = backupPath
         selectedChat = nil
@@ -53,7 +63,15 @@ final class WhatsAppViewModel: ObservableObject {
         errorMessage = nil
         isLoading = true
         do {
-            let exporter = try WhatsAppExporter(backupPath: backupPath)
+            let sources = try BackupManifest(backupPath: backupPath).whatsAppDatabases().map(\.source)
+            availableSources = sources
+            guard let source = requestedSource ?? selectedSource ?? sources.first,
+                  sources.contains(source) else {
+                throw NSError(domain: "Phosphor", code: 404,
+                              userInfo: [NSLocalizedDescriptionKey: "WhatsApp ChatStorage.sqlite not found in backup."])
+            }
+            selectedSource = source
+            let exporter = try WhatsAppExporter(backupPath: backupPath, source: source)
             self.exporter = exporter
             chats = try exporter.getChats()
         } catch {
@@ -61,6 +79,11 @@ final class WhatsAppViewModel: ObservableObject {
             errorMessage = error.localizedDescription
         }
         isLoading = false
+    }
+
+    func selectSource(_ source: BackupManifest.WhatsAppSource) {
+        guard let backupPath, availableSources.contains(source), source != selectedSource else { return }
+        loadChats(from: backupPath, source: source)
     }
 
     func selectChat(_ chat: WhatsAppExporter.WAChat) {
@@ -103,11 +126,11 @@ final class WhatsAppViewModel: ObservableObject {
         customEnd: Date = Date(),
         visibleMessages: [WhatsAppExporter.WAMessage]? = nil
     ) {
-        guard let chat = selectedChat, let backupPath else { return }
+        guard let chat = selectedChat, let backupPath, let source = selectedSource else { return }
         let range = dateFilter.range(customStart: customStart, customEnd: customEnd)
         let options = MessageExportOptions(startDate: range.start, endDate: range.end, includeAttachments: true)
         let sourceMessages = visibleMessages ?? messages
-        startExport(text: "Creating PDF bundle for \(chat.displayName)…", backupPath: backupPath) { exporter, _ in
+        startExport(text: "Creating PDF bundle for \(chat.displayName)…", backupPath: backupPath, source: source) { exporter, _ in
             let result = try exporter.exportChatPDFBundle(
                 chat: chat,
                 messages: sourceMessages,
@@ -131,12 +154,12 @@ final class WhatsAppViewModel: ObservableObject {
         includeAttachments: Bool = true,
         visibleMessages: [WhatsAppExporter.WAMessage]? = nil
     ) {
-        guard let chat = selectedChat, let backupPath else { return }
+        guard let chat = selectedChat, let backupPath, let source = selectedSource else { return }
         let range = dateFilter.range(customStart: customStart, customEnd: customEnd)
         let options = MessageExportOptions(startDate: range.start, endDate: range.end, includeAttachments: includeAttachments)
         let sourceMessages = visibleMessages ?? messages
         let outputPath = ensureExtension(path, for: format)
-        startExport(text: "Exporting \(chat.displayName)…", backupPath: backupPath) { exporter, _ in
+        startExport(text: "Exporting \(chat.displayName)…", backupPath: backupPath, source: source) { exporter, _ in
             try exporter.exportMessages(
                 sourceMessages,
                 title: chat.displayName,
@@ -160,10 +183,10 @@ final class WhatsAppViewModel: ObservableObject {
         customEnd: Date = Date(),
         includeAttachments: Bool = true
     ) {
-        guard let backupPath else { return }
+        guard let backupPath, let source = selectedSource else { return }
         let range = dateFilter.range(customStart: customStart, customEnd: customEnd)
         let options = MessageExportOptions(startDate: range.start, endDate: range.end, includeAttachments: includeAttachments)
-        startExport(text: "Preparing WhatsApp export…", backupPath: backupPath) { exporter, progress in
+        startExport(text: "Preparing WhatsApp export…", backupPath: backupPath, source: source) { exporter, progress in
             let result = try exporter.exportAllChats(
                 format: format,
                 to: directory,
@@ -184,10 +207,10 @@ final class WhatsAppViewModel: ObservableObject {
         customStart: Date = Date(),
         customEnd: Date = Date()
     ) {
-        guard let backupPath else { return }
+        guard let backupPath, let source = selectedSource else { return }
         let range = dateFilter.range(customStart: customStart, customEnd: customEnd)
         let options = MessageExportOptions(startDate: range.start, endDate: range.end, includeAttachments: true)
-        startExport(text: "Preparing complete WhatsApp export…", backupPath: backupPath) { exporter, progress in
+        startExport(text: "Preparing complete WhatsApp export…", backupPath: backupPath, source: source) { exporter, progress in
             let result = try exporter.exportAllChatsAllFormats(
                 to: parentDirectory,
                 options: options,
@@ -214,6 +237,7 @@ final class WhatsAppViewModel: ObservableObject {
     private func startExport(
         text: String,
         backupPath: String,
+        source: BackupManifest.WhatsAppSource,
         operation: @escaping (WhatsAppExporter, @escaping (Int, Int, String) throws -> Void) throws -> MessageExportResult
     ) {
         exportTask?.cancel()
@@ -223,16 +247,17 @@ final class WhatsAppViewModel: ObservableObject {
         let operationID = UUID()
         exportOperationID = operationID
 
-        exportTask = Task.detached(priority: .userInitiated) { [weak self, backupPath, operationID] in
+        exportTask = Task.detached(priority: .userInitiated) { [weak self, backupPath, source, operationID] in
             do {
-                let exporter = try WhatsAppExporter(backupPath: backupPath)
+                let exporter = try WhatsAppExporter(backupPath: backupPath, source: source)
                 let result = try operation(exporter) { completed, total, title in
                     try Task.checkCancellation()
                     let progress = total == 0 ? 0 : Double(completed) / Double(total)
                     Task { @MainActor [weak self] in
                         guard let self,
                               self.exportOperationID == operationID,
-                              self.backupPath == backupPath else { return }
+                              self.backupPath == backupPath,
+                              self.selectedSource == source else { return }
                         self.exportProgress = progress
                         self.exportProgressText = completed >= total
                             ? "Export complete"
@@ -242,7 +267,8 @@ final class WhatsAppViewModel: ObservableObject {
                 await MainActor.run { [weak self] in
                     guard let self,
                           self.exportOperationID == operationID,
-                          self.backupPath == backupPath else { return }
+                          self.backupPath == backupPath,
+                          self.selectedSource == source else { return }
                     self.isExporting = false
                     self.exportOperationID = nil
                     self.exportProgress = 1
@@ -252,7 +278,8 @@ final class WhatsAppViewModel: ObservableObject {
                 await MainActor.run { [weak self] in
                     guard let self,
                           self.exportOperationID == operationID,
-                          self.backupPath == backupPath else { return }
+                          self.backupPath == backupPath,
+                          self.selectedSource == source else { return }
                     self.isExporting = false
                     self.exportOperationID = nil
                     self.alertMessage = "Export cancelled"
@@ -262,7 +289,8 @@ final class WhatsAppViewModel: ObservableObject {
                 await MainActor.run { [weak self] in
                     guard let self,
                           self.exportOperationID == operationID,
-                          self.backupPath == backupPath else { return }
+                          self.backupPath == backupPath,
+                          self.selectedSource == source else { return }
                     self.isExporting = false
                     self.exportOperationID = nil
                     self.alertMessage = "Export failed: \(error.localizedDescription)"

--- a/Sources/Phosphor/Views/WhatsApp/WhatsAppView.swift
+++ b/Sources/Phosphor/Views/WhatsApp/WhatsAppView.swift
@@ -23,6 +23,10 @@ struct WhatsAppView: View {
         .onAppear(perform: loadIfNeeded)
         .onChange(of: backupVM.selectedBackup?.id) { _, _ in handleSelectedBackupChange() }
         .onChange(of: backupVM.backups.map(\.path)) { _, _ in reconcileLoadedBackup() }
+        .onChange(of: whatsAppVM.selectedSource) { _, _ in
+            chatSearchText = ""
+            messageSearchText = ""
+        }
         .alert("WhatsApp", isPresented: $whatsAppVM.showAlert) {
             Button("OK") {}
         } message: {
@@ -62,6 +66,12 @@ struct WhatsAppView: View {
 
             if !backupVM.backups.isEmpty {
                 backupPicker
+                    .padding(.horizontal, 16)
+                    .padding(.bottom, 8)
+            }
+
+            if whatsAppVM.availableSources.count > 1 {
+                sourcePicker
                     .padding(.horizontal, 16)
                     .padding(.bottom, 8)
             }
@@ -154,6 +164,19 @@ struct WhatsAppView: View {
         .padding(.vertical, 6)
         .background(.quaternary)
         .clipShape(RoundedRectangle(cornerRadius: 8))
+    }
+
+    private var sourcePicker: some View {
+        Picker("WhatsApp", selection: Binding(
+            get: { whatsAppVM.selectedSource ?? .personal },
+            set: { whatsAppVM.selectSource($0) }
+        )) {
+            ForEach(whatsAppVM.availableSources) { source in
+                Text(source.displayName).tag(source)
+            }
+        }
+        .pickerStyle(.segmented)
+        .accessibilityLabel("WhatsApp source")
     }
 
     private var exportAllMenu: some View {


### PR DESCRIPTION
## Summary
- discover Personal and Business WhatsApp databases independently and in deterministic order
- require an exact `ChatStorage.sqlite` basename so decoy database names cannot be selected
- show a source picker when both apps are present
- keep chat browsing, exports, stale-completion guards, and attachment lookup bound to the selected source

Fixes #78

## Verification
- `python3 Scripts/regression/run.py` — 156 checks passed
- `swiftc -frontend -parse` on all changed Swift files — passed
- `git diff --check` — passed
- independent pre-commit review — passed

## Local build note
`swift build` is blocked by this Mac's macOS 27 Command Line Tools (`SwiftUIMacros` plugin missing). The same failure reproduces on an untouched `origin/main` worktree; GitHub CI is the authoritative build check for this PR.
