### PR TITLE
feat: add Lithuanian and repair runtime localization

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -13,6 +13,7 @@
 		<string>es</string>
 		<string>fr</string>
 		<string>ar</string>
+		<string>lt</string>
 	</array>
 	<key>CFBundleDisplayName</key>
 	<string>Phosphor</string>

--- a/Scripts/regression/checks/localization.py
+++ b/Scripts/regression/checks/localization.py
@@ -63,3 +63,66 @@ def test_simplified_chinese_has_core_runtime_labels(root: Path) -> None:
         "Screen Capture": "屏幕录制",
     }.items():
         assert f'"{key}" = "{value}";' in strings, f"missing Simplified Chinese translation for {key}"
+
+
+def test_lithuanian_is_declared_packaged_and_complete(root: Path) -> None:
+    info = read(root, "Resources/Info.plist")
+    build = read(root, "Scripts/build.sh")
+    english = read(root, "Sources/Phosphor/Resources/en.lproj/Localizable.strings")
+    lithuanian_path = root / "Sources/Phosphor/Resources/lt.lproj/Localizable.strings"
+
+    assert "<string>lt</string>" in info, "Info.plist must declare Lithuanian"
+    assert 'Sources/Phosphor/Resources"/*.lproj' in build, "build script must package Lithuanian"
+    assert lithuanian_path.exists(), "Lithuanian Localizable.strings must be present"
+
+    def entries(source: str) -> dict[str, str]:
+        return {
+            line.split('"', 2)[1]: line.rsplit('"', 2)[1]
+            for line in source.splitlines()
+            if line.lstrip().startswith('"') and '" =' in line
+        }
+
+    english_entries = entries(english)
+    lithuanian_entries = entries(lithuanian_path.read_text())
+    missing = english_entries.keys() - lithuanian_entries.keys()
+    assert not missing, f"Lithuanian is missing English keys: {sorted(missing)}"
+
+    for semantic_key, english_label in english_entries.items():
+        translated_label = lithuanian_entries[semantic_key]
+        assert lithuanian_entries.get(english_label) == translated_label, (
+            f"Lithuanian runtime alias missing for {english_label!r}"
+        )
+
+
+def test_german_existing_translations_have_runtime_aliases(root: Path) -> None:
+    english = read(root, "Sources/Phosphor/Resources/en.lproj/Localizable.strings")
+    german = read(root, "Sources/Phosphor/Resources/de.lproj/Localizable.strings")
+
+    def entries(source: str) -> dict[str, str]:
+        return {
+            line.split('"', 2)[1]: line.rsplit('"', 2)[1]
+            for line in source.splitlines()
+            if line.lstrip().startswith('"') and '" =' in line
+        }
+
+    english_entries = entries(english)
+    german_entries = entries(german)
+    semantic_keys = english_entries.keys() & german_entries.keys()
+    assert semantic_keys, "German must contain semantic translations"
+
+    for key, value in {
+        "sidebar.devices": "Geräte",
+        "group.device": "Gerät",
+        "action.delete": "Löschen",
+        "device.noDeviceConnected": "Kein Gerät verbunden",
+        "device.scanForDevices": "Nach Geräten suchen",
+        "welcome.subtitle": "Verbinden Sie ein iOS-Gerät oder wählen Sie einen Bereich in der Seitenleiste.",
+    }.items():
+        assert german_entries.get(key) == value, f"incorrect German translation for {key}"
+
+    for semantic_key in semantic_keys:
+        english_label = english_entries[semantic_key]
+        translated_label = german_entries[semantic_key]
+        assert german_entries.get(english_label) == translated_label, (
+            f"German runtime alias missing for {english_label!r}"
+        )

--- a/Sources/Phosphor/Resources/de.lproj/Localizable.strings
+++ b/Sources/Phosphor/Resources/de.lproj/Localizable.strings
@@ -1,7 +1,7 @@
 /* Phosphor - German */
 
 /* Sidebar */
-"sidebar.devices" = "Gerate";
+"sidebar.devices" = "Geräte";
 "sidebar.backups" = "Backups";
 "sidebar.backupBrowser" = "Backup-Browser";
 "sidebar.timeMachine" = "Time Machine";
@@ -19,7 +19,7 @@
 "sidebar.watch" = "Apple Watch";
 
 /* Section Groups */
-"group.device" = "Gerat";
+"group.device" = "Gerät";
 "group.data" = "Daten";
 "group.backups" = "Backups";
 "group.tools" = "Werkzeuge";
@@ -28,7 +28,7 @@
 "action.refresh" = "Aktualisieren";
 "action.export" = "Exportieren...";
 "action.browse" = "Durchsuchen";
-"action.delete" = "Loschen";
+"action.delete" = "Löschen";
 "action.cancel" = "Abbrechen";
 "action.save" = "Speichern";
 "action.search" = "Suchen...";
@@ -36,9 +36,9 @@
 "action.newBackup" = "Neues Backup";
 
 /* Device */
-"device.noDeviceConnected" = "Kein Gerat verbunden";
+"device.noDeviceConnected" = "Kein Gerät verbunden";
 "device.connectViaUSB" = "Verbinden Sie Ihr iPhone, iPad oder iPod touch per USB, um es mit Phosphor zu verwalten.";
-"device.scanForDevices" = "Nach Geraten suchen";
+"device.scanForDevices" = "Nach Geräten suchen";
 
 /* Backups */
 "backup.backups" = "Backups";
@@ -47,7 +47,56 @@
 
 /* Welcome */
 "welcome.title" = "Willkommen bei Phosphor";
-"welcome.subtitle" = "Verbinden Sie ein iOS-Gerat oder wahlen Sie einen Bereich in der Seitenleiste.";
+"welcome.subtitle" = "Verbinden Sie ein iOS-Gerät oder wählen Sie einen Bereich in der Seitenleiste.";
+
+/* Runtime aliases for SwiftUI English literal keys */
+"%lld items" = "%lld Objekte";
+"All Domains" = "Alle Domänen";
+"Apple Watch" = "Apple Watch";
+"Apps" = "Apps";
+"Backup Browser" = "Backup-Browser";
+"Backups" = "Backups";
+"Browse" = "Durchsuchen";
+"Call Log" = "Anrufliste";
+"Cancel" = "Abbrechen";
+"Connect an iOS device or select a section from the sidebar." = "Verbinden Sie ein iOS-Gerät oder wählen Sie einen Bereich in der Seitenleiste.";
+"Connect your iPhone, iPad, or iPod touch via USB to manage it with Phosphor." = "Verbinden Sie Ihr iPhone, iPad oder iPod touch per USB, um es mit Phosphor zu verwalten.";
+"Could Not Read Layout" = "Layout konnte nicht gelesen werden";
+"Data" = "Daten";
+"Delete" = "Löschen";
+"Device" = "Gerät";
+"Devices" = "Geräte";
+"Diagnostics" = "Diagnose";
+"Export PNG" = "PNG exportieren";
+"Export..." = "Exportieren...";
+"Extract" = "Extrahieren";
+"File System" = "Dateisystem";
+"Health" = "Gesundheit";
+"Home Screen" = "Home-Bildschirm";
+"Messages" = "Nachrichten";
+"Music" = "Musik";
+"New Backup" = "Neues Backup";
+"No Backup Selected" = "Kein Backup ausgewählt";
+"No Backups Found" = "Keine Backups gefunden";
+"No Device Connected" = "Kein Gerät verbunden";
+"No Home Screen Data" = "Keine Home-Bildschirm-Daten";
+"Notes" = "Notizen";
+"Photos" = "Fotos";
+"Reading home screen layout…" = "Home-Bildschirm-Layout wird gelesen…";
+"Refresh" = "Aktualisieren";
+"Reload" = "Neu laden";
+"Restore" = "Wiederherstellen";
+"Safari" = "Safari";
+"Save" = "Speichern";
+"Scan for Devices" = "Nach Geräten suchen";
+"Search..." = "Suchen...";
+"Select a backup from the Backups section to see its home screen." = "Wähle ein Backup im Bereich „Backups“, um den Home-Bildschirm zu sehen.";
+"This backup does not contain IconState.plist (HomeDomain/SpringBoard)." = "Dieses Backup enthält keine IconState.plist (HomeDomain/SpringBoard).";
+"Time Machine" = "Time Machine";
+"Toggle Preview" = "Vorschau ein-/ausblenden";
+"Tools" = "Werkzeuge";
+"Welcome to Phosphor" = "Willkommen bei Phosphor";
+"WhatsApp" = "WhatsApp";
 
 /* Home Screen */
 "homeScreen.homeScreen" = "Home-Bildschirm";

--- a/Sources/Phosphor/Resources/lt.lproj/Localizable.strings
+++ b/Sources/Phosphor/Resources/lt.lproj/Localizable.strings
@@ -1,0 +1,283 @@
+/* Phosphor - Lietuvių kalba */
+
+/* Šoninė juosta */
+"sidebar.devices" = "Įrenginiai";
+"sidebar.backups" = "Atsarginės kopijos";
+"sidebar.backupBrowser" = "Atsarginių kopijų naršyklė";
+"sidebar.timeMachine" = "Time Machine";
+"sidebar.messages" = "Žinutės";
+"sidebar.whatsapp" = "WhatsApp";
+"sidebar.photos" = "Nuotraukos";
+"sidebar.apps" = "Programos";
+"sidebar.notes" = "Užrašai";
+"sidebar.callLog" = "Skambučių žurnalas";
+"sidebar.safari" = "Safari";
+"sidebar.health" = "Sveikata";
+"sidebar.music" = "Muzika";
+"sidebar.files" = "Failų sistema";
+"sidebar.diagnostics" = "Diagnostika";
+"sidebar.watch" = "Apple Watch";
+"sidebar.contacts" = "Kontaktai";
+"sidebar.calendar" = "Kalendorius";
+
+/* Skirsnių grupės */
+"group.device" = "Įrenginys";
+"group.data" = "Duomenys";
+"group.backups" = "Atsarginės kopijos";
+"group.tools" = "Įrankiai";
+
+/* Įprasti veiksmai */
+"action.refresh" = "Atnaujinti";
+"action.export" = "Eksportuoti...";
+"action.exportAll" = "Eksportuoti viską...";
+"action.extractHere" = "Išskleisti čia";
+"action.browse" = "Naršyti";
+"action.delete" = "Ištrinti";
+"action.cancel" = "Atšaukti";
+"action.save" = "Išsaugoti";
+"action.search" = "Ieškoti...";
+"action.copyToMac" = "Kopijuoti į Mac...";
+"action.copyToDevice" = "Kopijuoti į įrenginį...";
+"action.mount" = "Prijungti įrenginį";
+"action.unmount" = "Atjungti";
+"action.restore" = "Atkurti";
+"action.pair" = "Susieti įrenginį";
+"action.newBackup" = "Nauja atsarginė kopija";
+"action.importArchive" = "Importuoti .phosphor";
+"action.exportArchive" = "Eksportuoti .phosphor";
+
+/* Įrenginys */
+"device.noDeviceConnected" = "Įrenginys neprijungtas";
+"device.connectViaUSB" = "Prijunkite savo iPhone, iPad arba iPod touch per USB, kad galėtumėte jį valdyti naudodami Phosphor.";
+"device.scanForDevices" = "Ieškoti įrenginių";
+"device.noDevice" = "Įrenginys neprijungtas";
+"device.connectViaUSBOrWiFi" = "Prijungti per USB arba Wi-Fi";
+"device.batteryHealth" = "Baterijos būklė";
+"device.storage" = "Saugykla";
+"device.deviceInfo" = "Įrenginio informacija";
+"device.quickActions" = "Spartieji veiksmai";
+"device.restart" = "Paleisti iš naujo";
+"device.sleep" = "Užmigdyti";
+"device.screenshot" = "Ekrano kopija";
+
+/* Atsarginės kopijos */
+"backup.backups" = "Atsarginės kopijos";
+"backup.noBackupsFound" = "Atsarginių kopijų nerasta";
+"backup.createBackupDesc" = "Sukurkite įrenginio atsarginę kopiją, kad galėtumėte naršyti jos turinį ir išgauti žinutes, nuotraukas bei programų duomenis.";
+"backup.createBackup" = "Sukurti atsarginę kopiją";
+"backup.deleteBackup" = "Ištrinti atsarginę kopiją?";
+"backup.deleteConfirm" = "Atsarginė kopija %@ (%@) bus ištrinta visam laikui. Šio veiksmo atšaukti negalima.";
+"backup.encrypted" = "Šifruota atsarginė kopija";
+"backup.browseContents" = "Naršyti turinį";
+"backup.showInFinder" = "Rodyti Finder";
+"backup.backupComplete" = "Atsarginė kopija sukurta";
+"backup.backupFailed" = "Nepavyko sukurti atsarginės kopijos";
+"backup.timeMachine" = "Time Machine";
+"backup.restoreThisBackup" = "Atkurti šią atsarginę kopiją";
+"backup.restoreWarning" = "Įrenginys bus atkurtas į būseną, buvusią %@. Įrenginys bus paleistas iš naujo.";
+"backup.scheduled" = "Suplanuotos atsarginės kopijos";
+
+/* Žinutės */
+"messages.messages" = "Žinutės";
+"messages.noBackupSelected" = "Nepasirinkta atsarginė kopija";
+"messages.selectBackup" = "Pasirinkite atsarginę kopiją, kad peržiūrėtumėte iMessage ir SMS pokalbius.";
+"messages.noConversations" = "Pokalbių nėra";
+"messages.exportCSV" = "Eksportuoti CSV";
+"messages.exportHTML" = "Eksportuoti HTML";
+"messages.exportJSON" = "Eksportuoti JSON";
+
+/* Nuotraukos */
+"photos.photos" = "Nuotraukos ir vaizdo įrašai";
+"photos.noPhotos" = "Nuotraukų nerasta";
+"photos.selectBackup" = "Pasirinkite atsarginę kopiją, kad galėtumėte naršyti Kameros ritinio nuotraukas ir vaizdo įrašus.";
+"photos.filter.all" = "Visos";
+"photos.filter.photos" = "Nuotraukos";
+"photos.filter.videos" = "Vaizdo įrašai";
+"photos.filter.screenshots" = "Ekrano kopijos";
+"photos.extractSelected" = "Išgauti pasirinktas";
+
+/* Programos */
+"apps.apps" = "Programos";
+"apps.installed" = "Įdiegtos";
+"apps.inBackup" = "Atsarginėje kopijoje";
+"apps.installIPA" = "Įdiegti IPA...";
+"apps.removeApp" = "Pašalinti programą";
+
+/* Failai */
+"files.fileSystem" = "Failų sistema";
+"files.notMounted" = "Įrenginys neprijungtas";
+"files.mountDesc" = "Prijunkite įrenginio failų sistemą, kad galėtumėte naršyti ir perkelti failus.";
+"files.emptyDir" = "Tuščias katalogas";
+"files.dropFilesHere" = "Nutempkite failus čia, kad perkeltumėte juos į įrenginį";
+
+/* Diagnostika */
+"diagnostics.diagnostics" = "Diagnostika";
+"diagnostics.battery" = "Baterija";
+"diagnostics.storage" = "Saugykla";
+"diagnostics.syslog" = "Sistemos žurnalas";
+"diagnostics.clear" = "Išvalyti";
+"diagnostics.startStreaming" = "Pradėti srautinį perdavimą";
+"diagnostics.stopStreaming" = "Sustabdyti srautinį perdavimą";
+
+/* Nustatymai */
+"settings.general" = "Bendrieji";
+"settings.dependencies" = "Priklausomybės";
+"settings.about" = "Apie";
+"settings.backupLocation" = "Atsarginių kopijų vieta";
+"settings.devicePolling" = "Įrenginio tikrinimas";
+"settings.autoRefresh" = "Automatinio atnaujinimo intervalas";
+"settings.backupSchedule" = "Atsarginių kopijų tvarkaraštis";
+"settings.scheduleEnabled" = "Įjungti suplanuotas atsargines kopijas";
+"settings.scheduleFrequency" = "Dažnis";
+"settings.wifiOnly" = "Tik Wi-Fi";
+
+/* Watch */
+"watch.appleWatch" = "Apple Watch";
+"watch.noWatch" = "Apple Watch nerastas";
+"watch.selectBackup" = "Pasirinkite atsarginę kopiją iš susieto iPhone, kad peržiūrėtumėte Apple Watch duomenis.";
+"watch.overview" = "Apžvalga";
+"watch.apps" = "Watch programos";
+"watch.activity" = "Aktyvumas";
+
+/* Pagrindinis ekranas */
+"homeScreen.homeScreen" = "Pagrindinis ekranas";
+"homeScreen.noBackupSelected" = "Nepasirinkta atsarginė kopija";
+"homeScreen.selectBackup" = "Pasirinkite atsarginę kopiją skiltyje „Atsarginės kopijos“, kad pamatytumėte jos pagrindinį ekraną.";
+"homeScreen.noLayout" = "Pagrindinio ekrano duomenų nėra";
+"homeScreen.noLayoutDesc" = "Šioje atsarginėje kopijoje nėra IconState.plist (HomeDomain/SpringBoard).";
+"homeScreen.readFailed" = "Nepavyko perskaityti išdėstymo";
+"homeScreen.exportPNG" = "Eksportuoti PNG";
+"homeScreen.reload" = "Įkelti iš naujo";
+"homeScreen.reading" = "Skaitomas pagrindinio ekrano išdėstymas…";
+
+/* Atsarginių kopijų naršyklė */
+"browser.allDomains" = "Visi domenai";
+"browser.items" = "%lld elementų";
+"browser.preview" = "Rodyti / slėpti peržiūrą";
+"browser.extract" = "Išgauti";
+
+/* Pasisveikinimas */
+"welcome.title" = "Sveiki atvykę į Phosphor";
+"welcome.subtitle" = "Prijunkite iOS įrenginį arba pasirinkite skiltį šoninėje juostoje.";
+
+/* Runtime aliases for SwiftUI English literal keys */
+"Devices" = "Įrenginiai";
+"Backups" = "Atsarginės kopijos";
+"Backup Browser" = "Atsarginių kopijų naršyklė";
+"Time Machine" = "Time Machine";
+"Messages" = "Žinutės";
+"WhatsApp" = "WhatsApp";
+"Photos" = "Nuotraukos";
+"Apps" = "Programos";
+"Notes" = "Užrašai";
+"Call Log" = "Skambučių žurnalas";
+"Safari" = "Safari";
+"Health" = "Sveikata";
+"Music" = "Muzika";
+"File System" = "Failų sistema";
+"Diagnostics" = "Diagnostika";
+"Apple Watch" = "Apple Watch";
+"Contacts" = "Kontaktai";
+"Calendar" = "Kalendorius";
+"Device" = "Įrenginys";
+"Data" = "Duomenys";
+"Tools" = "Įrankiai";
+"Refresh" = "Atnaujinti";
+"Export..." = "Eksportuoti...";
+"Export All..." = "Eksportuoti viską...";
+"Extract Here" = "Išskleisti čia";
+"Browse" = "Naršyti";
+"Delete" = "Ištrinti";
+"Cancel" = "Atšaukti";
+"Save" = "Išsaugoti";
+"Search..." = "Ieškoti...";
+"Copy to Mac..." = "Kopijuoti į Mac...";
+"Copy to Device..." = "Kopijuoti į įrenginį...";
+"Mount Device" = "Prijungti įrenginį";
+"Unmount" = "Atjungti";
+"Restore" = "Atkurti";
+"Pair Device" = "Susieti įrenginį";
+"New Backup" = "Nauja atsarginė kopija";
+"Import .phosphor" = "Importuoti .phosphor";
+"Export .phosphor" = "Eksportuoti .phosphor";
+"No Device Connected" = "Įrenginys neprijungtas";
+"Connect your iPhone, iPad, or iPod touch via USB to manage it with Phosphor." = "Prijunkite savo iPhone, iPad arba iPod touch per USB, kad galėtumėte jį valdyti naudodami Phosphor.";
+"Scan for Devices" = "Ieškoti įrenginių";
+"No device connected" = "Įrenginys neprijungtas";
+"Connect via USB or Wi-Fi" = "Prijungti per USB arba Wi-Fi";
+"Battery Health" = "Baterijos būklė";
+"Storage" = "Saugykla";
+"Device Information" = "Įrenginio informacija";
+"Quick Actions" = "Spartieji veiksmai";
+"Restart" = "Paleisti iš naujo";
+"Sleep" = "Užmigdyti";
+"Screenshot" = "Ekrano kopija";
+"No Backups Found" = "Atsarginių kopijų nerasta";
+"Back up your device to browse its contents, extract messages, photos, and app data." = "Sukurkite įrenginio atsarginę kopiją, kad galėtumėte naršyti jos turinį ir išgauti žinutes, nuotraukas bei programų duomenis.";
+"Create Backup" = "Sukurti atsarginę kopiją";
+"Delete Backup?" = "Ištrinti atsarginę kopiją?";
+"This will permanently delete the backup of %@ (%@). This cannot be undone." = "Atsarginė kopija %@ (%@) bus ištrinta visam laikui. Šio veiksmo atšaukti negalima.";
+"Encrypted backup" = "Šifruota atsarginė kopija";
+"Browse Contents" = "Naršyti turinį";
+"Show in Finder" = "Rodyti Finder";
+"Backup completed" = "Atsarginė kopija sukurta";
+"Backup failed" = "Nepavyko sukurti atsarginės kopijos";
+"Restore This Backup" = "Atkurti šią atsarginę kopiją";
+"This will restore your device to the state from %@. The device will restart." = "Įrenginys bus atkurtas į būseną, buvusią %@. Įrenginys bus paleistas iš naujo.";
+"Scheduled Backups" = "Suplanuotos atsarginės kopijos";
+"No Backup Selected" = "Nepasirinkta atsarginė kopija";
+"Select a backup to view iMessage and SMS conversations." = "Pasirinkite atsarginę kopiją, kad peržiūrėtumėte iMessage ir SMS pokalbius.";
+"No Conversations" = "Pokalbių nėra";
+"Export CSV" = "Eksportuoti CSV";
+"Export HTML" = "Eksportuoti HTML";
+"Export JSON" = "Eksportuoti JSON";
+"Photos & Videos" = "Nuotraukos ir vaizdo įrašai";
+"No Photos Found" = "Nuotraukų nerasta";
+"Select a backup to browse Camera Roll photos and videos." = "Pasirinkite atsarginę kopiją, kad galėtumėte naršyti Kameros ritinio nuotraukas ir vaizdo įrašus.";
+"All" = "Visos";
+"Videos" = "Vaizdo įrašai";
+"Screenshots" = "Ekrano kopijos";
+"Extract Selected" = "Išgauti pasirinktas";
+"Applications" = "Programos";
+"Installed" = "Įdiegtos";
+"In Backup" = "Atsarginėje kopijoje";
+"Install IPA..." = "Įdiegti IPA...";
+"Remove App" = "Pašalinti programą";
+"Device Not Mounted" = "Įrenginys neprijungtas";
+"Mount the device filesystem to browse and transfer files." = "Prijunkite įrenginio failų sistemą, kad galėtumėte naršyti ir perkelti failus.";
+"Empty Directory" = "Tuščias katalogas";
+"Drop files here to transfer to device" = "Nutempkite failus čia, kad perkeltumėte juos į įrenginį";
+"Battery" = "Baterija";
+"System Log" = "Sistemos žurnalas";
+"Clear" = "Išvalyti";
+"Start Streaming" = "Pradėti srautinį perdavimą";
+"Stop Streaming" = "Sustabdyti srautinį perdavimą";
+"General" = "Bendrieji";
+"Dependencies" = "Priklausomybės";
+"About" = "Apie";
+"Backup Location" = "Atsarginių kopijų vieta";
+"Device Polling" = "Įrenginio tikrinimas";
+"Auto-refresh interval" = "Automatinio atnaujinimo intervalas";
+"Backup Schedule" = "Atsarginių kopijų tvarkaraštis";
+"Enable scheduled backups" = "Įjungti suplanuotas atsargines kopijas";
+"Frequency" = "Dažnis";
+"Wi-Fi only" = "Tik Wi-Fi";
+"No Apple Watch Found" = "Apple Watch nerastas";
+"Select a backup from a paired iPhone to view Apple Watch data." = "Pasirinkite atsarginę kopiją iš susieto iPhone, kad peržiūrėtumėte Apple Watch duomenis.";
+"Overview" = "Apžvalga";
+"Watch Apps" = "Watch programos";
+"Activity" = "Aktyvumas";
+"Home Screen" = "Pagrindinis ekranas";
+"Select a backup from the Backups section to see its home screen." = "Pasirinkite atsarginę kopiją skiltyje „Atsarginės kopijos“, kad pamatytumėte jos pagrindinį ekraną.";
+"No Home Screen Data" = "Pagrindinio ekrano duomenų nėra";
+"This backup does not contain IconState.plist (HomeDomain/SpringBoard)." = "Šioje atsarginėje kopijoje nėra IconState.plist (HomeDomain/SpringBoard).";
+"Could Not Read Layout" = "Nepavyko perskaityti išdėstymo";
+"Export PNG" = "Eksportuoti PNG";
+"Reload" = "Įkelti iš naujo";
+"Reading home screen layout…" = "Skaitomas pagrindinio ekrano išdėstymas…";
+"All Domains" = "Visi domenai";
+"%lld items" = "%lld elementų";
+"Toggle Preview" = "Rodyti / slėpti peržiūrą";
+"Extract" = "Išgauti";
+"Welcome to Phosphor" = "Sveiki atvykę į Phosphor";
+"Connect an iOS device or select a section from the sidebar." = "Prijunkite iOS įrenginį arba pasirinkite skiltį šoninėje juostoje.";


### PR DESCRIPTION
## Summary
- add the issue-provided Lithuanian localization and declare it in the app bundle
- add literal-key aliases so Lithuanian translations resolve through the app's current SwiftUI localization calls
- add equivalent runtime aliases and correct representative German text so existing translations are displayed
- add localization declaration, key-parity, runtime-alias, and representative-value regressions

Fixes #76
Fixes #77

## Verification
- `python3 Scripts/regression/run.py` — 157 checks passed
- `plutil -lint` on `Info.plist` and both localization files — passed
- Foundation `Bundle.localizedString` runtime fixture for German and Lithuanian — passed
- `git diff --check` — passed
- independent pre-commit review — passed

## Local build note
`swift build` is blocked by this Mac's macOS 27 Command Line Tools (`SwiftUIMacros` plugin missing). The same failure reproduces on an untouched `origin/main` worktree; GitHub CI is the authoritative build check for this PR.
