### PR TITLE
feat: add safe bulk app uninstall

### DIFF
--- a/Scripts/regression/checks/app_uninstall.py
+++ b/Scripts/regression/checks/app_uninstall.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def read(root: Path, rel: str) -> str:
+    return (root / rel).read_text()
+
+
+def test_bulk_uninstall_selects_only_user_apps_and_keeps_failed_selection(root: Path) -> None:
+    """Issue #79: system apps cannot enter a removal batch; failed app IDs remain
+    selected so the user can retry only those failures."""
+    view = read(root, "Sources/Phosphor/Views/Apps/AppManagerView.swift")
+    view_model = read(root, "Sources/Phosphor/ViewModels/AppViewModel.swift")
+
+    assert "@State private var selectedAppIDs: Set<String> = []" in view
+    assert "app.appType == .user" in view, "only user apps may be selectable for removal"
+    assert "Uninstall Selected" in view, "the device-app list needs a bulk removal action"
+    assert "confirmationDialog" in view, "bulk removal needs an explicit destructive confirmation"
+    assert "selectedAppIDs.subtract(successfulIDs)" in view, (
+        "only successfully removed IDs may leave the selection; failures must remain for retry"
+    )
+    assert "selectedAppIDs.formIntersection" in view, (
+        "selection must not retain IDs that disappear after a same-device refresh"
+    )
+    assert "func uninstall(bundleIds: [String], udid: String) async -> Set<String>" in view_model
+    assert "app.appType == .user" in view_model, "the view model must reject system-app removal too"
+    assert "activeInstalledDeviceID" in view_model, "uninstall completion must be scoped to the loaded device"
+    assert "guard activeInstalledDeviceID == udid" in view_model, (
+        "switching devices must prevent stale uninstall results from mutating the new device list"
+    )
+    prepare_signature = "func prepareForInstalledDevice(_ udid: String?, isDeviceTabActive: Bool)"
+    assert prepare_signature in view_model, "device identity changes must be scoped to the visible app source"
+    prepare_body = view_model.split(prepare_signature, 1)[1].split(
+        "func loadInstalledApps", 1
+    )[0]
+    assert "guard activeInstalledDeviceID != udid else { return }" in prepare_body, (
+        "same-device refresh must not blank a valid installed-app list"
+    )
+    assert "installedApps = []" in prepare_body, (
+        "switching between non-nil devices must clear stale rows before destructive actions are available"
+    )
+    assert "if isDeviceTabActive && udid == nil" in prepare_body, (
+        "device disconnects must stop only the visible device-list spinner, not an active backup-app load"
+    )
+    assert "appVM.prepareForInstalledDevice(newDeviceID, isDeviceTabActive: activeTab == .device)" in view
+    assert "@Published private(set) var isUninstalling = false" in view_model
+    assert "guard !isUninstalling" in view_model, "overlapping destructive uninstall tasks must be rejected"
+    assert "appVM.isUninstalling" in view, "bulk uninstall controls must stay disabled while removal is active"
+    assert "@Published private(set) var isUninstalling" in view_model, (
+        "one shared operation gate must prevent overlapping row and bulk uninstalls"
+    )
+    assert "guard !isUninstalling else" in view_model
+    assert ".disabled(appVM.isUninstalling)" in view, "all uninstall affordances must honor the gate"
+
+
+def test_uninstall_removes_successes_locally_without_reloading_the_list(root: Path) -> None:
+    """Issue #79: local row removal preserves the current List scroll position."""
+    view_model = read(root, "Sources/Phosphor/ViewModels/AppViewModel.swift")
+
+    assert "installedApps.removeAll { $0.id == bundleId }" in view_model
+    assert "installedApps.removeAll { successfulIDs.contains($0.id) }" in view_model
+
+    uninstall_body = view_model.split("func uninstall(bundleId: String, udid: String) async", 1)[1].split(
+        "func uninstall(bundleIds: [String], udid: String) async -> Set<String>", 1
+    )[0]
+    bulk_body = view_model.split("func uninstall(bundleIds: [String], udid: String) async -> Set<String>", 1)[1].split(
+        "func extractAppData", 1
+    )[0]
+    assert "loadInstalledApps" not in uninstall_body, "single removal must not reload and jump the list"
+    assert "loadInstalledApps" not in bulk_body, "bulk removal must not reload and jump the list"

--- a/Sources/Phosphor/ViewModels/AppViewModel.swift
+++ b/Sources/Phosphor/ViewModels/AppViewModel.swift
@@ -11,8 +11,11 @@ final class AppViewModel: ObservableObject {
     @Published var searchQuery = ""
     @Published var showAlert = false
     @Published var alertMessage = ""
+    @Published private(set) var isUninstalling = false
 
     let appManager = AppManager()
+    private var activeInstalledDeviceID: String?
+    private var installedAppsLoadID: UUID?
 
     var filteredInstalled: [InstalledApp] {
         guard !searchQuery.isEmpty else { return installedApps }
@@ -30,9 +33,23 @@ final class AppViewModel: ObservableObject {
         }
     }
 
+    func prepareForInstalledDevice(_ udid: String?, isDeviceTabActive: Bool) {
+        guard activeInstalledDeviceID != udid else { return }
+        activeInstalledDeviceID = udid
+        installedAppsLoadID = nil
+        installedApps = []
+        if isDeviceTabActive && udid == nil {
+            isLoading = false
+        }
+    }
+
     func loadInstalledApps(udid: String) async {
+        activeInstalledDeviceID = udid
+        let loadID = UUID()
+        installedAppsLoadID = loadID
         isLoading = true
         await appManager.listInstalledApps(udid: udid)
+        guard activeInstalledDeviceID == udid, installedAppsLoadID == loadID else { return }
         installedApps = appManager.installedApps
         isLoading = false
     }
@@ -61,10 +78,58 @@ final class AppViewModel: ObservableObject {
     }
 
     func uninstall(bundleId: String, udid: String) async {
+        guard !isUninstalling else { return }
+        guard activeInstalledDeviceID == udid,
+              let app = installedApps.first(where: { $0.id == bundleId }),
+              app.appType == .user else {
+            alertMessage = "Only user-installed apps can be removed"
+            showAlert = true
+            return
+        }
+
+        isUninstalling = true
+        defer { isUninstalling = false }
         let ok = await appManager.uninstallApp(bundleId: bundleId, udid: udid)
+        guard activeInstalledDeviceID == udid else { return }
         alertMessage = ok ? "App removed" : (appManager.lastError ?? "Removal failed")
         showAlert = true
-        if ok { await loadInstalledApps(udid: udid) }
+        if ok { installedApps.removeAll { $0.id == bundleId } }
+    }
+
+    /// Removes the requested user apps one at a time so failures can be reported
+    /// honestly and left selected for a retry. Successful rows are removed in
+    /// place, preserving the List's current scroll position.
+    func uninstall(bundleIds: [String], udid: String) async -> Set<String> {
+        guard !isUninstalling else { return [] }
+        guard activeInstalledDeviceID == udid else { return [] }
+        let removableIDs = bundleIds.filter { bundleId in
+            installedApps.first(where: { $0.id == bundleId })?.appType == .user
+        }
+        guard !removableIDs.isEmpty else { return [] }
+        isUninstalling = true
+        defer { isUninstalling = false }
+        var successfulIDs = Set<String>()
+        var failedCount = 0
+
+        for bundleId in removableIDs {
+            guard activeInstalledDeviceID == udid else { break }
+            if await appManager.uninstallApp(bundleId: bundleId, udid: udid) {
+                successfulIDs.insert(bundleId)
+            } else {
+                failedCount += 1
+            }
+        }
+
+        guard activeInstalledDeviceID == udid else { return successfulIDs }
+        installedApps.removeAll { successfulIDs.contains($0.id) }
+        let removedCount = successfulIDs.count
+        if failedCount == 0 {
+            alertMessage = "Removed \(removedCount) \(removedCount == 1 ? "app" : "apps")"
+        } else {
+            alertMessage = "Removed \(removedCount) \(removedCount == 1 ? "app" : "apps"). Failed to remove \(failedCount) \(failedCount == 1 ? "app" : "apps"); keep them selected and try again."
+        }
+        showAlert = true
+        return successfulIDs
     }
 
     func extractAppData(bundleId: String, backupPath: String, to dest: String) async {

--- a/Sources/Phosphor/Views/Apps/AppManagerView.swift
+++ b/Sources/Phosphor/Views/Apps/AppManagerView.swift
@@ -9,6 +9,8 @@ struct AppManagerView: View {
     @StateObject private var appVM = AppViewModel()
     @State private var activeTab: AppTab = .backup
     @State private var searchText = ""
+    @State private var selectedAppIDs: Set<String> = []
+    @State private var showBulkUninstallConfirmation = false
 
     enum AppTab: String, CaseIterable {
         case device = "On Device"
@@ -35,14 +37,37 @@ struct AppManagerView: View {
             guard activeTab == .backup else { return }
             reloadBackupApps()
         }
-        .onChange(of: deviceVM.selectedDevice?.id) { _, _ in
+        .onChange(of: deviceVM.selectedDevice?.id) { _, newDeviceID in
+            selectedAppIDs.removeAll()
+            appVM.prepareForInstalledDevice(newDeviceID, isDeviceTabActive: activeTab == .device)
             guard activeTab == .device else { return }
             loadApps()
+        }
+        .onChange(of: appVM.installedApps.map(\.id)) { _, currentIDs in
+            selectedAppIDs.formIntersection(currentIDs)
         }
         .alert("Apps", isPresented: $appVM.showAlert) {
             Button("OK") {}
         } message: {
             Text(appVM.alertMessage)
+        }
+        .confirmationDialog(
+            "Uninstall \(selectedAppIDs.count) \(selectedAppIDs.count == 1 ? "App" : "Apps")?",
+            isPresented: $showBulkUninstallConfirmation,
+            titleVisibility: .visible
+        ) {
+            Button("Uninstall Selected", role: .destructive) {
+                guard let udid = deviceVM.selectedDevice?.id else { return }
+                let appIDs = Array(selectedAppIDs)
+                Task {
+                    let successfulIDs = await appVM.uninstall(bundleIds: appIDs, udid: udid)
+                    selectedAppIDs.subtract(successfulIDs)
+                }
+            }
+            .disabled(appVM.isUninstalling)
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("This cannot be undone. System apps are never selected.")
         }
     }
 
@@ -148,6 +173,8 @@ struct AppManagerView: View {
                 )
             } else {
                 VStack(spacing: 0) {
+                    bulkUninstallControls
+
                     // The device list cannot extract anything - app containers only
                     // exist in a backup. Say so here instead of leaving people
                     // hunting for a button that is on the other tab (issue #46).
@@ -176,8 +203,57 @@ struct AppManagerView: View {
         }
     }
 
+    private var bulkUninstallControls: some View {
+        HStack(spacing: 10) {
+            Text(selectedAppIDs.isEmpty ? "Select user apps to uninstall" : "\(selectedAppIDs.count) selected")
+                .font(.system(size: 11))
+                .foregroundStyle(.secondary)
+
+            Button(selectedAppIDs.isEmpty ? "Select All User Apps" : "Clear Selection") {
+                if selectedAppIDs.isEmpty {
+                    selectedAppIDs = Set(appVM.installedApps.filter { $0.appType == .user }.map(\.id))
+                } else {
+                    selectedAppIDs.removeAll()
+                }
+            }
+            .controlSize(.small)
+            .disabled(appVM.isUninstalling)
+
+            Button("Uninstall Selected", role: .destructive) {
+                showBulkUninstallConfirmation = true
+            }
+            .controlSize(.small)
+            .disabled(selectedAppIDs.isEmpty || deviceVM.selectedDevice == nil || appVM.isUninstalling)
+
+            Spacer()
+        }
+        .padding(.horizontal, 20)
+        .padding(.vertical, 8)
+        .background(.quaternary.opacity(0.4))
+    }
+
     private func installedAppRow(_ app: InstalledApp) -> some View {
         HStack(spacing: 12) {
+            if app.appType == .user {
+                Toggle(
+                    "Select \(app.displayName)",
+                    isOn: Binding(
+                        get: { selectedAppIDs.contains(app.id) },
+                        set: { isSelected in
+                            if isSelected {
+                                selectedAppIDs.insert(app.id)
+                            } else {
+                                selectedAppIDs.remove(app.id)
+                            }
+                        }
+                    )
+                )
+                .labelsHidden()
+                .toggleStyle(.checkbox)
+                .accessibilityLabel("Select \(app.displayName) for uninstall")
+                .disabled(appVM.isUninstalling)
+            }
+
             ZStack {
                 RoundedRectangle(cornerRadius: 10)
                     .fill(app.appType == .system ? Color.gray.opacity(0.1) : Color.brandAccent.opacity(0.1))
@@ -216,6 +292,7 @@ struct AppManagerView: View {
                 }
                 .menuStyle(.borderlessButton)
                 .frame(width: 24)
+                .disabled(appVM.isUninstalling)
             }
         }
         .padding(.vertical, 3)


### PR DESCRIPTION
## Summary
- add checkbox selection and Select All/Clear controls for user-installed apps only
- add destructive confirmation and serialized sequential bulk uninstall with partial-failure reporting
- remove successful rows locally instead of reloading the list, preserving scroll position
- clear stale rows immediately on device changes and prevent stale uninstall/load completions from mutating a newly selected device

Fixes #79

## Verification
- `python3 Scripts/regression/run.py` — 157 checks passed
- `swiftc -frontend -parse` on all changed Swift files — passed
- `git diff --check` — passed
- independent pre-commit review — passed

## Local build note
`swift build` is blocked by this Mac's macOS 27 Command Line Tools (`SwiftUIMacros` plugin missing). The same failure reproduces on an untouched `origin/main` worktree; GitHub CI is the authoritative build check for this PR.
